### PR TITLE
Allow YAML comments to pass through AttrDict

### DIFF
--- a/calliope/core/attrdict.py
+++ b/calliope/core/attrdict.py
@@ -10,24 +10,37 @@ used for managing model configuration.
 
 """
 
-import copy
-import logging
-
 import numpy as np
-import ruamel.yaml as yaml
+import ruamel.yaml as ruamel_yaml
 
 from calliope.core.util.tools import relative_path
 from calliope.core.util.logging import logger
 
-class __Missing(object):
-    def __repr__(self):
-        return ('MISSING')
 
+class __Missing(object):
     def __nonzero__(self):
         return False
 
 
 _MISSING = __Missing()
+
+
+class CalliopeYAMLEmitter(ruamel_yaml.emitter.Emitter):
+
+    def write_comment(self, comment):
+        """
+        Override write_comment such as to ensure that inline
+        comments are two spaces from the end of a statement,
+        while full-line comments are aligned with their line.
+
+        """
+        comment_too_close = comment.start_mark.column < self.column
+        comment_too_far = comment.start_mark.column > self.column + 2
+
+        if comment_too_close or comment_too_far:
+            comment.start_mark.column = self.column + 2
+
+        super().write_comment(comment)
 
 
 def _yaml_load(src):
@@ -43,9 +56,17 @@ def _yaml_load(src):
     else:
         src_name = '<yaml string>'
     try:
-        return yaml.safe_load(src)
-    except yaml.YAMLError:
-        logger.error('Parser error when reading YAML from {}.'.format(src_name))
+        # Create a ruamel_yaml.YAML instance in order to get the
+        # comment roundtripping that it provides by default
+        yaml_ = ruamel_yaml.YAML()
+        result = yaml_.load(src)
+        if not isinstance(result, dict):
+            raise ValueError('Could not parse {} as YAML'.format(src_name))
+        return result
+    except ruamel_yaml.YAMLError:
+        logger.error(
+            'Parser error when reading YAML '
+            'from {}.'.format(src_name))
         raise
 
 
@@ -62,19 +83,63 @@ class AttrDict(dict):
     """
     __getattr__ = dict.__getitem__
     __setattr__ = dict.__setitem__
-    __delattr__ = dict.__delitem__
+
+    # We add a dict key that contains comment metadata, but override
+    # the __iter__, keys, and items methods below in order to hide
+    # this key from users -- it remains accessible with direct key
+    # access but is not listed or iterated over
+    __hidden_keys__ = ['__dict_comments__']
 
     def __init__(self, source_dict=None):
-        super(AttrDict, self).__init__()
-        if isinstance(source_dict, dict):
-            self.init_from_dict(source_dict)
+        super().__init__()
 
-    def copy(self, deep=False):
-        """Override copy method so that it returns an AttrDict"""
-        if deep:
-            return AttrDict(copy.deepcopy(self.as_dict()))
+        setattr(self, '__dict_comments__', {})
+
+        if source_dict is not None:
+            if isinstance(source_dict, dict):
+                self.init_from_dict(source_dict)
+            else:
+                raise ValueError('Must pass a dict to AttrDict')
+
+    def __iter__(self):
+        return iter(self.keys())
+
+    def __delitem__(self, key):
+        try:
+            del self['__dict_comments__'][key]
+        except KeyError:
+            pass
+        super().__delitem__(key)
+
+    __delattr__ = __delitem__
+
+    def keys(self, filtered=True):
+        if filtered:
+            return [
+                i for i in super().keys()
+                if i not in self.__hidden_keys__]
         else:
-            return AttrDict(self.as_dict().copy())
+            return super().keys()
+
+    def values(self, filtered=True):
+        if filtered:
+            return [
+                i[1] for i in super().items()
+                if i[0] not in self.__hidden_keys__]
+        else:
+            return super().values()
+
+    def items(self, filtered=True):
+        if filtered:
+            return [
+                i for i in super().items()
+                if i[0] not in self.__hidden_keys__]
+        else:
+            return super().items()
+
+    def copy(self):
+        """Override copy method so that it returns an AttrDict"""
+        return AttrDict(self.as_dict(filtered=False).copy())
 
     def init_from_dict(self, d):
         """
@@ -85,18 +150,49 @@ class AttrDict(dict):
             d.b.x == 1  # True
 
         """
