### PR TITLE
Patch plot transmission

### DIFF
--- a/calliope/analysis.py
+++ b/calliope/analysis.py
@@ -230,7 +230,7 @@ def plot_transmission(solution, tech='hvac', carrier='power',
     # Determine maximum that could have been transmitted across a link
     def get_edge_capacity(solution, a, b):
         hrs = solution['time_res'].to_pandas().sum()
-        cap = solution['e_cap_net'].loc[dict(x=a, y='{}:'.format(tech) + b)].value() * hrs
+        cap = solution['e_cap_net'].loc[dict(x=a, y='{}:'.format(tech) + b)].to_pandas() * hrs
         return cap
 
     # Get annual power transmission between zones
@@ -238,7 +238,7 @@ def plot_transmission(solution, tech='hvac', carrier='power',
     trans_tech = lambda x: '{}:{}'.format(tech, x)
     def get_annual_power_transmission(zone):
         try:
-            return solution['e'].loc[dict(c=carrier, y=trans_tech(zone))].sum(dim='t').value()
+            return solution['e'].loc[dict(c=carrier, y=trans_tech(zone))].sum(dim='t').to_pandas()
         except KeyError:
             return 0
     df = pd.DataFrame({zone: get_annual_power_transmission(zone)

--- a/calliope/analysis.py
+++ b/calliope/analysis.py
@@ -244,10 +244,14 @@ def plot_transmission(solution, tech='hvac', carrier='power',
     df = pd.DataFrame({zone: get_annual_power_transmission(zone)
                       for zone in zones}, index=zones)
 
-    # Set smaller than zero to zero --
-    # we only want to know about 'production' from
-    # transmission, not their consumptions
-    df[df < 0] = 0
+    # Set negative and very small (erroneous) values to zero --
+    # Positive values = energy received at a node by transmission,
+    # negative values = energy sent by transmission.
+    # The absolute value sent and recieved between two nodes will be
+    # different when there is line loss (i.e. negative values will have a
+    # larger absolute value than the positive value for the same transmission
+    # line), which is why we take the recieving (positive) value.
+    df[df < df.max().max()*1e-10] = 0
 
     # Create directed graph
     G = nx.from_numpy_matrix(df.as_matrix().T, create_using=nx.DiGraph())

--- a/calliope/analysis_utils.py
+++ b/calliope/analysis_utils.py
@@ -192,6 +192,10 @@ def plot_graph_on_map(config_model, G=None,
                                               rotate=rotate_labels,
                                               font_size=fontsize)
 
+        # Adding node names just above node points
+        pos_offset = {i: (pos[i][0], pos[i][1]+20) for i in pos}
+        nx.draw_networkx_labels(G, pos_offset, font_size=fontsize)
+
     # Add a map scale
     if show_scale:
         scale = m.drawmapscale(


### PR DESCRIPTION
`.values()` is incorrect for DataArrays, so have updated to `to_pandas()` as with other DataArrays in analysis. Also added node labelling, as it is currently unknown which node is which when plotted.

Would be good to have node label background, so labels aren't obscured by edges, but `newtorkx.draw_networkx_labels` doesn't have that functionality it seems.