### PR TITLE
Objective function cost class/sense definition in run config

### DIFF
--- a/calliope/backend/pyomo/model.py
+++ b/calliope/backend/pyomo/model.py
@@ -137,9 +137,16 @@ def generate_model(model_data):
     #         self.add_constraint(load_function(c))
 
     # Objective function
-    objective_name = model_data.attrs['run.objective']
-    objective_function = 'calliope.backend.pyomo.objective.' + objective_name
-    load_function(objective_function)(backend_model)
+    # FIXME re-enable loading custom objectives
+
+    # fetch objective function by name, pass through objective options
+    # if they are present
+    objective_function = 'calliope.backend.pyomo.objective.' + \
+                        model_data.attrs['run.objective']
+    objective_args = dict([(k.split('.')[-1],v) for k,v in model_data.attrs.items() \
+                                        if (k.startswith('run.objective_options'))])
+    load_function(objective_function)(backend_model,**objective_args)
+
 
     # delattr(backend_model, '__calliope_model_data__')
 

--- a/calliope/backend/pyomo/objective.py
+++ b/calliope/backend/pyomo/objective.py
@@ -1,5 +1,6 @@
 """
 Copyright (C) 2013-2018 Calliope contributors listed in AUTHORS.
+
 Licensed under the Apache 2.0 License (see LICENSE file).
 
 objective.py
@@ -10,17 +11,23 @@ Objective functions.
 """
 
 import pyomo.core as po  # pylint: disable=import-error
+from calliope.core.util.tools import load_function
 
 
-def cost_minimization(backend_model):
+def minmax_cost_optimization(backend_model, cost_class, sense):
     """
-    Minimizes total system monetary cost.
+    Minimize or maximise total system cost for specified cost class.
+
+    If unmet_demand is in use, then the calculated cost of unmet_demand is
+    added or subtracted from the total cost in the opposite sense to the
+    objective.
 
     .. container:: scrolling-wrapper
 
         .. math::
 
-            min: z = \sum_{loc::tech_{cost}} cost(loc::tech, cost=cost_{monetary})) + \sum_{loc::carrier,timestep} unmet\_demand(loc::carrier, timestep) \\times bigM
+            min: z = \sum_{loc::tech_{cost}} cost(loc::tech, cost=cost_{k})) + \sum_{loc::carrier,timestep} unmet\_demand(loc::carrier, timestep) \\times bigM
+            max: z = \sum_{loc::tech_{cost}} cost(loc::tech, cost=cost_{k})) - \sum_{loc::carrier,timestep} unmet\_demand(loc::carrier, timestep) \\times bigM
 
     """
     def obj_rule(backend_model):
@@ -30,21 +37,23 @@ def cost_minimization(backend_model):
                 for loc_carrier in backend_model.loc_carriers
                 for timestep in backend_model.timesteps
             ) * backend_model.bigM
+            if sense == 'maximize':
+                unmet_demand *= -1
         else:
             unmet_demand = 0
 
         return (
             sum(
-                backend_model.cost['monetary', loc_tech]
+                backend_model.cost[cost_class, loc_tech]
                 for loc_tech in backend_model.loc_techs_cost
             ) + unmet_demand
         )
 
-    backend_model.obj = po.Objective(sense=po.minimize, rule=obj_rule)
+    backend_model.obj = po.Objective(sense=load_function('pyomo.core.'+sense), rule=obj_rule)
     backend_model.obj.domain = po.Reals
 
 
