### PR TITLE
Define scenarios in YAML as list, not string

### DIFF
--- a/calliope/cli.py
+++ b/calliope/cli.py
@@ -325,8 +325,7 @@ def generate_scenarios(
         scenario_string = '{}{:0>' + str(len(str(len(combinations)))) + 'd}'
 
         scenarios = {'scenarios': {
-            scenario_string.format(scenario_name_prefix, i + 1):
-            ','.join(c)
+            scenario_string.format(scenario_name_prefix, i + 1): c
             for i, c in enumerate(combinations)}}
 
         AttrDict(scenarios).to_yaml(out_file)

--- a/calliope/core/preprocess/model_run.py
+++ b/calliope/core/preprocess/model_run.py
@@ -154,7 +154,7 @@ def apply_overrides(config, scenario=None, override_dict=None):
     if scenario:
         scenarios = config_model.get('scenarios', {})
 
-        if scenario in scenarios:
+        if scenario in scenarios.keys():
             # Manually defined scenario names cannot be the same as single
             # overrides or any combination of semicolon-delimited overrides
             if all([i in config_model.get('overrides', {})
@@ -162,20 +162,20 @@ def apply_overrides(config, scenario=None, override_dict=None):
                 raise exceptions.ModelError(
                     'Manually defined scenario cannot be a combination of override names.'
                 )
-            if not isinstance(scenarios[scenario], str):
+            if not isinstance(scenarios[scenario], list):
                 raise exceptions.ModelError(
-                    'Scenario definition must be string of comma-separated overrides.'
+                    'Scenario definition must be a list of override names.'
                 )
-            overrides = scenarios[scenario].split(',')
+            overrides = [str(i) for i in scenarios[scenario]]
             logger.info(
                 'Using scenario `{}` leading to the application of '
-                'overrides `{}`.'.format(scenario, scenarios[scenario])
+                'overrides `{}`.'.format(scenario, overrides)
             )
         else:
             overrides = str(scenario).split(',')
             logger.info(
-                'Applying overrides `{}` without a '
-                'specific scenario name.'.format(scenario)
+                'Applying the following overrides without a '
+                'specific scenario name: {}'.format(overrides)
             )
 
         overrides_from_scenario = combine_overrides(config_model, overrides)

--- a/calliope/example_models/national_scale/scenarios.yaml
+++ b/calliope/example_models/national_scale/scenarios.yaml
@@ -2,8 +2,8 @@
 # Scenarios are optional, named combinations of overrides
 ##
 scenarios:
-    cold_fusion_with_production_share: 'cold_fusion,group_share_cold_fusion_prod'
-    cold_fusion_with_capacity_share: 'cold_fusion,group_share_cold_fusion_cap'
+    cold_fusion_with_production_share: ['cold_fusion', 'group_share_cold_fusion_prod']
+    cold_fusion_with_capacity_share: ['cold_fusion', 'group_share_cold_fusion_cap']
 
 
 ##

--- a/calliope/test/common/html_strings.yaml
+++ b/calliope/test/common/html_strings.yaml
@@ -2,14 +2,16 @@ national_scale:
     capacity:
         - '"type": "dropdown", "x": 0, "xanchor": "left", "y": 1.13'
         - '"yaxis": {"showticklabels": true, "title": "Location"}'
-        - '{"showLink": false, "linkText": "Export to plot.ly", "modeBarButtonsToRemove": ["sendDataToCloud"], "displaylogo": false}'
+        - '"showLink": false'
+        - '"modeBarButtonsToRemove": ["sendDataToCloud"]'
     timeseries:
         - '"type": "scatter",'
         - '"x": ["2005-01-01", "2005-01-01 01:00:00",'
         - '"y": [27538.578, 26518.588, 25820.82,'
         - '"name": "Concentrating solar power"'
         - '"title": "Carrier flow: power",'
-        - '{"showLink": false, "linkText": "Export to plot.ly", "modeBarButtonsToRemove": ["sendDataToCloud"], "displaylogo": false}'
+        - '"showLink": false'
+        - '"modeBarButtonsToRemove": ["sendDataToCloud"]'
     transmission:
         - '"type": "scattergeo",'
         - '"lat": [40, 40, null],'
@@ -18,7 +20,8 @@ national_scale:
         - '"scope": "world"'
         - '"showcountries": true'
         - '"type": "mercator"'
-        - '{"showLink": false, "linkText": "Export to plot.ly", "modeBarButtonsToRemove": ["sendDataToCloud"], "displaylogo": false}'
+        - '"showLink": false'
+        - '"modeBarButtonsToRemove": ["sendDataToCloud"]'
     flows:
         - '"type": "scattergeo"'
         - '"lon": [-2, -2],'
@@ -32,11 +35,13 @@ milp:
         - '"type": "bar"'
         - '"y": ["X3", "X2", "X1", "N1"]'
         - '"name": "Natural gas boiler"'
-        - '{"showLink": false, "linkText": "Export to plot.ly", "modeBarButtonsToRemove": ["sendDataToCloud"], "displaylogo": false}'
+        - '"showLink": false'
+        - '"modeBarButtonsToRemove": ["sendDataToCloud"]'
     timeseries:
         - '"type": "scatter"'
         - '"x": ["2005-07-01", "2005-07-01 01:00:00",'
-        - '{"showLink": false, "linkText": "Export to plot.ly", "modeBarButtonsToRemove": ["sendDataToCloud"], "displaylogo": false}'
+        - '"showLink": false'
+        - '"modeBarButtonsToRemove": ["sendDataToCloud"]'
     transmission:
         - '"type": "scatter"'
         - '"x": [5, 2, null]'
@@ -44,7 +49,8 @@ milp:
         - '"name": "District heat distribution"'
         - '"name": "Locations",'
         - '"hovermode": "closest"'
-        - '{"showLink": false, "linkText": "Export to plot.ly", "modeBarButtonsToRemove": ["sendDataToCloud"], "displaylogo": false}'
+        - '"showLink": false'
+        - '"modeBarButtonsToRemove": ["sendDataToCloud"]'
 
 clustering:
     timeseries:

--- a/calliope/test/test_cli.py
+++ b/calliope/test/test_cli.py
@@ -117,4 +117,6 @@ class TestCLI:
             assert os.path.isfile(out_file)
             scenarios = AttrDict.from_yaml(out_file)
             assert 'scenario_0' not in scenarios['scenarios']
-            assert scenarios['scenarios']['scenario_1'] == 'cold_fusion,run1,group_share_cold_fusion_cap'
+            assert scenarios['scenarios']['scenario_1'] == [
+                'cold_fusion', 'run1', 'group_share_cold_fusion_cap'
+            ]

--- a/changelog.rst
+++ b/changelog.rst
@@ -8,6 +8,8 @@ Release History
 
 |changed| Default value of resource_area_max now is ``inf`` instead of ``0``, deactivating the constraint by default.
 
+|changed| Scenarios in YAML files defined as list of override names, not comma-separated strings: `fusion_scenario: cold_fusion,high_cost` becomes `fusion_scenario: ['cold_fusion', 'high_cost']`. No change to the command-line interface.
+
 |fixed| Updated documentation on amendments of abstract base technology groups
 
 |fixed| Models without time series data fail gracefully.

--- a/doc/user/building.rst
+++ b/doc/user/building.rst
@@ -235,8 +235,8 @@ To make it easier to run a given model multiple times with slightly changed sett
 .. code-block:: yaml
 
     scenarios:
-        high_cost_2005: "high_cost,year2005"
-        high_cost_2006: "high_cost,year2006"
+        high_cost_2005: ["high_cost", "year2005"]
+        high_cost_2006: ["high_cost", "year2006"]
 
     overrides:
         high_cost:
@@ -254,7 +254,7 @@ To make it easier to run a given model multiple times with slightly changed sett
 
 Each override is given by a name (e.g. ``high_cost``) and any number of model settings -- anything in the model configuration can be overridden by an override. In the above example, one override defines higher costs for an ``onshore_wind`` tech while the two other overrides specify different time subsets, so would run an otherwise identical model over two different periods of time series data.
 
-One or several overrides can be applied when running a model, as described in :doc:`running`. Overrides can also be combined into scenarios to make applying them at run-time easier. Scenarios consist of a name and a string of comma-delimited override names which together form that scenario.
+One or several overrides can be applied when running a model, as described in :doc:`running`. Overrides can also be combined into scenarios to make applying them at run-time easier. Scenarios consist of a name and a list of override names which together form that scenario.
 
 Scenarios and overrides can be used to generate scripts that run a single Calliope model many times, either sequentially, or in parallel on a high-performance cluster (see :ref:`generating_scripts`).
 


### PR DESCRIPTION
Summary of changes in this pull request:

* Define scenarios in YAML as list, not string

Reviewer checklist:

- [x] Test(s) added to cover contribution
- [x] Documentation updated
- [x] Changelog updated
- [x] Coverage maintained or improved