### PR TITLE
Add unit_capacity_systemwide_constraint

### DIFF
--- a/calliope/config/defaults.yaml
+++ b/calliope/config/defaults.yaml
@@ -80,6 +80,8 @@ default_tech:
         units_min: false  # name: Minimum number of purchased units ¦ unit: integer ¦ Turns the model from LP to MILP.
         units_max: false  # name: Maximum number of purchased units ¦ unit: integer ¦ Turns the model from LP to MILP.
         units_equals: false  # name: Specific number of purchased units ¦ unit: integer ¦ Turns the model from LP to MILP.
+        units_max_systemwide: .inf  # name: System-wide maximum installed energy capacity ¦ unit: kW ¦ Limits the sum to a maximum/minimum, for a particular technology, of the decision variables ``carrier_prod``/``carrier_con`` over all locations.
+        units_equals_systemwide: false   # name: System-wide specific installed energy capacity ¦ unit: kW ¦ fixes the sum to a
     costs:
         default:  # These costs are used for any value not defined for a given cost class
             interest_rate: 0  # name: Interest rate ¦ unit: fraction ¦ Used when computing levelized costs

--- a/calliope/config/model.yaml
+++ b/calliope/config/model.yaml
@@ -44,7 +44,7 @@ model:
 tech_groups:
     supply:
         required_constraints: [['energy_cap_max', 'energy_cap_equals', 'energy_cap_per_unit']]
-        allowed_constraints: ['energy_prod', 'lifetime', 'resource', 'force_resource', 'resource_min_use', 'resource_unit', 'resource_area_min', 'resource_area_max', 'resource_area_equals', 'resource_area_per_energy_cap', 'resource_scale', 'energy_eff', 'energy_cap_min', 'energy_cap_max', 'energy_cap_equals', 'energy_cap_max_systemwide', 'energy_cap_equals_systemwide', 'energy_cap_scale', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_ramping', 'energy_eff_per_distance', 'export_cap', 'export_carrier', 'units_min', 'units_max', 'units_equals']
+        allowed_constraints: ['energy_prod', 'lifetime', 'resource', 'force_resource', 'resource_min_use', 'resource_unit', 'resource_area_min', 'resource_area_max', 'resource_area_equals', 'resource_area_per_energy_cap', 'resource_scale', 'energy_eff', 'energy_cap_min', 'energy_cap_max', 'energy_cap_equals', 'energy_cap_max_systemwide', 'energy_cap_equals_systemwide', 'energy_cap_scale', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_ramping', 'energy_eff_per_distance', 'export_cap', 'export_carrier', 'units_min', 'units_max', 'units_equals', 'units_max_systemwide', 'units_equals_systemwide']
         allowed_costs: ['interest_rate', 'resource_area', 'energy_cap', 'om_annual_investment_fraction', 'om_annual', 'om_prod', 'om_con', 'export', 'purchase', 'depreciation_rate']
         essentials:
             parent: null
@@ -54,7 +54,7 @@ tech_groups:
             energy_prod: true
     supply_plus:
         required_constraints: [['energy_cap_max', 'energy_cap_equals', 'energy_cap_per_unit']]
-        allowed_constraints: ['energy_prod', 'lifetime', 'resource', 'force_resource', 'resource_min_use', 'resource_unit', 'resource_eff', 'resource_area_min', 'resource_area_max', 'resource_area_equals', 'resource_area_per_energy_cap', 'resource_cap_min', 'resource_cap_max', 'resource_cap_equals', 'resource_cap_equals_energy_cap', 'resource_scale', 'parasitic_eff', 'energy_eff', 'energy_cap_min', 'energy_cap_max', 'energy_cap_equals', 'energy_cap_max_systemwide', 'energy_cap_equals_systemwide', 'energy_cap_scale', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_ramping', 'energy_eff_per_distance', 'export_cap', 'export_carrier', 'units_min', 'units_max', 'units_equals', 'storage_initial', 'storage_cap_min', 'storage_cap_max', 'storage_cap_equals', 'storage_cap_per_unit', 'charge_rate', 'storage_time_max', 'storage_loss']
+        allowed_constraints: ['energy_prod', 'lifetime', 'resource', 'force_resource', 'resource_min_use', 'resource_unit', 'resource_eff', 'resource_area_min', 'resource_area_max', 'resource_area_equals', 'resource_area_per_energy_cap', 'resource_cap_min', 'resource_cap_max', 'resource_cap_equals', 'resource_cap_equals_energy_cap', 'resource_scale', 'parasitic_eff', 'energy_eff', 'energy_cap_min', 'energy_cap_max', 'energy_cap_equals', 'energy_cap_max_systemwide', 'energy_cap_equals_systemwide', 'energy_cap_scale', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_ramping', 'energy_eff_per_distance', 'export_cap', 'export_carrier', 'units_min', 'units_max', 'units_equals', 'units_max_systemwide', 'units_equals_systemwide', 'storage_initial', 'storage_cap_min', 'storage_cap_max', 'storage_cap_equals', 'storage_cap_per_unit', 'charge_rate', 'storage_time_max', 'storage_loss']
         allowed_costs: ['interest_rate', 'storage_cap', 'resource_area', 'resource_cap', 'energy_cap', 'om_annual_investment_fraction', 'om_annual', 'om_prod', 'om_con', 'export', 'purchase', 'depreciation_rate']
         essentials:
             parent: null
@@ -75,7 +75,7 @@ tech_groups:
             energy_con: true
     storage:
         required_constraints: [['energy_cap_max', 'energy_cap_equals', 'energy_cap_per_unit'], ['storage_cap_max', 'storage_cap_equals']]
-        allowed_constraints: ['energy_prod', 'energy_con', 'lifetime', 'energy_eff', 'energy_cap_min', 'energy_cap_max', 'energy_cap_equals', 'energy_cap_max_systemwide', 'energy_cap_equals_systemwide', 'energy_cap_scale', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_ramping', 'storage_initial', 'storage_cap_min', 'storage_cap_max', 'storage_cap_equals', 'storage_cap_per_unit', 'charge_rate', 'storage_time_max', 'storage_loss', 'export_cap', 'export_carrier', 'units_min', 'units_max', 'units_equals']
+        allowed_constraints: ['energy_prod', 'energy_con', 'lifetime', 'energy_eff', 'energy_cap_min', 'energy_cap_max', 'energy_cap_equals', 'energy_cap_max_systemwide', 'energy_cap_equals_systemwide', 'energy_cap_scale', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_ramping', 'storage_initial', 'storage_cap_min', 'storage_cap_max', 'storage_cap_equals', 'storage_cap_per_unit', 'charge_rate', 'storage_time_max', 'storage_loss', 'export_cap', 'export_carrier', 'units_min', 'units_max', 'units_equals', 'units_max_systemwide', 'units_equals_systemwide']
         allowed_costs: ['interest_rate', 'storage_cap', 'energy_cap', 'om_annual_investment_fraction', 'om_annual', 'om_prod','export', 'purchase', 'depreciation_rate']
         essentials:
             parent: null
@@ -94,7 +94,7 @@ tech_groups:
             energy_con: true
     conversion:
         required_constraints: [['energy_cap_max', 'energy_cap_equals', 'energy_cap_per_unit']]
-        allowed_constraints: ['energy_prod', 'energy_con', 'lifetime', 'energy_eff', 'energy_cap_min', 'energy_cap_max', 'energy_cap_equals', 'energy_cap_max_systemwide', 'energy_cap_equals_systemwide', 'energy_cap_scale', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_ramping', 'energy_eff_per_distance', 'export_cap', 'export_carrier', 'units_min', 'units_max', 'units_equals']
+        allowed_constraints: ['energy_prod', 'energy_con', 'lifetime', 'energy_eff', 'energy_cap_min', 'energy_cap_max', 'energy_cap_equals', 'energy_cap_max_systemwide', 'energy_cap_equals_systemwide', 'energy_cap_scale', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_ramping', 'energy_eff_per_distance', 'export_cap', 'export_carrier', 'units_min', 'units_max', 'units_equals', 'units_max_systemwide', 'units_equals_systemwide']
         allowed_costs: ['interest_rate', 'energy_cap', 'om_annual_investment_fraction', 'om_annual', 'om_prod', 'om_con', 'export', 'purchase', 'depreciation_rate']
         essentials:
             parent: null
@@ -103,7 +103,7 @@ tech_groups:
             energy_con: true
     conversion_plus:
         required_constraints: [['energy_cap_max', 'energy_cap_equals', 'energy_cap_per_unit']]
-        allowed_constraints: ['energy_prod', 'energy_con', 'lifetime', 'carrier_ratios', 'energy_eff', 'energy_cap_min', 'energy_cap_max', 'energy_cap_equals', 'energy_cap_max_systemwide', 'energy_cap_equals_systemwide', 'energy_cap_scale', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_ramping', 'energy_eff_per_distance', 'export_cap', 'export_carrier', 'units_min', 'units_max', 'units_equals']
+        allowed_constraints: ['energy_prod', 'energy_con', 'lifetime', 'carrier_ratios', 'energy_eff', 'energy_cap_min', 'energy_cap_max', 'energy_cap_equals', 'energy_cap_max_systemwide', 'energy_cap_equals_systemwide', 'energy_cap_scale', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_ramping', 'energy_eff_per_distance', 'export_cap', 'export_carrier', 'units_min', 'units_max', 'units_equals', 'units_max_systemwide', 'units_equals_systemwide']
         allowed_costs: ['interest_rate', 'energy_cap', 'om_annual_investment_fraction', 'om_annual', 'om_prod', 'om_con', 'export', 'purchase', 'depreciation_rate']
         essentials:
             parent: null

--- a/calliope/core/preprocess/constraint_sets.py
+++ b/calliope/core/preprocess/constraint_sets.py
@@ -215,10 +215,16 @@ def generate_constraint_sets(model_run):
         i for i in sets.loc_techs_milp
         if i in sets.loc_techs_investment_cost and
         any(constraint_exists(model_run, i, 'costs.{}.purchase'.format(j))
-               for j in model_run.sets.costs)
+            for j in model_run.sets.costs)
     ]
     # loc_techs_purchase technologies only exist because they have defined a purchase cost
     constraint_sets['loc_techs_update_costs_investment_purchase_constraint'] = sets.loc_techs_purchase
+
+    constraint_sets['techs_unit_capacity_systemwide_constraint'] = [
+        i for i in sets.techs
+        if model_run.get_key('techs.{}.constraints.units_max_systemwide'.format(i), None)
+        or model_run.get_key('techs.{}.constraints.units_equals_systemwide'.format(i), None)
+    ]
 
     # conversion.py
     constraint_sets['loc_techs_balance_conversion_constraint'] = sets.loc_techs_conversion

--- a/calliope/core/preprocess/locations.py
+++ b/calliope/core/preprocess/locations.py
@@ -311,6 +311,7 @@ def cleanup_undesired_keys(tech_settings):
     # We also remove any system-wide constraints here,
     # as they should not be accidentally read from or
     # changed in per-location settings later
+    # FIXME: Raise warning that these constraints are deleted?
     system_wide_keys = [
         k for k in tech_settings.constraints.keys()
         if k.endswith('_systemwide')

--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,8 @@ Release History
 0.6.2-dev
 ---------
 
+|new| ``units_max_systemwide`` and ``units_equals_systemwide`` can be applied to an integer/binary constrained technology (capacity limited by ``units`` not ``energy_cap``, or has an associated ``purchase`` (binary) cost). Constraint works similarly to existing ``energy_cap_max_systemwide``, limiting the number of units of a technology that can be purchased across all locations in the model.
+
 |new| ``primary_carrier`` for `conversion_plus` techs is now split into ``primary_carrier_in`` and ``primary_carrier_out``. Previously, it only accounted for output costs, by separating it, `om_con` and `om_prod` are correctly accounted for. These are required conversion_plus essentials if there's more than one input and output carrier, respectively.
 
 |new| Storage can be set to cyclic using ``run.cyclic_storage``. The last timestep in the series will then be used as the 'previous day' conditions for the first timestep in the series. This also applies to ``storage_inter_cluster``, if clustering. Defaults to False, with intention of defaulting to True in 0.6.2.


### PR DESCRIPTION
``units_max_systemwide`` and ``units_equals_systemwide`` can be applied to an integer/binary constrained technology (capacity limited by ``units`` not ``energy_cap``, or has an associated ``purchase`` (binary) cost). Constraint works similarly to existing ``energy_cap_max_systemwide``, limiting the number of units of a technology that can be purchased across all locations in the model.

Reviewer checklist:

- [x] Test(s) added to cover contribution
- [x] Documentation updated
- [x] Changelog updated
- [x] Coverage maintained or improved