### PR TITLE
Add `excess_supply` variable when ensuring feasibility

### DIFF
--- a/calliope/analysis/postprocess.py
+++ b/calliope/analysis/postprocess.py
@@ -183,14 +183,14 @@ def clean_results(results, zero_threshold, timings):
         comment='Postprocessing: ' + comment
     )
 
-    # Combine excess_supply and unmet_demand into one variable
+    # Combine unused_supply and unmet_demand into one variable
     if ('unmet_demand' in results.data_vars.keys() or
-            'excess_supply' in results.data_vars.keys()):
+            'unused_supply' in results.data_vars.keys()):
         results['unmet_demand'] = (
-            results.get('unmet_demand', 0) + results.get('excess_supply', 0)
+            results.get('unmet_demand', 0) + results.get('unused_supply', 0)
         )
 
-        results = results.drop('excess_supply')
+        results = results.drop('unused_supply')
 
         if not results.unmet_demand.sum():
 

--- a/calliope/analysis/postprocess.py
+++ b/calliope/analysis/postprocess.py
@@ -183,12 +183,21 @@ def clean_results(results, zero_threshold, timings):
         comment='Postprocessing: ' + comment
     )
 
-    if 'unmet_demand' in results.data_vars.keys() and not results.unmet_demand.sum():
-
-        log_time(
-            timings, 'delete_unmet_demand',
-            comment='Postprocessing: Model was feasible, deleting unmet_demand variable'
+    # Combine excess_supply and unmet_demand into one variable
+    if ('unmet_demand' in results.data_vars.keys() or
+            'excess_supply' in results.data_vars.keys()):
+        results['unmet_demand'] = (
+            results.get('unmet_demand', 0) + results.get('excess_supply', 0)
         )
-        results = results.drop('unmet_demand')
+
+        results = results.drop('excess_supply')
+
+        if not results.unmet_demand.sum():
+
+            log_time(
+                timings, 'delete_unmet_demand',
+                comment='Postprocessing: Model was feasible, deleting unmet_demand variable'
+            )
+            results = results.drop('unmet_demand')
 
     return results

--- a/calliope/backend/pyomo/constraints/energy_balance.py
+++ b/calliope/backend/pyomo/constraints/energy_balance.py
@@ -106,15 +106,16 @@ def system_balance_constraint_rule(backend_model, loc_carrier, timestep):
 
     """
     prod, con, export = get_loc_tech_carriers(backend_model, loc_carrier)
-    if hasattr(backend_model, 'unmet_demand'):
+    if hasattr(backend_model, 'bigM'):
         unmet_demand = backend_model.unmet_demand[loc_carrier, timestep]
+        excess_supply = backend_model.excess_supply[loc_carrier, timestep]
     else:
-        unmet_demand = 0
+        unmet_demand = excess_supply = 0
 
     backend_model.system_balance[loc_carrier, timestep].expr = (
         sum(backend_model.carrier_prod[loc_tech_carrier, timestep] for loc_tech_carrier in prod) +
         sum(backend_model.carrier_con[loc_tech_carrier, timestep] for loc_tech_carrier in con) +
-        unmet_demand
+        unmet_demand + excess_supply
     )
 
     return backend_model.system_balance[loc_carrier, timestep] == 0

--- a/calliope/backend/pyomo/constraints/energy_balance.py
+++ b/calliope/backend/pyomo/constraints/energy_balance.py
@@ -106,16 +106,16 @@ def system_balance_constraint_rule(backend_model, loc_carrier, timestep):
 
     """
     prod, con, export = get_loc_tech_carriers(backend_model, loc_carrier)
-    if hasattr(backend_model, 'bigM'):
+    if backend_model.__calliope_model_data__['attrs'].get('run.ensure_feasibility', False):
         unmet_demand = backend_model.unmet_demand[loc_carrier, timestep]
-        excess_supply = backend_model.excess_supply[loc_carrier, timestep]
+        unused_supply = backend_model.unused_supply[loc_carrier, timestep]
     else:
-        unmet_demand = excess_supply = 0
+        unmet_demand = unused_supply = 0
 
     backend_model.system_balance[loc_carrier, timestep].expr = (
         sum(backend_model.carrier_prod[loc_tech_carrier, timestep] for loc_tech_carrier in prod) +
         sum(backend_model.carrier_con[loc_tech_carrier, timestep] for loc_tech_carrier in con) +
-        unmet_demand + excess_supply
+        unmet_demand + unused_supply
     )
 
     return backend_model.system_balance[loc_carrier, timestep] == 0

--- a/calliope/backend/pyomo/objective.py
+++ b/calliope/backend/pyomo/objective.py
@@ -31,10 +31,10 @@ def minmax_cost_optimization(backend_model, cost_class, sense):
 
     """
     def obj_rule(backend_model):
-        if hasattr(backend_model, 'unmet_demand'):
+        if backend_model.__calliope_model_data__['attrs'].get('run.ensure_feasibility', False):
             unmet_demand = sum(
                 backend_model.unmet_demand[loc_carrier, timestep] -
-                backend_model.excess_supply[loc_carrier, timestep]
+                backend_model.unused_supply[loc_carrier, timestep]
                 for loc_carrier in backend_model.loc_carriers
                 for timestep in backend_model.timesteps
             ) * backend_model.bigM

--- a/calliope/backend/pyomo/objective.py
+++ b/calliope/backend/pyomo/objective.py
@@ -33,7 +33,8 @@ def minmax_cost_optimization(backend_model, cost_class, sense):
     def obj_rule(backend_model):
         if hasattr(backend_model, 'unmet_demand'):
             unmet_demand = sum(
-                backend_model.unmet_demand[loc_carrier, timestep]
+                backend_model.unmet_demand[loc_carrier, timestep] -
+                backend_model.excess_supply[loc_carrier, timestep]
                 for loc_carrier in backend_model.loc_carriers
                 for timestep in backend_model.timesteps
             ) * backend_model.bigM

--- a/calliope/backend/pyomo/variables.py
+++ b/calliope/backend/pyomo/variables.py
@@ -92,4 +92,5 @@ def initialize_decision_variables(backend_model):
 
     if model_data_dict['attrs'].get('run.ensure_feasibility', False):
         backend_model.unmet_demand = po.Var(backend_model.loc_carriers, backend_model.timesteps, within=po.NonNegativeReals)
+        backend_model.excess_supply = po.Var(backend_model.loc_carriers, backend_model.timesteps, within=po.NegativeReals)
         backend_model.bigM = model_data_dict['attrs'].get('run.bigM')

--- a/calliope/backend/pyomo/variables.py
+++ b/calliope/backend/pyomo/variables.py
@@ -30,6 +30,7 @@ def initialize_decision_variables(backend_model):
     units                loc_techs_milp
     operating\_units     loc_techs_milp, timesteps
     unmet\_demand        loc_carriers, timesteps
+    unused\_supply       loc_carriers, timesteps
     ==================== ========================================
 
     """
@@ -92,5 +93,5 @@ def initialize_decision_variables(backend_model):
 
     if model_data_dict['attrs'].get('run.ensure_feasibility', False):
         backend_model.unmet_demand = po.Var(backend_model.loc_carriers, backend_model.timesteps, within=po.NonNegativeReals)
-        backend_model.excess_supply = po.Var(backend_model.loc_carriers, backend_model.timesteps, within=po.NegativeReals)
+        backend_model.unused_supply = po.Var(backend_model.loc_carriers, backend_model.timesteps, within=po.NegativeReals)
         backend_model.bigM = model_data_dict['attrs'].get('run.bigM')

--- a/calliope/test/test_constraint_results.py
+++ b/calliope/test/test_constraint_results.py
@@ -90,13 +90,13 @@ class TestModelSettings:
 
             return override_dict
 
-        # Feasible case, unmet_demand/excess_supply is deleted
+        # Feasible case, unmet_demand/unused_supply is deleted
         model_10 = build_model(
             override_dict=override(True, 10),
             override_groups='investment_costs'
         )
         model_10.run()
-        for i in ['unmet_demand', 'excess_supply']:
+        for i in ['unmet_demand', 'unused_supply']:
             assert hasattr(model_10._backend_model, i)
             assert i not in model_10._model_data.data_vars.keys()
 
@@ -107,20 +107,20 @@ class TestModelSettings:
         )
         model_5.run()
         assert hasattr(model_5._backend_model, 'unmet_demand')
-        assert hasattr(model_5._backend_model, 'excess_supply')
+        assert hasattr(model_5._backend_model, 'unused_supply')
         assert model_5._model_data['unmet_demand'].sum() == 15
-        assert 'excess_supply' not in model_5._model_data.data_vars.keys()
+        assert 'unused_supply' not in model_5._model_data.data_vars.keys()
 
-        # Infeasible case, excess_supply is required
+        # Infeasible case, unused_supply is required
         model_15 = build_model(
             override_dict=override(True, 15),
             override_groups='investment_costs'
         )
         model_15.run()
         assert hasattr(model_15._backend_model, 'unmet_demand')
-        assert hasattr(model_15._backend_model, 'excess_supply')
+        assert hasattr(model_15._backend_model, 'unused_supply')
         assert model_15._model_data['unmet_demand'].sum() == -15
-        assert 'excess_supply' not in model_15._model_data.data_vars.keys()
+        assert 'unused_supply' not in model_15._model_data.data_vars.keys()
 
         assert (
             model_15._backend_model.obj.expr() - model_10._backend_model.obj.expr() ==
@@ -140,7 +140,7 @@ class TestModelSettings:
         )
         model.run()
         assert not hasattr(model._backend_model, 'unmet_demand')
-        assert not hasattr(model._backend_model, 'excess_supply')
+        assert not hasattr(model._backend_model, 'unused_supply')
         assert not model._model_data.attrs['termination_condition'] == 'optimal'
 
         # too little supply

--- a/calliope/test/test_constraint_results.py
+++ b/calliope/test/test_constraint_results.py
@@ -2,6 +2,7 @@ import pytest
 from pytest import approx
 
 import calliope
+from calliope.test.common.util import build_test_model as build_model
 
 _OVERRIDE_FILE = calliope.examples._PATHS['national_scale'] + '/overrides.yaml'
 
@@ -68,3 +69,84 @@ class TestNationalScaleExampleModelSenseChecks:
         # assert constraint_string in model._backend_model.reserve_margin_constraint.pprint()
 
         assert float(model.results.cost.sum()) == approx(282487.35489)
+
+
+class TestModelSettings:
+    def test_feasibility(self):
+
+        def override(feasibility, cap_val):
+            override_dict = {
+                'locations.0.techs': {'test_supply_elec': {}, 'test_demand_elec': {}},
+                'links.0,1.exists': False,
+                # pick a time subset where demand is uniformally -10 throughout
+                'model.subset_time': ['2005-01-01 06:00:00', '2005-01-01 08:00:00'],
+                'run.ensure_feasibility': feasibility, 'run.bigM': 1e3,
+                # Allow setting resource and energy_cap_max/equals to force infeasibility
+                'techs.test_supply_elec.constraints': {
+                    'resource': cap_val, 'energy_eff': 1, 'energy_cap_equals': 15,
+                    'force_resource': True
+                }
+            }
+
+            return override_dict
+
+        # Feasible case, unmet_demand/excess_supply is deleted
+        model_10 = build_model(
+            override_dict=override(True, 10),
+            override_groups='investment_costs'
+        )
+        model_10.run()
+        for i in ['unmet_demand', 'excess_supply']:
+            assert hasattr(model_10._backend_model, i)
+            assert i not in model_10._model_data.data_vars.keys()
+
+        # Infeasible case, unmet_demand is required
+        model_5 = build_model(
+            override_dict=override(True, 5),
+            override_groups='investment_costs'
+        )
+        model_5.run()
+        assert hasattr(model_5._backend_model, 'unmet_demand')
+        assert hasattr(model_5._backend_model, 'excess_supply')
+        assert model_5._model_data['unmet_demand'].sum() == 15
+        assert 'excess_supply' not in model_5._model_data.data_vars.keys()
+
+        # Infeasible case, excess_supply is required
+        model_15 = build_model(
+            override_dict=override(True, 15),
+            override_groups='investment_costs'
+        )
+        model_15.run()
+        assert hasattr(model_15._backend_model, 'unmet_demand')
+        assert hasattr(model_15._backend_model, 'excess_supply')
+        assert model_15._model_data['unmet_demand'].sum() == -15
+        assert 'excess_supply' not in model_15._model_data.data_vars.keys()
+
+        assert (
+            model_15._backend_model.obj.expr() - model_10._backend_model.obj.expr() ==
+            approx(1e3 * 15)
+        )
+
+        assert (
+            model_5._backend_model.obj.expr() - model_10._backend_model.obj.expr() ==
+            approx(1e3 * 15)
+        )
+
+        # Infeasible cases = non-optimal termination
+        # too much supply
+        model = build_model(
+            override_dict=override(False, 15),
+            override_groups='investment_costs'
+        )
+        model.run()
+        assert not hasattr(model._backend_model, 'unmet_demand')
+        assert not hasattr(model._backend_model, 'excess_supply')
+        assert not model._model_data.attrs['termination_condition'] == 'optimal'
+
+        # too little supply
+        model = build_model(
+            override_dict=override(False, 5),
+            override_groups='investment_costs'
+        )
+        model.run()
+        assert not model._model_data.attrs['termination_condition'] == 'optimal'

--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,8 @@ Release History
 0.6.3-dev
 ---------
 
+|fixed| When setting `ensure_feasibility`, the resulting `unmet_demand` variable can also be negative, accounting for possible infeasibility when there is excess supply, relative to demand (assuming no load shedding abilities). This is particularly pertinent when the `force_resource` constraint is in place.
+
 |fixed| When applying systemwide constraints to transmission technologies, they are no longer silently ignored. Instead, the constraint value is doubled (to account for the constant existence of a pair of technologies to describe one link) and applied to the relevant transmission techs.
 
 |new| ``calliope generate_runs`` in the command line interface can now produce scripts for remote clusters which require SLURM-based submission (``sbatch...``).

--- a/changelog.rst
+++ b/changelog.rst
@@ -6,7 +6,7 @@ Release History
 0.6.3-dev
 ---------
 
-|fixed| When setting `ensure_feasibility`, the resulting `unmet_demand` variable can also be negative, accounting for possible infeasibility when there is excess supply, relative to demand (assuming no load shedding abilities). This is particularly pertinent when the `force_resource` constraint is in place.
+|fixed| When setting `ensure_feasibility`, the resulting `unmet_demand` variable can also be negative, accounting for possible infeasibility when there is unused supply, once all demand has been met (assuming no load shedding abilities). This is particularly pertinent when the `force_resource` constraint is in place.
 
 |fixed| When applying systemwide constraints to transmission technologies, they are no longer silently ignored. Instead, the constraint value is doubled (to account for the constant existence of a pair of technologies to describe one link) and applied to the relevant transmission techs.
 


### PR DESCRIPTION
Summary of changes in this pull request:

* System can be balanced due to forced excess supply, by the same mechanism as we currently handle unmet demand. 
* `excess_supply` decision variable is merged into `unmet_demand` on completion, leading to just the one data variable in `model.results`. However, it's possible for `unmet_demand` to be negative (i.e. excess supply).

Reviewer checklist:

- [x] Test(s) added to cover contribution
~~- [ ] Documentation updated~~
- [x] Changelog updated
- [x] Coverage maintained or improved