### PR TITLE
Add groups_file option to generate_runs CLI

### DIFF
--- a/calliope/cli.py
+++ b/calliope/cli.py
@@ -265,6 +265,7 @@ def run(model_file, override_file, save_netcdf, save_csv, save_plots,
 @click.argument('out_file')
 @click.option('--kind', help='One of: "bash", "bsub", "sbatch", or "windows".')
 @click.option('--override_file')
+@click.option('--groups_file')
 @click.option('--groups')
 @click.option('--cluster_threads', default=1)
 @click.option('--cluster_mem')
@@ -276,7 +277,7 @@ def run(model_file, override_file, save_netcdf, save_csv, save_plots,
 @_quiet
 @_pdb
 def generate_runs(
-        model_file, out_file, kind, override_file, groups, additional_args,
+        model_file, out_file, kind, override_file, groups_file, groups, additional_args,
         cluster_threads, cluster_mem, cluster_time,
         debug, quiet, pdb):
 
@@ -286,6 +287,7 @@ def generate_runs(
         model_file=model_file,
         out_file=out_file,
         override_file=override_file,
+        groups_file=groups_file,
         groups=groups,
         additional_args=additional_args,
         cluster_mem=cluster_mem,

--- a/calliope/test/test_cli.py
+++ b/calliope/test/test_cli.py
@@ -97,6 +97,17 @@ class TestCLI:
             assert os.path.isfile(os.path.join(tempdir, 'test.sh'))
             assert os.path.isfile(os.path.join(tempdir, 'test.sh.array.sh'))
 
+    def test_generate_runs_groups_file_and_groups(self):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem() as tempdir:
+            result = runner.invoke(cli.generate_runs, [
+                _MODEL_NATIONAL, 'test.sh', '--kind=bash',
+                '--groups="run1,run2,run3,run4"',
+                '--groups_file="foobar"'
+            ])
+            assert result.exit_code == 1
+
     def test_debug(self):
         runner = CliRunner()
         result = runner.invoke(cli.run, ['foo.yaml', '--debug'])

--- a/changelog.rst
+++ b/changelog.rst
@@ -10,6 +10,8 @@ Release History
 
 |fixed| When applying systemwide constraints to transmission technologies, they are no longer silently ignored. Instead, the constraint value is doubled (to account for the constant existence of a pair of technologies to describe one link) and applied to the relevant transmission techs.
 
+|new| Added ``--groups_file`` option to the ``calliope generate_runs`` command, allowing the flexible specification of a large number of scenario combinations. See the documentaion (:doc:`user/ref_advanced_func`) for details.
+
 |new| ``calliope generate_runs`` in the command line interface can now produce scripts for remote clusters which require SLURM-based submission (``sbatch...``).
 
 0.6.2 (2018-06-04)

--- a/doc/user/ref_advanced_func.rst
+++ b/doc/user/ref_advanced_func.rst
@@ -478,7 +478,26 @@ This functionality can be used together with the ``calliope generate_runs`` comm
 * the name of the script to create
 * ``--kind``: Currently, three options are available. ``windows`` creates a Windows batch (``.bat``) script that runs all models sequentially, ``bash`` creates an equivalent script to run on Linux or macOS, ``bsub`` creates a submission script for a LSF-based high-performance cluster, and ``sbatch`` creates a submission script for a SLURM-based high-performance cluster.
 * ``--override_file``: The file that specifies override groups.
-* ``--groups``: A semicolon-separated list of override groups to generate scripts for, for example, ``run1;run2``. A comma is used to group override groups together into a single model -- for example, ``run1,high_costs;run1,low_costs`` would run the model twice, once applying the ``run1`` and ``high_costs`` override groups, and once applying ``run1`` and ``low_costs``.
+
+To select the groups to use, one of two options can be used:
+
+1. ``--groups_file``: A YAML file that specifies the combinations of groups to use or a list of groups to use. It must either contain a single ``groups`` key which specifies a list of override groups, for examle, ``groups: ['run1', 'run2']``, or a single ``combinations`` key which specifies a combination of groups (see below for an example).
+2. ``--groups``: A semicolon-separated list of override groups to generate scripts for, for example, ``run1;run2``.
+
+A comma is used to group override groups together into a single model -- for example, ``run1,high_costs;run1,low_costs`` would run the model twice, once applying the ``run1`` and ``high_costs`` override groups, and once applying ``run1`` and ``low_costs``.
+
+An example of a YAML file specifying combinations:
+
+.. code-block:: yaml
+
+    combinations: [
+        # Cost scenarios
+        ['base_cost', 'low_cost', 'high_cost'],
+        # Weather scenarios
+        ['base_weather', 'good_weather', 'bad_weather']
+    ]
+
+This example would result in the runs like this: ``base_cost,base_weather;base_cost,good_weather; ...``
 
 A fully-formed command generating a Windows batch script to run a model four times with each of the override groups "run1", "run2", "run3", and "run4":
 


### PR DESCRIPTION
### Summary of changes in this pull request:

Adds a ``--groups_file`` option to the ``calliope generate_runs`` command.

Possibly, the documentation for this needs some changes, as it may not be easy enough to follow.

### Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved