### PR TITLE
Update map plotting for x-y and lat-lon

### DIFF
--- a/calliope/example_models/national_scale/model_config/locations.yaml
+++ b/calliope/example_models/national_scale/model_config/locations.yaml
@@ -45,14 +45,18 @@ links:
 ##
 
 metadata:
-    coordinate_system: geographic # default, i.e. lat-lon. 'cartesian' would allow x-y inputs
+    # map boundary defined by the lower left and upper right of the square
+    map_boundary:
+        lower_left:
+            lat: 35
+            lon: -10
+        upper_right:
+            lat: 45
+            lon: 5
 
-    # lower left corner lat, lower left corner lon, upper right corner lat, upper right corner lon
-    map_boundary: [35, -10, 45, 5]
-
-    location_coordinates:  # lat, lon coordinates
-        region1: [40, -2]
-        region2: [40, -8]
-        region1-1: [41, -2]
-        region1-2: [39, -1]
-        region1-3: [39, -2]
+    location_coordinates:  # lat, lon coordinates in a dictionary
+        region1: {lat: 40, lon: -2}
+        region2: {lat: 40, lon: -8}
+        region1-1: {lat: 41, lon: -2}
+        region1-2: {lat: 39, lon: -1}
+        region1-3: {lat: 39, lon: -2}

--- a/calliope/example_models/national_scale/model_config/locations.yaml
+++ b/calliope/example_models/national_scale/model_config/locations.yaml
@@ -45,8 +45,10 @@ links:
 ##
 
 metadata:
-    # lower left corner lon, lower left corner lat, upper right corner lon, upper right corner lat
-    map_boundary: [-10, 35, 5, 45]
+    coordinate_system: geographic # default, i.e. lat-lon. 'cartesian' would allow x-y inputs
+
+    # lower left corner lat, lower left corner lon, upper right corner lat, upper right corner lon
+    map_boundary: [35, -10, 45, 5]
 
     location_coordinates:  # lat, lon coordinates
         region1: [40, -2]

--- a/calliope/example_models/urban_scale/model_config/locations.yaml
+++ b/calliope/example_models/urban_scale/model_config/locations.yaml
@@ -68,14 +68,16 @@ links:
             constraints: # nothing to define, but model requires a key at this level of nesting
 
 metadata:
-    # default coord system is 'geographic', i.e. lat-lon. 'cartesian' allows x-y inputs
-    coordinate_system: cartesian
-
-    # lower left corner x, lower left corner y, upper right corner x, upper right corner y
-    map_boundary: [0, 0, 1, 1]
-
-    location_coordinates:  # lat, lon coordinates
-        X1: [2, 7]
-        X2: [8, 7]
-        X3: [5, 3]
-        N1: [5, 7]
+    # metadata given in cartesian coordinates, not lat, lon.
+    map_boundary:
+        lower_left:
+            x: 0
+            y: 0
+        upper_right:
+            x: 1
+            y: 1
+    location_coordinates:
+        X1: {x: 2, y: 7}
+        X2: {x: 8, y: 7}
+        X3: {x: 5, y: 3}
+        N1: {x: 5, y: 7}

--- a/calliope/example_models/urban_scale/model_config/locations.yaml
+++ b/calliope/example_models/urban_scale/model_config/locations.yaml
@@ -53,16 +53,29 @@ locations:
 links:
     X1,X2:
         power_lines:
-            distance: 0.5
+            constraints: # nothing to define, but model requires a key at this level of nesting
     X1,X3:
         power_lines:
-            distance: 0.6
+            constraints: # nothing to define, but model requires a key at this level of nesting
     X1,N1:
         heat_pipes:
-            distance: 0.25
+            constraints: # nothing to define, but model requires a key at this level of nesting
     N1,X2:
         heat_pipes:
-            distance: 0.25
+            constraints: # nothing to define, but model requires a key at this level of nesting
     N1,X3:
         heat_pipes:
-            distance: 0.35
+            constraints: # nothing to define, but model requires a key at this level of nesting
+
+metadata:
+    # default coord system is 'geographic', i.e. lat-lon. 'cartesian' allows x-y inputs
+    coordinate_system: cartesian
+
+    # lower left corner x, lower left corner y, upper right corner x, upper right corner y
+    map_boundary: [0, 0, 1, 1]
+
+    location_coordinates:  # lat, lon coordinates
+        X1: [2, 7]
+        X2: [8, 7]
+        X3: [5, 3]
+        N1: [5, 7]

--- a/calliope/test/test_analysis.py
+++ b/calliope/test/test_analysis.py
@@ -31,9 +31,11 @@ class TestModel:
                             constraints:
                                 r: -50
             metadata:
-                map_boundary: [-10, 35, 5, 45]
+                map_boundary:
+                    lower_left: {lat: 35, lon: -10}
+                    upper_right: {lat: 45, lon: 5}
                 location_coordinates:
-                    1: [40, -2]
+                    1: {lat: 40, lon: -2}
             links:
         """
         config_run = """


### PR DESCRIPTION
Metadata can be supplied as lat-lon, and is then plotted with Basemap background. But, if you want a quick 'abstract' model (i.e. not geographically located, but there are distinct locations with distances between them) you can define as x-y. This allows for that.

Also updates metadata map boundary to be `[lat1, lon1, lat2, lon2]` instead of `[lon1, lat1, lon2, lat2]` to be in line with the definition of the other location lat-lons (i.e. `[lat, lon]`). For cartesian, this becomes [x1, y1, x2, y2], but isn't actually used at the moment.