+        if isinstance(d, ruamel_yaml.comments.CommentedMap):
+            setattr(self, '__dict_comments__', dict(d.ca.items))
+
         for k, v in d.items():
             # First, keys must be strings, not ints
             if isinstance(k, int):
                 k = str(k)
+
             # Now, assign to the key, handling nested AttrDicts properly
             if isinstance(v, dict):
                 self.set_key(k, AttrDict(v))
             elif isinstance(v, list):
-                self.set_key(k, [i if not isinstance(i, dict) else AttrDict(i)
-                                 for i in v])
+                # Modifying the list in-place so that if it is a modified
+                # list subclass, e.g. CommentedSeq, it is not killed
+                for i in range(len(v)):
+                    if isinstance(v[i], dict):
+                        v[i] = AttrDict(v[i])
+                self.set_key(k, v)
             else:
                 self.set_key(k, v)
+
+            # Deal with comments on collapsed dict notation, e.g. if a
+            # YAML file says ``foo.bar.baz: 1  # A comment``
+            if '.' in k and k in self['__dict_comments__']:
+                base_key, comment_key = k.rsplit('.', 1)
+                self.get_key(base_key)['__dict_comments__'][comment_key] = self['__dict_comments__'][k]
+                del self['__dict_comments__'][k]
+
+    @classmethod
+    def _resolve_imports(cls, loaded, resolve_imports, base_path=None):
+        if resolve_imports and 'import' in loaded:
+            for k in loaded['import']:
+                if base_path:
+                    path = relative_path(base_path, k)
+                else:
+                    path = k
+                imported = cls.from_yaml(path)
+                # loaded is added to imported (i.e. it takes precedence)
+                imported.union(loaded)
+                loaded = imported
+            # 'import' key no longer needed, so we drop it
+            loaded.pop('import', None)
+        return loaded
 
     @classmethod
     def from_yaml(cls, f, resolve_imports=True):
@@ -116,24 +212,19 @@ class AttrDict(dict):
                 loaded = cls(_yaml_load(src))
         else:
             loaded = cls(_yaml_load(f))
-        if resolve_imports and 'import' in loaded:
-            for k in loaded['import']:
-                imported = cls.from_yaml(relative_path(f, k))
-                # loaded is added to imported (i.e. it takes precedence)
-                imported.union(loaded)
-                loaded = imported
-            # 'import' key no longer needed, so we drop it
-            loaded.pop('import', None)
+        loaded = cls._resolve_imports(loaded, resolve_imports, base_path=f)
         return loaded
 
     @classmethod
-    def from_yaml_string(cls, string):
+    def from_yaml_string(cls, string, resolve_imports=False):
         """
         Returns an AttrDict initialized from the given string, which
         must be valid YAML.
 
         """
-        return cls(_yaml_load(string))
+        loaded = cls(_yaml_load(string))
+        loaded = cls._resolve_imports(loaded, resolve_imports)
+        return loaded
 
     def set_key(self, key, value):
         """
@@ -145,6 +236,8 @@ class AttrDict(dict):
             d.foo.bar == 1  # True
 
         """
+        if isinstance(value, dict) and not isinstance(value, AttrDict):
+            value = AttrDict(value)
         if '.' in key:
             key, remainder = key.split('.', 1)
             try:
@@ -202,82 +295,198 @@ class AttrDict(dict):
                 del self[key][remainder]
             except KeyError:
                 self[key].del_key(remainder)
+
+            # If we removed the last subkey, delete the parent key too
+            if len(self[key].keys()) == 0:
+                del self[key]
+
         else:
             del self[key]
 
-    def as_dict(self, flat=False):
+    def as_dict(self, flat=False, filtered=True):
         """
         Return the AttrDict as a pure dict (with nested dicts if
         necessary).
 
         """
         if flat:
-            return self.as_dict_flat()
+            return self.as_dict_flat(filtered=filtered)
         else:
-            return self.as_dict_nested()
+            return self.as_dict_nested(filtered=filtered)
 
-    def as_dict_nested(self):
+    def as_dict_nested(self, filtered=True):
         d = {}
