### PR TITLE
Re-add cost key to demand tech_group

### DIFF
--- a/calliope/config/model.yaml
+++ b/calliope/config/model.yaml
@@ -64,7 +64,7 @@ tech_groups:
     demand:
         required_constraints: ['resource']
         allowed_constraints: ['energy_con', 'force_resource', 'resource', 'resource_area_equals', 'resource_scale', 'resource_unit']
-        allowed_costs: ['om_prod']
+        allowed_costs: ['om_con']
         essentials:
             parent: null
         constraints:

--- a/calliope/config/model.yaml
+++ b/calliope/config/model.yaml
@@ -64,7 +64,7 @@ tech_groups:
     demand:
         required_constraints: ['resource']
         allowed_constraints: ['energy_con', 'force_resource', 'resource', 'resource_area_equals', 'resource_scale', 'resource_unit']
-        allowed_costs: []
+        allowed_costs: ['om_prod']
         essentials:
             parent: null
         constraints:


### PR DESCRIPTION
Added a cost key (om_prod) to the demand tech_group, as in prior versions of Calliope, so as to allow for modelling of import and export (and possibly curtailment and more) as demand techs

Fixes issue(s) #
- Impossibility to model export as a single entity and curtailment

Summary of changes in this pull request:
* om_prod is added as a cost key to the demand tech_group

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved

