### PR TITLE
Fix only interest rate defined in a cost class

### DIFF
--- a/calliope/core/preprocess/locations.py
+++ b/calliope/core/preprocess/locations.py
@@ -438,8 +438,14 @@ def compute_depreciation_rates(tech_id, tech_config, warnings, errors):
 
             tech_config.costs[cost]['depreciation_rate'] = dep
         try:
-            del tech_config.costs[cost]['interest_rate']
+            tech_config.costs[cost].del_key('interest_rate')
         except KeyError:
             pass
+        # If, by deleting 'interest_rate', we end up with an empty dict, delete the cost class
+        if len(tech_config.costs[cost].keys()) == 0:
+            tech_config.costs.del_key(cost)
+    # If, by deleting the cost class, we end up with an empty dict, delete the cost key
+    if len(cost_classes) > 0 and len(tech_config.costs.keys()) == 0:
+            tech_config.del_key('costs')
 
     return tech_config

--- a/calliope/test/test_core_preprocess.py
+++ b/calliope/test/test_core_preprocess.py
@@ -274,6 +274,18 @@ class TestModelRun:
         }
         build_model(override_dict=override7, override_groups='simple_supply,one_day')
 
+    def test_delete_interest_rate(self):
+        """
+        If only 'interest_rate' is given in the cost class for a technology, we
+        should be able to handle deleting it without leaving an empty cost key.
+        """
+
+        override1 = {
+            'techs.test_supply_elec.costs.monetary.interest_rate': 0.1
+        }
+        m = build_model(override_dict=override1, override_groups='simple_supply,one_day')
+        assert 'loc_techs_cost' not in m._model_data.dims
+
 
 class TestChecks:
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -16,6 +16,8 @@ Release History
 
 |fixed| When applying systemwide constraints to transmission technologies, they are no longer silently ignored. Instead, the constraint value is doubled (to account for the constant existence of a pair of technologies to describe one link) and applied to the relevant transmission techs.
 
+|fixed| If only `interest_rate` is defined within a cost class of a technology, the entire cost class is correctly removed after deleting the `interest_rate` key. This ensures an empty cost key doesn't break things later on.
+
 0.6.2 (2018-06-04)
 ------------------
 


### PR DESCRIPTION
Fixes issue(s) #113 

Summary of changes in this pull request:

* If only interest rate is defined for a cost class, resulting empty keys will be deleted before building the xarray dataset.

Reviewer checklist:

- [ ] Test(s) added to cover contribution
~~- [ ] Documentation updated~~
- [ ] Changelog updated
- [ ] Coverage maintained or improved