-        for k, v in self.items():
+        for k, v in self.items(filtered=filtered):
             if isinstance(v, AttrDict):
-                d[k] = v.as_dict()
+                d[k] = v.as_dict(filtered=filtered)
             elif isinstance(v, list):
-                d[k] = [i if not isinstance(i, AttrDict) else i.as_dict()
-                        for i in v]
+                d[k] = [
+                    i if not isinstance(i, AttrDict)
+                    else i.as_dict(filtered=filtered)
+                    for i in v]
             else:
                 d[k] = v
         return d
 
-    def as_dict_flat(self):
+    def as_dict_flat(self, filtered=True):
         d = {}
-        keys = self.keys_nested()
+        keys = self.keys_nested(filtered=filtered)
         for k in keys:
             d[k] = self.get_key(k)
         return d
 
-    def to_yaml(
-            self, path=None, convert_objects=True, format_lists=True,
-            **kwargs):
+    def _comment_key_dict(self, key):
+        if '.' in key:
+            base_key, comment_key = key.rsplit('.', 1)
+            comment_dict = self.get_key(base_key).__dict_comments__
+        else:
+            comment_key = key
+            comment_dict = self.__dict_comments__
+        return comment_key, comment_dict
+
+    def get_comments(self, key):
         """
-        Saves the AttrDict to the given path as a YAML file.
+        Get comments for the given key. Returns a dict of the form
+        ``{'above': ..., 'inline': ..., 'below': ...}``.
 
-        If ``path`` is None, returns the YAML string instead.
+        """
+        comment_key, comment_dict = self._comment_key_dict(key)
 
-        Any additional keyword arguments are passed to the YAML writer,
-        so can use e.g. ``indent=4`` to override the default of 2.
+        if comment_key not in comment_dict:
+            raise KeyError(key)
 
-        ``convert_objects`` (defaults to True) controls whether Numpy
-        objects should be converted to regular Python objects, so that
-        they are properly displayed in the resulting YAML output.
+        comments = comment_dict[comment_key]
+
+        # comments is a list of four entries:
+        # [1] is a list of comments above the key,
+        # [2] is inline comment,
+        # [3] is a list of comments below the key
+        try:
+            above = '\n'.join(i.value for i in comments[1])
+        except (TypeError, AttributeError):
+            above = None
+        try:
+            inline = comments[2].value
+        except AttributeError:
+            inline = None
+        try:
+            below = '\n'.join(i.value for i in comments[3])
+        except (TypeError, AttributeError):
+            below = None
+
+        return {
+            'above': above,
+            'inline': inline,
+            'below': below
+        }
+
+    def set_comment(self, key, comment, kind='inline', exist_ok=False):
+        """
+        Set a comment for the given key. Returns None if successful,
+        KeyError if key does not exist, and ValueError if a comment
+        already exists, unless exist_ok is set to False.
+
+        Parameters
+        ----------
+        key : str
+        comment : str
+        kind : str, optional, default 'inline'
+            Can be 'inline', 'above'.
+        exist_ok : bool, optional, default False
+            If True, existing comments are overwritten.
+
+        """
+        comment_key, comment_dict = self._comment_key_dict(key)
+
+        assert isinstance(comment, str)
+        if not comment.startswith('#'):
+            comment = '# ' + comment
+
+        token = ruamel_yaml.CommentToken(
+            comment,
+            start_mark=ruamel_yaml.CommentMark(0),
+            end_mark=None
+        )
+
+        if kind == 'inline':
+            comments = token
+            pos = 2
+        elif kind == 'above':
+            comments = [token]
+            pos = 1
+        else:
+            raise ValueError('Invalid kind')
+
+        if comment_key not in comment_dict:
+            comment_list = [None, None, None, None]
+            comment_list[pos] = comments
+            comment_dict[comment_key] = comment_list
+        elif (  # Comment empty or allowed to overwrite
+            comment_dict[comment_key][pos] is None
+            or (kind == 'inline'
+                and comment_dict[comment_key][pos].value.strip('#').strip() == '')
+            or (kind == 'above'
+                and ''.join([i.value for i in comment_dict[comment_key][pos]]).strip('#').strip() == '')
+            or exist_ok
+        ):
+            comment_dict[comment_key][pos] = comments
+        else:
+            raise ValueError('Comment exists')
+
+    def del_comments(self, key):
+        """
+        Remove any comments at the given key. Returns None if successful,
+        KeyError if key has no comments.
+
+        """
+        comment_key, comment_dict = self._comment_key_dict(key)
+        del comment_dict[comment_key]
+
+    def as_commentedmap(self):
+        commented_map = ruamel_yaml.comments.CommentedMap(
+            self.as_dict_nested())
+        commented_map.ca._items = self.get('__dict_comments__', {})
+
+        for k, v in self.items():
+            if isinstance(v, dict):
+                commented_map[k] = v.as_commentedmap()
+
+        return commented_map
+
+    def to_yaml(self, path=None):
+        """
+        Saves the AttrDict to the ``path`` as a YAML file, or returns
+        a YAML string if ``path`` is None.
 
         """
         result = self.copy()