-def check_feasibility(backend_model):
+def check_feasibility(backend_model, **kwargs):
     """
     Dummy objective, to check that there are no conflicting constraints.
 

--- a/calliope/config/model.yaml
+++ b/calliope/config/model.yaml
@@ -19,7 +19,8 @@ run:
         window: null
         horizon: null
         use_cap_results: false
-    objective: 'cost_minimization'  # Objective function to use. As of v0.6.0, this has no effect.
+    objective:  minmax_cost_optimization # Name of internal objective function to use, currently only min/max cost-based optimisation is available
+    objective_options: {'cost_class': 'monetary', 'sense': 'minimize'}  # Arguments to pass to objective function. If cost-based objective function in use, should include 'cost_class' and 'sense' (maximize/minimize)
     mode: plan  # Which mode to run the model in: 'plan' or 'operation'
     zero_threshold: 1e-10 # Any value coming out of the backend that is smaller than this threshold (due to floating point errors, probably) will be set to zero
 

--- a/calliope/core/preprocess/checks.py
+++ b/calliope/core/preprocess/checks.py
@@ -15,12 +15,15 @@ import logging
 import numpy as np
 import xarray as xr
 
+from inspect import signature
+
 import calliope
 from calliope._version import __version__
 from calliope.core.attrdict import AttrDict
 from calliope.core.util.tools import flatten_list
 from calliope.core.preprocess.util import get_all_carriers
 from calliope.core.util.logging import logger
+from calliope.core.util.tools import load_function
 
 _defaults_files = {
     k: os.path.join(os.path.dirname(calliope.__file__), 'config', k + '.yaml')
@@ -203,6 +206,26 @@ def check_initial(config_model):
                     'Cannot load `{}` from file for configuration {}'
                     .format(constraint_name, k)
                 )
+
+    # Check the objective function being used has all the appropriate
+    # options set in objective_options, and that no options are unused
+    objective_function = 'calliope.backend.pyomo.objective.' + \
+                        config_model.run.objective
+    objective_args_expected = list(signature(load_function(objective_function)).parameters.keys())
+    objective_args_expected = [arg for arg in objective_args_expected
+                                if arg not in ['backend_model','kwargs']]
+    for arg in objective_args_expected:
+        if arg not in config_model.run.objective_options:
+            errors.append(
+                'Objective function argument `{}` not found in run.objective_options'
+                .format(arg)
+            )
+    for arg in config_model.run.objective_options:
+        if arg not in objective_args_expected:
+            warnings.append(
+                'Objective function argument `{}` given but not used by objective function `{}`'
+                .format(arg,config_model.run.objective)
+            )
 
     return warnings, errors
 

--- a/calliope/example_models/national_scale/overrides.yaml
+++ b/calliope/example_models/national_scale/overrides.yaml
@@ -102,3 +102,32 @@ group_share_cold_fusion_cap:
                 ccgt:
                     constraints:
                         energy_cap_max: 100000  # Increased to keep model feasible
+
+minimize_emissions_costs:
+    run:
+        objective_options:
+            cost_class: emissions
+    techs:
+        ccgt:
+            costs:
+                emissions:
+                    om_prod: 100 # kgCO2/kWh
+        csp:
+            costs:
+                emissions:
+                    om_prod: 10 # kgCO2/kWh
+
+maximize_utility_costs:
+    run:
+        objective_options:
+            cost_class: utility
+            sense: maximize
+    techs:
+        ccgt:
+              costs:
+                  utility:
+                      om_prod: 10 # arbitrary utility value
+        csp:
+              costs:
+                  utility:
+                      om_prod: 100 # arbitrary utility value

--- a/calliope/test/common/test_model/overrides.yaml
+++ b/calliope/test/common/test_model/overrides.yaml
@@ -264,4 +264,3 @@ investment_costs:
                 monetary:
                     interest_rate: 0.1
                     energy_cap: 10
-

--- a/calliope/test/test_objective.py
+++ b/calliope/test/test_objective.py
@@ -1,0 +1,33 @@
+from pytest import approx
+
+import calliope
+
+_OVERRIDE_FILE = calliope.examples._PATHS['national_scale'] + '/overrides.yaml'
+
+
+class TestNationalScaleObjectives:
+    def test_nationalscale_minimize_emissions(self):
+        model = calliope.examples.national_scale(
+            override_file=_OVERRIDE_FILE + ':minimize_emissions_costs'
+        )
+        model.run()
+
+        assert model.results.energy_cap.to_pandas()['region1-2::csp'] == approx(10000.0)
+        assert model.results.energy_cap.to_pandas()['region1::ac_transmission:region2'] == approx(3423.336471)
+
+        assert model.results.carrier_prod.sum('timesteps').to_pandas()['region1::ccgt::power'] == approx(1099770.5894141179)
+
+        assert float(model.results.cost.sum()) == approx(145746966.86280513)
+
+    def test_nationalscale_maximize_utility(self):
+        model = calliope.examples.national_scale(
+            override_file=_OVERRIDE_FILE + ':maximize_utility_costs'
+        )
+        model.run()
+
+        assert model.results.energy_cap.to_pandas()['region1-2::csp'] == approx(10000.0)
+        assert model.results.energy_cap.to_pandas()['region1::ac_transmission:region2'] == approx(10000.0)
+
+        assert model.results.carrier_prod.sum('timesteps').to_pandas()['region1::ccgt::power'] == approx(1439820.5542000004)
+
+        assert float(model.results.cost.sum()) == approx(323248560.11846155)

--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,8 @@ Release History
 0.6.1-dev
 ---------
 
+|changed| Cost class and sense (maximize/minimize) for objective function may now be specified in run configuration (default remains monetary cost minimization)
+
 0.6.0 (2018-04-20)
 ------------------
 

--- a/doc/user/building.rst
+++ b/doc/user/building.rst
@@ -128,7 +128,7 @@ The ``constraints`` section gives all constraints for the technology, such as al
 
 The ``costs`` section gives costs for the technology. Calliope uses the concept of "cost classes" to allow accounting for more than just monetary costs. The above example specifies only the ``monetary`` cost class, but any number of other classes could be used, for example ``co2`` to account for emissions.
 
-Only the ``monetary`` cost class is entered into the default objective function. Additional cost classes can be created simply by adding them to the definition of costs for a technology.
+By default the ``monetary`` cost class is used in the objective function, which seeks to minimize total costs. Additional cost classes can be created simply by adding them to the definition of costs for a technology. To use an alternative cost class and/or sense (minimize/maximize) in the objective function, the ``objective_options`` parameter can be set in the run configuration, e.g. ``objective_options: {'cost_class': 'emissions', 'sense': 'minimize'}``.
 
 .. seealso::
 


### PR DESCRIPTION
Summary of changes in this pull request:

* Objective function altered to accept cost_class and sense parameters
* Backend amended to pass through parameters from model run config
* Additional checks on run config

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved