### PR TITLE
Per distance patch

### DIFF
--- a/calliope/config/defaults.yaml
+++ b/calliope/config/defaults.yaml
@@ -90,9 +90,6 @@ techs:
                 sub_var: 0 #variable subsidy (per kWh of ``es_prod`` or ``es_con``)
                 sub_cap: 0 #fixed subsidy (per kW gross) ##e_cap.max must be defined (and not infinite) if using this with demand
                 sub_annual: 0 #annual subsidy (per kW of ``e_cap``) ##e_cap.max must be defined (and not infinite) if using this with demand
-        costs_per_distance:
-            default:
-                e_cap: 0
         depreciation:
             plant_life: 25  # Lifetime of a plant (years)
             interest:
@@ -136,10 +133,16 @@ techs:
             e_con: true
     transmission:  # ``r`` is not used but still must be defined as inf
         parent: defaults
+        per_distance: 1
         constraints:
             r: inf
             e_cap.max: inf
             e_con: true
+        costs_per_distance:
+            default:
+                e_cap: 0
+        constraints_per_distance:
+            e_loss: 0
     conversion:  # ``r`` is not used but still must be defined as inf
         parent: defaults
         constraints:

--- a/calliope/constraints/base.py
+++ b/calliope/constraints/base.py
@@ -531,7 +531,7 @@ def node_costs(model):
 
     cost_getter = utils.cost_getter(model.get_option)
     depreciation_getter = utils.depreciation_getter(model.get_option)
-    cost_per_distance_getter = utils.cost_per_distance_getter(model.get_option)
+    cost_per_distance_getter = utils.cost_per_distance_getter(model.config_model)
 
     @utils.memoize
     def _depreciation_rate(y, k):

--- a/calliope/constraints/base.py
+++ b/calliope/constraints/base.py
@@ -139,30 +139,24 @@ def node_energy_balance(model):
     time_res = model.data['_time_res'].to_series()
 
     def get_e_eff_per_distance(model, y, x):
-        try:
-            e_loss = model.get_option(y + '.constraints_per_distance.e_loss', x=x)
-        except exceptions.OptionNotSetError:
-            return 1.0
-        try:
-            per_distance = model.get_option(y + '.per_distance')
-        except: # assume one unit distance
-            per_distance = 1
-        # assuming only tranmission techs are passed into distance_getter:
+        e_loss = model.get_option(y + '.constraints_per_distance.e_loss', x=x)
+        per_distance = model.get_option(y + '.per_distance')
         tech, x2 = y.split(':')
-        try:
-            link = model.config_model.get_key('links.'+ x + ',' + x2,
-                   default=model.config_model['links'].get(x2 + ',' + x))
-        except: #no link
+        link = model.config_model.get_key('links.'+ x + ',' + x2,
+            default=model.config_model['links'].get(x2 + ',' + x))
+        # link = None if no link exists
+        if not link:
             return 1.0
         try:
             distance = link.get_key(tech + '.distance')
         except KeyError:
-            e = exceptions.OptionNotSetError
-            raise e('Distance must be defined for '
-                    'link: {} and transmission tech: {}, '
-                    'as e_loss per distance is defined'.format(x + ',' + x2, tech))
-        except:
-            return 1.0
+            if e_loss > 0:
+                e = exceptions.OptionNotSetError
+                raise e('Distance must be defined for link: {} '
+                        'and transmission tech: {}, as e_loss per distance '
+                        'is defined'.format(x + ',' + x2, tech))
+            else:
+                return 1.0
         return 1 - (e_loss * (distance / per_distance))
 
     # Variables


### PR DESCRIPTION
The technology doesn't retain distance information, so the previous line `distance = model.get_option(y + '.distance')` would always lead to an exception, leading to cost per distance always being 0. This has been updated along with more checks to ensure everything else is caught along the way. Could do with being generally cleaner, but it works in this format.