### PR TITLE
Make exporting energy simpler to include

### DIFF
--- a/calliope/config/defaults.yaml
+++ b/calliope/config/defaults.yaml
@@ -31,6 +31,7 @@ techs:
         source_carrier: false # Defaults to false, allows technologies to define a carrier to consume
         group: false
         x_map: null
+        export: null
         constraints:
             force_r: false  # Forces this technology to use all available ``r``, rather than making it a maximum upper boundary (for production) or minimum lower boundary (for consumption)
             r_unit: power  # Sets the unit of ``r`` to either ``power`` (i.e. kW) or ``energy`` (i.e. kWh), which affects how resource time series are processed when performing time resolution adjustments
@@ -90,6 +91,7 @@ techs:
                 sub_var: 0 #variable subsidy (per kWh of ``es_prod`` or ``es_con``)
                 sub_cap: 0 #fixed subsidy (per kW gross) ##e_cap.max must be defined (and not infinite) if using this with demand
                 sub_annual: 0 #annual subsidy (per kW of ``e_cap``) ##e_cap.max must be defined (and not infinite) if using this with demand
+                sub_export: 0
         costs_per_distance:
             default:
                 e_cap: 0

--- a/calliope/core.py
+++ b/calliope/core.py
@@ -1141,6 +1141,8 @@ class Model(BaseModel):
         m.y_conv = po.Set(initialize=self._sets['y_conv'], within=m.y, ordered=True)
         # Demand sources
         m.y_demand = po.Set(initialize=self._sets['y_demand'], within=m.y, ordered=True)
+        # Exporting technologies
+        m.y_export = po.Set(initialize=self._sets['y_export'], within=m.y, ordered=True)
         ##TIMESERIES vars
         for param in self.config_model.timeseries_constraints:
             setattr(m, 'y_def_'+param, po.Set(initialize = self._sets['y_def_' + param], within=m.y))
@@ -1457,6 +1459,10 @@ class Model(BaseModel):
             p['rbs'] = p['rs'].copy()  # get same dimensions
             p['rbs'].loc[:] = 0
         p['e'] = self.get_ec_sum()
+        try:
+            p['export'] = self.get_var('export')
+        except:
+            None
         return p
 
     def get_node_parameters(self):

--- a/calliope/sets.py
+++ b/calliope/sets.py
@@ -64,6 +64,12 @@ def init_set_y(model, _x):
     # Subset of technologies that are demand sources
     _y_demand = [y for y in _y if model.ischild(y, of='demand')]
 
+    _y_export = []
+    for y in _y:
+        for x in _x:
+            if model.get_option(y + '.export', x=x):
+                _y_export.append(y)
+                break
 
     # Subset of technologies that allow rb
     _y_rb = []
@@ -91,8 +97,10 @@ def init_set_y(model, _x):
         'y_p': _y_p,
         'y_trans': _y_trans,
         'techs_transmission': transmission_techs,
-        'y_demand': _y_demand
+        'y_demand': _y_demand,
+        'y_export': _y_export
     }
+
 
     return sets
 

--- a/calliope/test/test_model_export.py
+++ b/calliope/test/test_model_export.py
@@ -1,0 +1,47 @@
+import pytest
+import tempfile
+
+from calliope.utils import AttrDict
+from . import common
+from .common import solver, solver_io
+
+
+class TestModel:
+    @pytest.fixture(scope='module')
+    def model(self):
+        locations = """
+            locations:
+                1:
+                    techs: ['ccgt', 'demand_power',
+                            'unmet_demand_power']
+                    override:
+                        ccgt:
+                            export: True
+                        demand_power:
+                            x_map: '1: demand'
+                            constraints:
+                                r: file=demand-sin_r.csv
+                        revenue:
+                            sub_export: 0.12
+            links:
+        """
+        config_run = """
+            mode: plan
+            model: ['{techs}', '{locations}']
+            subset_t: ['2005-01-01', '2005-01-02']
+        """
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(locations.encode('utf-8'))
+            f.read()
+            override_dict = AttrDict({
+                'solver': solver,
+                'solver_io': solver_io,
+            })
+            model = common.simple_model(config_run=config_run,
+                                        config_locations=f.name,
+                                        override=override_dict)
+        model.run()
+        return model
+
+    def test_model_solves(self, model):
+        assert str(model.results.solver.termination_condition) == 'optimal'


### PR DESCRIPTION
Currently it is possible to include export, by creating a demand technology with some big M demand and `force_r` set to false. However, you then have to define a new carrier for that export, to ensure only certain technologies are allowed to export (those that can produce this proxy carrier). 

This patch allows you to set `techs.[technology].export` to true for any technology you would like to have export some of its production outside the grid. `techs.[technology].revenue.[cost_type].sub_export` can then be set for that technology & given cost type to allow export to produce revenue.

Export energy is taken away *before* es_prod (i.e. technology production = es_prod + export), I think I've sorted any issues this may cause with costing and system balancing, but that might need more testing.

Export is in the solution file, but currently not part of visualisation.