### PR TITLE
Fix assert time series

### DIFF
--- a/calliope/core/preprocess/model_run.py
+++ b/calliope/core/preprocess/model_run.py
@@ -399,6 +399,8 @@ def process_timeseries_data(config_model, model_run):
         constraint_filenames = get_filenames(location_config)
         cluster_filenames = get_filenames(model_config)
 
+        _assert_timeseries_available(constraint_filenames | cluster_filenames)
+
         datetime_min = []
         datetime_max = []
 
@@ -481,6 +483,14 @@ def process_timeseries_data(config_model, model_run):
             )
 
     return timeseries_data, first_index
+
+
+def _assert_timeseries_available(filenames):
+    if len(filenames) == 0:
+        raise exceptions.ModelError(
+            'There is no timeseries in the model. At least one timeseries is '
+            'necessary to run the model.'
+        )
 
 
 def generate_model_run(config, debug_comments, applied_overrides, scenario):

--- a/calliope/test/test_example_models.py
+++ b/calliope/test/test_example_models.py
@@ -85,6 +85,15 @@ class TestNationalScaleExampleModelSenseChecks:
         else:
             pytest.skip('CBC not installed')
 
+    def test_fails_gracefully_without_timeseries(self):
+        override = {
+            "locations.region1.techs.demand_power.constraints.resource": -200,
+            "locations.region2.techs.demand_power.constraints.resource": -400,
+            "techs.csp.constraints.resource": 100
+        }
+        with pytest.raises(calliope.exceptions.ModelError):
+            calliope.examples.national_scale(override_dict=override)
+
 
 class TestNationalScaleExampleModelInfeasibility:
     def example_tester(self):

--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,7 @@ Release History
 0.6.4 (dev)
 -----------
 
+|fixed| Models without time series data fail gracefully.
 
 0.6.3 (2018-10-03)
 ------------------

--- a/doc/user/building.rst
+++ b/doc/user/building.rst
@@ -202,7 +202,7 @@ The only required setting in the run configuration is the solver to use:
 
     run:
         solver: glpk
-        model: plan
+        mode: plan
 
 the most important parts of the ``run`` section are ``solver`` and  ``mode``. A model can run either in planning mode (``plan``) or operational mode (``operate``). In planning mode, capacities are determined by the model, whereas in operational mode, capacities are fixed and the system is operated with a receding horizon control algorithm.
 

--- a/doc/user/ref_advanced_func.rst
+++ b/doc/user/ref_advanced_func.rst
@@ -56,7 +56,7 @@ Time series data
 
 .. Note::
 
-   If a parameter is not explicit in time and space, it can be specified as a single value in the model definition (or, using location-specific definitions, be made spatially explicit). This applies both to parameters that never vary through time (for example, cost of installed capacity) and for those that may be time-varying (for example, a technology's available resource).
+   If a parameter is not explicit in time and space, it can be specified as a single value in the model definition (or, using location-specific definitions, be made spatially explicit). This applies both to parameters that never vary through time (for example, cost of installed capacity) and for those that may be time-varying (for example, a technology's available resource). However, each model must contain at least one time series.
 
 
 For parameters that vary in time, time series data can be read from CSV files, by specifying ``resource: file=filename.csv`` to pick the desired CSV file from within the configured timeseries data path (``model.timeseries_data_path``).

--- a/doc/user/tutorials_01_national.rst
+++ b/doc/user/tutorials_01_national.rst
@@ -94,7 +94,7 @@ Three more technologies are needed for a simple model. First, a definition of po
 
 Power demand is a technology like any other. We will associate an actual demand time series with the demand technology later.
 
-What remains to set up is a simple transmission technologies. Transmission technologies (like conversion technologies) look different than other nodes, as they link the carrier at one location to the carrier at another (or, in the case of conversion, one carrier to another at the same location):
+What remains to set up is a simple transmission technology. Transmission technologies (like conversion technologies) look different than other nodes, as they link the carrier at one location to the carrier at another (or, in the case of conversion, one carrier to another at the same location):
 
 .. figure:: images/transmission.*
    :alt: Transmission node


### PR DESCRIPTION
### Summary of changes in this pull request:

Calliope needs at least one time series otherwise the model preprocess failed with unspecific error messages.

Now there is a check that at least one time series exists and the preprocess fails gracefully with a specific error message in case none exists.

###  Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved