### PR TITLE
Fix systemwide constraints to include transmission techs

### DIFF
--- a/calliope/backend/pyomo/constraints/capacity.py
+++ b/calliope/backend/pyomo/constraints/capacity.py
@@ -335,10 +335,19 @@ def energy_capacity_systemwide_constraint_rule(backend_model, tech):
             \\forall tech \\in techs
 
     """
-    all_loc_techs = [
-        i for i in backend_model.loc_techs
-        if i.split('::')[1] == tech
-    ]
+
+    if tech in backend_model.techs_transmission_names:
+        all_loc_techs = [
+            i for i in backend_model.loc_techs_transmission
+            if i.split('::')[1].split(':')[0] == tech
+        ]
+        multiplier = 2  # there are always two technologies associated with one link
+    else:
+        all_loc_techs = [
+            i for i in backend_model.loc_techs
+            if i.split('::')[1] == tech
+        ]
+        multiplier = 1
 
     max_systemwide = get_param(backend_model, 'energy_cap_max_systemwide', tech)
     equals_systemwide = get_param(backend_model, 'energy_cap_equals_systemwide', tech)
@@ -351,9 +360,8 @@ def energy_capacity_systemwide_constraint_rule(backend_model, tech):
         )
 
     sum_expr = sum(backend_model.energy_cap[loc_tech] for loc_tech in all_loc_techs)
-    total_expr = equals_systemwide if equals_systemwide else max_systemwide
 
     if equals_systemwide:
-        return sum_expr == total_expr
+        return sum_expr == equals_systemwide * multiplier
     else:
-        return sum_expr <= total_expr
+        return sum_expr <= max_systemwide * multiplier

--- a/calliope/backend/pyomo/constraints/milp.py
+++ b/calliope/backend/pyomo/constraints/milp.py
@@ -566,10 +566,18 @@ def unit_capacity_systemwide_constraint_rule(backend_model, tech):
 
     """
 
-    all_loc_techs = [
-        i for i in backend_model.loc_techs
-        if i.split('::')[1] == tech
-    ]
+    if tech in backend_model.techs_transmission_names:
+        all_loc_techs = [
+            i for i in backend_model.loc_techs_transmission
+            if i.split('::')[1].split(':')[0] == tech
+        ]
+        multiplier = 2  # there are always two technologies associated with one link
+    else:
+        all_loc_techs = [
+            i for i in backend_model.loc_techs
+            if i.split('::')[1] == tech
+        ]
+        multiplier = 1
 
     max_systemwide = get_param(backend_model, 'units_max_systemwide', tech)
     equals_systemwide = get_param(backend_model, 'units_equals_systemwide', tech)
@@ -590,9 +598,7 @@ def unit_capacity_systemwide_constraint_rule(backend_model, tech):
         if loc_tech_is_in(backend_model, loc_tech, 'loc_techs_purchase')
     )
 
-    total_expr = equals_systemwide if equals_systemwide else max_systemwide
-
     if equals_systemwide:
-        return sum_expr_units + sum_expr_purchase == total_expr
+        return sum_expr_units + sum_expr_purchase == equals_systemwide * multiplier
     else:
-        return sum_expr_units + sum_expr_purchase <= total_expr
+        return sum_expr_units + sum_expr_purchase <= max_systemwide * multiplier

--- a/calliope/core/preprocess/model_data.py
+++ b/calliope/core/preprocess/model_data.py
@@ -402,11 +402,11 @@ def tech_specific_to_dataset(model_run):
         lambda: {'dims': ['techs'], 'data': []}
     )
 
-    systemwide_constraints = [
+    systemwide_constraints = set([
         k.split('.')[-1] for k in model_run.techs.keys_nested()
         if '.constraints.' in k and
         k.endswith('_systemwide')
-    ]
+    ])
 
     for tech in model_run.sets['techs']:
         if tech in model_run.sets['techs_transmission']:

--- a/calliope/test/test_backend_pyomo.py
+++ b/calliope/test/test_backend_pyomo.py
@@ -1255,6 +1255,15 @@ class TestMILPConstraints:
             'techs.test_conversion_plus.constraints.units_equals_systemwide': np.inf,
             'locations.1.techs.test_conversion_plus.costs.monetary.purchase': 1
         }
+        override_transmission = {
+            'links.0,1.exists': True,
+            'techs.test_transmission_elec.constraints': {
+                'units_max_systemwide': 1, 'lifetime': 25
+            },
+            'techs.test_transmission_elec.costs.monetary': {
+                'purchase': 1, 'interest_rate': 0.1
+            }
+        }
 
         m = build_model(override_max, 'conversion_plus_milp,two_hours,investment_costs')
         m.run(build_only=True)
@@ -1271,6 +1280,11 @@ class TestMILPConstraints:
             m = build_model(override_equals_inf, 'conversion_plus_milp,two_hours,investment_costs')
             m.run(build_only=True)
         assert check_error_or_warning(error, 'Cannot use inf for energy_cap_equals_systemwide')
+
+        m = build_model(override_transmission, 'simple_supply,two_hours,investment_costs')
+        m.run(build_only=True)
+        assert hasattr(m._backend_model, 'unit_capacity_systemwide_constraint')
+        assert m._backend_model.unit_capacity_systemwide_constraint['test_transmission_elec'].upper() == 2
 
 
 class TestConversionConstraints:

--- a/calliope/test/test_constraint_results.py
+++ b/calliope/test/test_constraint_results.py
@@ -41,12 +41,18 @@ class TestNationalScaleExampleModelSenseChecks:
 
     def test_systemwide_equals(self):
         model = calliope.examples.national_scale(
-            override_dict={'techs.ccgt.constraints.energy_cap_max_systemwide': 10000}
+            override_dict={
+                'techs.ccgt.constraints.energy_cap_max_systemwide': 10000,
+                'techs.ac_transmission.constraints.energy_cap_equals_systemwide': 6000
+            }
         )
         model.run()
         # Check that setting `_equals` to a finite value leads to forcing
         assert (
             model.get_formatted_array('energy_cap').loc[{'techs': 'ccgt'}].sum() == 10000
+        )
+        assert (
+            model.get_formatted_array('energy_cap').loc[{'techs': 'ac_transmission:region1'}].sum() == 6000
         )
 
     def test_reserve_margin(self):

--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,8 @@ Release History
 0.6.3-dev
 ---------
 
+|fixed| When applying systemwide constraints to transmission technologies, they are no longer silently ignored. Instead, the constraint value is doubled (to account for the constant existence of a pair of technologies to describe one link) and applied to the relevant transmission techs.
+
 |new| ``calliope generate_runs`` in the command line interface can now produce scripts for remote clusters which require SLURM-based submission (``sbatch...``).
 
 0.6.2 (2018-06-04)


### PR DESCRIPTION
Summary of changes in this pull request:

* If multiple technologies call the same systemwide constraint, the model won't break
* If a transmission technology calls a systemwide constraint, the systemwide constraint won't silently fail

Reviewer checklist:

- [x] Test(s) added to cover contribution
~~- [ ] Documentation updated~~
- [x] Changelog updated
- [ ] Coverage maintained or improved