-        y = yaml.YAML()
+        yaml_ = ruamel_yaml.YAML()
+        yaml_.Emitter = CalliopeYAMLEmitter
+        yaml_.indent = 2
+        yaml_.block_seq_indent = 0
 
-        if convert_objects:
-            for k in result.keys_nested():
-                # Convert numpy numbers to regular python ones
-                v = result.get_key(k)
-                if isinstance(v, np.floating):
-                    result.set_key(k, float(v))
-                elif isinstance(v, np.integer):
-                    result.set_key(k, int(v))
+        # Numpy objects should be converted to regular Python objects,
+        # so that they are properly displayed in the resulting YAML output
+        for k in result.keys_nested():
+            # Convert numpy numbers to regular python ones
+            v = result.get_key(k)
+            if isinstance(v, np.floating):
+                result.set_key(k, float(v))
+            elif isinstance(v, np.integer):
+                result.set_key(k, int(v))
+            # Lists are turned into seqs so that they are formatted nicely
+            elif isinstance(v, list):
+                result.set_key(k, yaml_.seq(v))
 
-        if format_lists:
-            for k in result.keys_nested():
-                v = result.get_key(k)
-                if isinstance(v, list):
-                    result.set_key(k, y.seq(v))
-
-        result = result.as_dict()
+        result = result.as_commentedmap()
 
         if path is not None:
             with open(path, 'w') as f:
-                yaml.dump(result, f, indent=4, Dumper=yaml.RoundTripDumper, **kwargs)
+                yaml_.dump(result, f)
         else:
-            return yaml.dump(result, indent=4, Dumper=yaml.RoundTripDumper, **kwargs)
+            return yaml_.dump(result)
 
-    def keys_nested(self, subkeys_as='list'):
+    def keys_nested(self, subkeys_as='list', filtered=True):
         """
         Returns all keys in the AttrDict, sorted, including the keys of
         nested subdicts (which may be either regular dicts or AttrDicts).
@@ -290,14 +499,22 @@ class AttrDict(dict):
 
         """
         keys = []
-        for k, v in sorted(self.items()):
+        for k, v in sorted(self.items(filtered=filtered)):
             # Check if dict instance (which AttrDict is too),
             # and for non-emptyness of the dict
             if isinstance(v, dict) and v:
                 if subkeys_as == 'list':
-                    keys.extend([k + '.' + kk for kk in v.keys_nested()])
+                    if k == '__dict_comments__':
+                        keys.append(k)
+                    else:
+                        keys.extend([
+                            k + '.' + kk
+                            for kk in v.keys_nested(filtered=filtered)
+                        ])
                 elif subkeys_as == 'dict':
-                    keys.append({k: v.keys_nested(subkeys_as=subkeys_as)})
+                    keys.append({k: v.keys_nested(
+                        subkeys_as=subkeys_as, filtered=filtered)
+                    })
             else:
                 keys.append(k)
         return keys
