### PR TITLE
Separate `primary_carrier` into `primary_carrier_in`/`_out`

### DIFF
--- a/calliope/backend/pyomo/constraints/conversion_plus.py
+++ b/calliope/backend/pyomo/constraints/conversion_plus.py
@@ -104,13 +104,13 @@ def balance_conversion_plus_primary_constraint_rule(backend_model, loc_tech, tim
     energy_eff = get_param(backend_model, 'energy_eff', (loc_tech, timestep))
 
     carrier_prod = sum(
-        backend_model.carrier_prod[loc_tech_carrier, timestep]
-        / get_param(backend_model, 'carrier_ratios', ('out', loc_tech_carrier))
+        backend_model.carrier_prod[loc_tech_carrier, timestep] /
+        get_param(backend_model, 'carrier_ratios', ('out', loc_tech_carrier))
         for loc_tech_carrier in loc_tech_carriers_out
     )
     carrier_con = sum(
-        backend_model.carrier_con[loc_tech_carrier, timestep]
-        * get_param(backend_model, 'carrier_ratios', ('in', loc_tech_carrier))
+        backend_model.carrier_con[loc_tech_carrier, timestep] *
+        get_param(backend_model, 'carrier_ratios', ('in', loc_tech_carrier))
         for loc_tech_carrier in loc_tech_carriers_in
     )
 

--- a/calliope/backend/pyomo/constraints/conversion_plus.py
+++ b/calliope/backend/pyomo/constraints/conversion_plus.py
@@ -103,12 +103,16 @@ def balance_conversion_plus_primary_constraint_rule(backend_model, loc_tech, tim
 
     energy_eff = get_param(backend_model, 'energy_eff', (loc_tech, timestep))
 
-    carrier_prod = sum(backend_model.carrier_prod[loc_tech_carrier, timestep]
-                 / get_param(backend_model, 'carrier_ratios', ('out', loc_tech_carrier))
-                 for loc_tech_carrier in loc_tech_carriers_out)
-    carrier_con = sum(backend_model.carrier_con[loc_tech_carrier, timestep]
-                 * get_param(backend_model, 'carrier_ratios', ('in', loc_tech_carrier))
-                 for loc_tech_carrier in loc_tech_carriers_in)
+    carrier_prod = sum(
+        backend_model.carrier_prod[loc_tech_carrier, timestep]
+        / get_param(backend_model, 'carrier_ratios', ('out', loc_tech_carrier))
+        for loc_tech_carrier in loc_tech_carriers_out
+    )
+    carrier_con = sum(
+        backend_model.carrier_con[loc_tech_carrier, timestep]
+        * get_param(backend_model, 'carrier_ratios', ('in', loc_tech_carrier))
+        for loc_tech_carrier in loc_tech_carriers_in
+    )
 
     return carrier_prod == -1 * carrier_con * energy_eff
 
@@ -135,7 +139,7 @@ def carrier_production_max_conversion_plus_constraint_rule(backend_model, loc_te
     )
 
     carrier_prod = sum(backend_model.carrier_prod[loc_tech_carrier, timestep]
-                 for loc_tech_carrier in loc_tech_carriers_out)
+                       for loc_tech_carrier in loc_tech_carriers_out)
 
     return carrier_prod <= timestep_resolution * backend_model.energy_cap[loc_tech]
 
@@ -165,7 +169,7 @@ def carrier_production_min_conversion_plus_constraint_rule(backend_model, loc_te
     )
 
     carrier_prod = sum(backend_model.carrier_prod[loc_tech_carrier, timestep]
-                for loc_tech_carrier in loc_tech_carriers_out)
+                       for loc_tech_carrier in loc_tech_carriers_out)
 
     return carrier_prod >= (
         timestep_resolution * backend_model.energy_cap[loc_tech] * min_use
@@ -191,28 +195,31 @@ def cost_var_conversion_plus_constraint_rule(backend_model, cost, loc_tech, time
     model_data_dict = backend_model.__calliope_model_data__['data']
     weight = backend_model.timestep_weights[timestep]
 
-    loc_tech_carrier = (
-        model_data_dict['lookup_primary_loc_tech_carriers'][loc_tech]
+    loc_tech_carrier_con = (
+        model_data_dict['lookup_primary_loc_tech_carriers_in'][loc_tech]
     )
 
+    loc_tech_carrier_prod = (
+        model_data_dict['lookup_primary_loc_tech_carriers_out'][loc_tech]
+    )
     var_cost = 0
 
-    if loc_tech_carrier in backend_model.loc_tech_carriers_prod:
+    if loc_tech_carrier_prod in backend_model.loc_tech_carriers_prod:
         cost_om_prod = get_param(backend_model, 'cost_om_prod',
                                  (cost, loc_tech, timestep))
         if cost_om_prod:
             var_cost += (
                 cost_om_prod * weight *
-                backend_model.carrier_prod[loc_tech_carrier, timestep]
+                backend_model.carrier_prod[loc_tech_carrier_prod, timestep]
             )
 
-    if loc_tech_carrier in backend_model.loc_tech_carriers_con:
+    if loc_tech_carrier_con in backend_model.loc_tech_carriers_con:
         cost_om_con = get_param(backend_model, 'cost_om_con',
                                 (cost, loc_tech, timestep))
         if cost_om_con:
             var_cost += (
                 cost_om_con * weight *
-                backend_model.carrier_con[loc_tech_carrier, timestep]
+                backend_model.carrier_con[loc_tech_carrier_con, timestep]
             )
 
     backend_model.cost_var_rhs[cost, loc_tech, timestep] = var_cost

--- a/calliope/config/conversion_0.6.0.yaml
+++ b/calliope/config/conversion_0.6.0.yaml
@@ -44,7 +44,7 @@ tech_config:
     color: essentials.color
     x_map: null  # now achieved by directly specifying file=filename.csv:column
     carrier: essentials.carrier
-    primary_carrier: essentials.primary_carrier
+    primary_carrier: essentials.primary_carrier_out
     carrier_in: essentials.carrier_in # If conversion_plus, now a list of carrier names. Ratios between carriers found in constraints.carrier_ratios
     carrier_in_2: essentials.carrier_in_2 # If conversion_plus, now a list of carrier names. Ratios between carriers found in constraints.carrier_ratios
     carrier_in_3: essentials.carrier_in_3 # If conversion_plus, now a list of carrier names. Ratios between carriers found in constraints.carrier_ratios

--- a/calliope/config/defaults.yaml
+++ b/calliope/config/defaults.yaml
@@ -29,7 +29,8 @@ default_tech:
         parent: null  # Parent tech_group. Must always be defined
         name: 'Default technology'  # Name of tech, used for plotting and analysis
         color: false  # Color to use when plotting results. If not defined, a random one will be chosen
-        primary_carrier: false  # Selects the primary output carrier to associate with costs & constraints (if multiple primary output carriers are assigned)
+        primary_carrier_out: false  # Selects the primary output carrier to associate with costs & constraints (if multiple primary output carriers are assigned)
+        primary_carrier_in: false  # Selects the primary input carrier to associate with costs & constraints (if multiple primary input carriers are assigned)
         carrier_in: false  # Defaults to false, allows technologies to define primary carrier(s) to consume
         carrier_in_2: false  # Defaults to false, allows technologies to define secondary carrier(s) to consume
         carrier_in_3: false  # Defaults to false, allows technologies to define tertiary carrier(s) to consume

--- a/calliope/core/preprocess/checks.py
+++ b/calliope/core/preprocess/checks.py
@@ -20,8 +20,7 @@ from inspect import signature
 import calliope
 from calliope._version import __version__
 from calliope.core.attrdict import AttrDict
-from calliope.core.util.tools import flatten_list
-from calliope.core.preprocess.util import get_all_carriers
+from calliope.core.preprocess.util import get_all_carriers, flatten_list
 from calliope.core.util.logging import logger
 from calliope.core.util.tools import load_function
 

--- a/calliope/core/preprocess/locations.py
+++ b/calliope/core/preprocess/locations.py
@@ -149,7 +149,7 @@ def process_locations(model_config, modelrun_techs):
             for config_key in file_configs:
                 if config_key.split('.')[-1] not in allowed_from_file:
                     # Allow any custom settings that end with _time_varying
-                    # FIXME add this to docs
+                    # FIXME: add this to docs
                     if config_key.endswith('_time_varying'):
                         warn('Using custom constraint '
                              '{} with time-varying data.'.format(config_key))

--- a/calliope/core/preprocess/model_run.py
+++ b/calliope/core/preprocess/model_run.py
@@ -309,6 +309,28 @@ def process_techs(config_model):
                 errors.append(
                     '`carrier_out` must be defined for {}'.format(tech_id)
                 )
+        # Deal with primary carrier in/out for conversion_plus techs
+        if tech_result.inheritance[-1] == 'conversion_plus':
+            for direction in ['_in', '_out']:
+                carriers = set(util.flatten_list([
+                    v for k, v in tech_result.essentials.items()
+                    if k.startswith('carrier' + direction)
+                ]))
+                primary_carrier = tech_result.essentials.get(
+                    'primary_carrier' + direction, None
+                )
+                if primary_carrier is None and len(carriers) == 1:
+                    tech_result.essentials['primary_carrier' + direction] = carriers.pop()
+                elif primary_carrier is None and len(carriers) > 1:
+                    errors.append(
+                        'Primary_carrier{0} must be assigned for tech `{1}` as '
+                        'there are multiple carriers{0}'.format(direction, tech_id)
+                    )
+                elif primary_carrier not in carriers:
+                    errors.append(
+                        'Primary_carrier{0} `{1}` not one of the available carriers'
+                        '{0} for `{2}`'.format(direction, primary_carrier, tech_id)
+                    )
 
         # If necessary, pick a color for the tech, cycling through
         # the hardcoded default palette

--- a/calliope/core/util/tools.py
+++ b/calliope/core/util/tools.py
@@ -101,13 +101,3 @@ def plugin_load(name, builtin_module):
         func_string = builtin_module + '.' + name
         func = load_function(func_string)
     return func
-
-
-def flatten_list(nested):
-    l = deepcopy(nested)
-    while l:
-        sublist = l.pop(0)
-        if isinstance(sublist, list):
-            l = sublist + l
-        else:
-            yield sublist

--- a/calliope/example_models/urban_scale/model_config/techs.yaml
+++ b/calliope/example_models/urban_scale/model_config/techs.yaml
@@ -96,7 +96,7 @@ techs:
             name: 'Combined heat and power'
             color: '#E4AB97'
             parent: conversion_plus
-            primary_carrier: electricity
+            primary_carrier_out: electricity
             carrier_in: gas
             carrier_out: electricity
             carrier_out_2: heat

--- a/calliope/test/common/test_model/model.yaml
+++ b/calliope/test/common/test_model/model.yaml
@@ -77,7 +77,7 @@ techs:
     test_conversion_plus:
         essentials:
             name: Conversion plus tech
-            primary_carrier: electricity
+            primary_carrier_out: electricity
             carrier_in: gas
             carrier_out: electricity
             carrier_out_2: heat

--- a/calliope/test/test_backend_pyomo.py
+++ b/calliope/test/test_backend_pyomo.py
@@ -1303,7 +1303,9 @@ class TestConversionPlusConstraints:
         assert hasattr(m._backend_model, 'balance_conversion_plus_primary_constraint')
 
         m = build_model(
-            {'techs.test_conversion_plus.essentials.carrier_in': ['coal', 'gas']},
+            {'techs.test_conversion_plus.essentials': {
+                'carrier_in': ['coal', 'gas'], 'primary_carrier_in': 'gas'
+             }},
             'simple_conversion_plus,two_hours,investment_costs'
         )
         m.run(build_only=True)
@@ -1399,14 +1401,18 @@ class TestConversionPlusConstraints:
         assert not hasattr(m._backend_model, 'balance_conversion_plus_in_2_constraint')
 
         m = build_model(
-            {'techs.test_conversion_plus.essentials.carrier_in_2': 'coal'},
+            {'techs.test_conversion_plus.essentials': {
+                'carrier_in_2': 'coal', 'primary_carrier_in': 'gas'
+            }},
             'simple_conversion_plus,two_hours,investment_costs'
         )
         m.run(build_only=True)
         assert hasattr(m._backend_model, 'balance_conversion_plus_in_2_constraint')
 
         m = build_model(
-            {'techs.test_conversion_plus.essentials.carrier_in_2': ['coal', 'heat']},
+            {'techs.test_conversion_plus.essentials': {
+                'carrier_in_2': ['coal', 'heat'], 'primary_carrier_in': 'gas'
+            }},
             'simple_conversion_plus,two_hours,investment_costs'
         )
         m.run(build_only=True)
@@ -1422,14 +1428,18 @@ class TestConversionPlusConstraints:
         assert not hasattr(m._backend_model, 'balance_conversion_plus_in_3_constraint')
 
         m = build_model(
-            {'techs.test_conversion_plus.essentials.carrier_in_3': 'coal'},
+            {'techs.test_conversion_plus.essentials': {
+                'carrier_in_3': 'coal', 'primary_carrier_in': 'gas'
+            }},
             'simple_conversion_plus,two_hours,investment_costs'
         )
         m.run(build_only=True)
         assert hasattr(m._backend_model, 'balance_conversion_plus_in_3_constraint')
 
         m = build_model(
-            {'techs.test_conversion_plus.essentials.carrier_in_3': ['coal', 'heat']},
+            {'techs.test_conversion_plus.essentials': {
+                'carrier_in_3': ['coal', 'heat'], 'primary_carrier_in': 'gas'
+            }},
             'simple_conversion_plus,two_hours,investment_costs'
         )
         m.run(build_only=True)

--- a/calliope/test/test_backend_pyomo.py
+++ b/calliope/test/test_backend_pyomo.py
@@ -1273,13 +1273,25 @@ class TestConversionConstraints:
         m.run(build_only=True)
         assert hasattr(m._backend_model, 'cost_var_conversion_constraint')
 
+        assert check_variable_exists(
+            m._backend_model, 'cost_var_conversion_constraint', 'carrier_prod'
+        )
+        assert not check_variable_exists(
+            m._backend_model, 'cost_var_conversion_constraint', 'carrier_con'
+        )
+
         m = build_model(
             {'techs.test_conversion.costs.monetary.om_con': 0.1},
             'simple_conversion,two_hours,investment_costs'
         )
         m.run(build_only=True)
         assert hasattr(m._backend_model, 'cost_var_conversion_constraint')
-
+        assert check_variable_exists(
+            m._backend_model, 'cost_var_conversion_constraint', 'carrier_con'
+        )
+        assert not check_variable_exists(
+            m._backend_model, 'cost_var_conversion_constraint', 'carrier_prod'
+        )
 
 class TestConversionPlusConstraints:
     # conversion_plus.py
@@ -1305,7 +1317,7 @@ class TestConversionPlusConstraints:
         m = build_model(
             {'techs.test_conversion_plus.essentials': {
                 'carrier_in': ['coal', 'gas'], 'primary_carrier_in': 'gas'
-             }},
+            }},
             'simple_conversion_plus,two_hours,investment_costs'
         )
         m.run(build_only=True)
@@ -1358,7 +1370,7 @@ class TestConversionPlusConstraints:
         """
         sets.loc_techs_om_cost_conversion_plus,
         """
-
+        # no conversion_plus = no constraint
         m = build_model(
             {'techs.test_supply_elec.costs.monetary.om_prod': 0.1},
             'simple_supply,two_hours,investment_costs'
@@ -1366,6 +1378,7 @@ class TestConversionPlusConstraints:
         m.run(build_only=True)
         assert not hasattr(m._backend_model, 'cost_var_conversion_plus_constraint')
 
+        # no conversion_plus = no constraint
         m = build_model(
             {'techs.test_conversion.costs.monetary.om_prod': 0.1},
             'simple_conversion,two_hours,investment_costs'
@@ -1373,23 +1386,38 @@ class TestConversionPlusConstraints:
         m.run(build_only=True)
         assert not hasattr(m._backend_model, 'cost_var_conversion_plus_constraint')
 
+        # no variable costs for conversion_plus = no constraint
         m = build_model({}, 'simple_conversion_plus,two_hours,investment_costs')
         m.run(build_only=True)
         assert not hasattr(m._backend_model, 'cost_var_conversion_plus_constraint')
 
+        # om_prod creates constraint and populates it with carrier_prod driven cost
         m = build_model(
             {'techs.test_conversion_plus.costs.monetary.om_prod': 0.1},
             'simple_conversion_plus,two_hours,investment_costs'
         )
         m.run(build_only=True)
         assert hasattr(m._backend_model, 'cost_var_conversion_plus_constraint')
+        assert check_variable_exists(
+            m._backend_model, 'cost_var_conversion_plus_constraint', 'carrier_prod'
+        )
+        assert not check_variable_exists(
+            m._backend_model, 'cost_var_conversion_plus_constraint', 'carrier_con'
+        )
 
+        # om_con creates constraint and populates it with carrier_con driven cost
         m = build_model(
             {'techs.test_conversion_plus.costs.monetary.om_con': 0.1},
             'simple_conversion_plus,two_hours,investment_costs'
         )
         m.run(build_only=True)
         assert hasattr(m._backend_model, 'cost_var_conversion_plus_constraint')
+        assert check_variable_exists(
+            m._backend_model, 'cost_var_conversion_plus_constraint', 'carrier_con'
+        )
+        assert not check_variable_exists(
+            m._backend_model, 'cost_var_conversion_plus_constraint', 'carrier_prod'
+        )
 
     def test_loc_techs_balance_conversion_plus_in_2_constraint(self):
         """

--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,8 @@ Release History
 0.6.2-dev
 ---------
 
+|new| ``primary_carrier`` for `conversion_plus` techs is now split into ``primary_carrier_in`` and ``primary_carrier_out``. Previously, it only accounted for output costs, by separating it, `om_con` and `om_prod` are correctly accounted for. These are required conversion_plus essentials if there's more than one input and output carrier, respectively.
+
 |new| Storage can be set to cyclic using ``run.cyclic_storage``. The last timestep in the series will then be used as the 'previous day' conditions for the first timestep in the series. This also applies to ``storage_inter_cluster``, if clustering. Defaults to False, with intention of defaulting to True in 0.6.2.
 
 |new| On clustering timeseries into representative days, an additional set of decision variables and constraints is generated. This addition allows for tracking stored energy between clusters, by considering storage between every `datestep` of the original (unclustered) timeseries as well as storage variation within a cluster.
@@ -13,7 +15,6 @@ Release History
 |fixed| Fix CLI error when running a model without transmission technologies
 
 |fixed| Allow plotting for inputs-only models, single location models, and models without location coordinates
-
 
 0.6.1 (2018-05-04)
 ------------------

--- a/doc/user/ref_advanced_func.rst
+++ b/doc/user/ref_advanced_func.rst
@@ -195,7 +195,7 @@ A combined heat and power plant produces electricity, in this case from natural 
                     carrier_in: gas
                     carrier_out: electricity
                     carrier_out_2: heat
-                    primary_carrier: electricity
+                    primary_carrier_out: electricity
                 constraints:
                     energy_eff: 0.45
                     energy_cap_max: 100
@@ -216,7 +216,7 @@ The output energy from the heat pump can be *either* heat or cooling, simulating
             name: Air source heat pump
             carrier_in: electricity
             carrier_out: [heat, cooling]
-            primary_carrier: heat
+            primary_carrier_out: heat
 
         constraints:
             energy_eff: 1
@@ -251,7 +251,7 @@ A CCHP plant can use generated heat to produce cooling via an absorption chiller
                     carrier_in: gas
                     carrier_out: electricity
                     carrier_out_2: [heat, cooling]
-                    primary_carrier: electricity
+                    primary_carrier_out: electricity
 
                 constraints:
                     energy_eff: 0.45
@@ -302,7 +302,7 @@ There are few instances where using the full capacity of a conversion_plus tech 
                     carrier_out: [high_T_heat, electricity]
                     carrier_out_2: [mid_T_heat, cooling]
                     carrier_out_3: low_T_heat
-                    primary_carrier: electricity
+                    primary_carrier_out: electricity
 
                 constraints:
                     energy_eff: 1
@@ -314,7 +314,7 @@ There are few instances where using the full capacity of a conversion_plus tech 
                         carrier_out_2: {mid_T_heat: 0.3, cooling: 0.2}
                         carrier_out_3.low_T_heat: 0.15
 
-A ``primary_carrier`` must be defined when there are multiple ``carrier_out`` values defined. ``primary_carrier`` can be defined as any carrier in a technology's output carriers (including secondary and tertiary carriers). The chosen carrier will be the one to which costs are applied.
+A ``primary_carrier_out`` must be defined when there are multiple ``carrier_out`` values defined, similarly ``primary_carrier_in`` can be defined for ``carrier_in``. `primary_carriers` can be defined as any carrier in a technology's input/output carriers (including secondary and tertiary carriers). The chosen output carrier will be the one to which production costs are applied (reciprocally, input carrier for consumption costs).
 
 .. note:: ``Conversion_plus`` technologies can also export any one of their output carriers, by specifying that carrier as ``carrier_export``.
 

--- a/doc/user/whatsnew.rst
+++ b/doc/user/whatsnew.rst
@@ -229,7 +229,7 @@ Old:
         stack_weight: 100
         parent: conversion_plus
         export: true
-        primary_carrier: power
+        primary_carrier_out: power
         carrier_in: gas
         carrier_out: power
         carrier_out_2:
@@ -251,7 +251,7 @@ New:
         essentials:
             name: 'Combined heat and power'
             parent: conversion_plus
-            primary_carrier: electricity
+            primary_carrier_out: electricity
             carrier_in: gas
             carrier_out: electricity
             carrier_out_2: heat


### PR DESCRIPTION
Separate `primary_carrier` into `primary_carrier_in`/`_out` for conversion_plus techs, to allow `om_con` and `om_prod` costs

Summary of changes in this pull request:

* If a conversion_plus tech has multiple input/output carriers, the use can define the `primary_carrier_in` / `primary_carrier_out` to correctly assign costs. Previously, there was only `primary_carrier`, which referred to output carriers only
* Fixed variable cost constraint for conversion plus to look for `primary_carrier_in` when adding om_con costs

Reviewer checklist:

- [x] Test(s) added to cover contribution
- [x] Documentation updated
- [x] Changelog updated
- [x] Coverage maintained or improved