### PR TITLE
Update `plot_carrier_production`

### DIFF
--- a/calliope/analysis.py
+++ b/calliope/analysis.py
@@ -43,7 +43,7 @@ def plot_carrier_production(solution, carrier='power', subset=dict(),
 
     """
     data = solution['e'].loc[dict(c=carrier, **subset)].sum(dim='x')
-    return plot_timeseries(solution, data, carrier=carrier, **kwargs)
+    return plot_timeseries(solution, data, carrier=carrier, demand='demand_{}'.format(carrier), **kwargs)
 
 
 def plot_timeseries(solution, data, carrier='power', demand='demand_power',


### PR DESCRIPTION
requires specification of `demand` when running the `plot_timeseries` function from `plot_carrier_production`, otherwise it will fail on any carrier that isn't `power` (as it defaults to searching for `demand_power`).