@@ -323,8 +540,8 @@ class AttrDict(dict):
         than wiping them.
 
         """
-        self_keys = self.keys_nested()
-        other_keys = other.keys_nested()
+        self_keys = self.keys_nested(filtered=False)
+        other_keys = other.keys_nested(filtered=False)
         if allow_replacement:
             WIPE_KEY = '_REPLACE_'
             override_keys = [k for k in other_keys
@@ -336,7 +553,9 @@ class AttrDict(dict):
             override_keys = other_keys
             wipe_keys = []
         for k in override_keys:
-            if not allow_override and k in self_keys:
+            if k.endswith('__dict_comments__'):
+                self.set_key(k, {**self.get_key(k, {}), **other.get_key(k, {})})
+            elif not allow_override and k in self_keys:
                 raise KeyError('Key defined twice: {}'.format(k))
             else:
                 other_value = other.get_key(k)

--- a/calliope/core/preprocess/time.py
+++ b/calliope/core/preprocess/time.py
@@ -72,7 +72,7 @@ def apply_time_clustering(model_data, model_run):
         for entry in time_config.masks:
             entry = AttrDict(entry)
             mask_func = plugin_load(entry.function, builtin_module='calliope.core.time.masks')
-            mask_kwargs = entry.get_key('options', default={})
+            mask_kwargs = entry.get_key('options', default=AttrDict()).as_dict()
             masks[entry.to_yaml()] = mask_func(data, **mask_kwargs)
         data.attrs['masks'] = masks
         # Concatenate the DatetimeIndexes by using dummy Series
@@ -90,7 +90,7 @@ def apply_time_clustering(model_data, model_run):
         func = plugin_load(
             time_config.function, builtin_module='calliope.core.time.funcs'
         )
-        func_kwargs = time_config.get('function_options', {})
+        func_kwargs = time_config.get('function_options', AttrDict()).as_dict()
         if 'file=' in func_kwargs.get('clustering_func', ''):
             func_kwargs.update({'model_run': model_run})
         data = func(data=data, timesteps=timesteps, **func_kwargs)

--- a/calliope/core/util/convert.py
+++ b/calliope/core/util/convert.py
@@ -204,10 +204,17 @@ def convert_subdict(in_dict, conversion_dict):
         value = in_dict.get_key(old_k, _MISSING)
 
         if value != _MISSING:
+            try:
+                comments = in_dict.get_comments(old_k)
+            except KeyError:
+                comments = {}
             if new_k is None:
                 out_dict.set_key('__disabled.{}'.format(old_k), value)
             else:
-                out_dict.set_key(conversion_dict.get_key(old_k), value)
+                out_dict.set_key(new_k, value)
+                for k, v in comments.items():
+                    if v is not None:
+                        out_dict.set_comment(key=new_k, comment=v, kind=k)
             in_dict.del_key(old_k)  # Remove from in_dict
 
     out_dict.union(in_dict)  # Merge remaining (unchanged) keys

--- a/calliope/example_models/national_scale/model.yaml
+++ b/calliope/example_models/national_scale/model.yaml
@@ -1,7 +1,8 @@
 import:  # Import other files from paths relative to this file, or absolute paths
-    - 'model_config/techs.yaml'
-    - 'model_config/locations.yaml'
+    - 'model_config/techs.yaml'  # This file specifies the model's technologies
+    - 'model_config/locations.yaml'  # This file specifies the model's locations
 
+# Model configuration: all settings that affect the built model
 model:
     name: National-scale example model
 
@@ -13,13 +14,14 @@ model:
 
     subset_time: ['2005-01-01', '2005-01-05']  # Subset of timesteps
 
+# Run configuration: all settings that affect how the built model is run
 run:
     solver: glpk
 
-    ensure_feasibility: true # Switching on unmet demand
+    ensure_feasibility: true  # Switches on the "unmet demand" constraint
 
-    bigM: 1e6 # setting the scale of unmet demand, which cannot be too high, otherwise the optimisation will not converge
+    bigM: 1e6  # Sets the scale of unmet demand, which cannot be too high, otherwise the optimisation will not converge
 
-    zero_threshold: 1e-10 # Any value coming out of the backend that is smaller than this (due to floating point errors, probably) will be set to zero
+    zero_threshold: 1e-10  # Any value coming out of the backend that is smaller than this (due to floating point errors, probably) will be set to zero
 
     mode: plan  # Choices: plan, operate


### PR DESCRIPTION
Fixes issue(s) #85 

Summary of changes in this pull request:

* Permit comments to roundtrip through AttrDict
* Adds methods to AttrDict: ``get_comments``, ``set_comment``, ``del_comments``, ``as_commentedmap``

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved