### PR TITLE
Fix plotly test and some deprecation warnings

### DIFF
--- a/calliope/backend/pyomo/constraints/capacity.py
+++ b/calliope/backend/pyomo/constraints/capacity.py
@@ -144,7 +144,7 @@ def energy_capacity_storage_constraint_rule(backend_model, loc_tech):
         .. math::
 
             \\boldsymbol{energy_{cap}}(loc::tech)
-            \\leq \\boldsymbol{storage_{cap}}(loc::tech) \\times charge\_rate(loc::tech)
+            \\leq \\boldsymbol{storage_{cap}}(loc::tech) \\times charge\\_rate(loc::tech)
             \\quad \\forall loc::tech \\in loc::techs_{store}
 
     """
@@ -171,7 +171,7 @@ def resource_capacity_constraint_rule(backend_model, loc_tech):
                 \\leq resource_{cap, max}(loc::tech),& \\text{if } resource_{cap, max}(loc::tech)\\\\
                 \\text{unconstrained},& \\text{otherwise}
             \\end{cases}
-            \\forall loc::tech \\in loc::techs_{finite\_resource\_supply\_plus}
+            \\forall loc::tech \\in loc::techs_{finite\\_resource\\_supply\\_plus}
 
     and (if ``equals`` not enforced):
 
@@ -180,7 +180,7 @@ def resource_capacity_constraint_rule(backend_model, loc_tech):
         .. math::
 
             \\boldsymbol{resource_{cap}}(loc::tech) \\geq resource_{cap, min}(loc::tech)
-            \\quad \\forall loc::tech \\in loc::techs_{finite\_resource\_supply\_plus}
+            \\quad \\forall loc::tech \\in loc::techs_{finite\\_resource\\_supply\\_plus}
     """
 
     return get_capacity_constraint(backend_model, 'resource_cap', loc_tech)
@@ -196,8 +196,8 @@ def resource_capacity_equals_energy_capacity_constraint_rule(backend_model, loc_
         .. math::
 
             \\boldsymbol{resource_{cap}}(loc::tech) = \\boldsymbol{energy_{cap}}(loc::tech)
-            \\quad \\forall loc::tech \\in loc::techs_{finite\_resource\_supply\_plus}
-            \\text{ if } resource\_cap\_equals\_energy\_cap = \\text{True}
+            \\quad \\forall loc::tech \\in loc::techs_{finite\\_resource\\_supply\\_plus}
+            \\text{ if } resource\\_cap\\_equals\\_energy\\_cap = \\text{True}
     """
     return backend_model.resource_cap[loc_tech] == backend_model.energy_cap[loc_tech]
 
@@ -250,8 +250,8 @@ def resource_area_per_energy_capacity_constraint_rule(backend_model, loc_tech):
         .. math::
 
             \\boldsymbol{resource_{area}}(loc::tech) =
-            \\boldsymbol{energy_{cap}}(loc::tech) \\times area\_per\_energy\_cap(loc::tech)
-            \\quad \\forall loc::tech \\in locs::techs_{area} \\text{ if } area\_per\_energy\_cap(loc::tech)
+            \\boldsymbol{energy_{cap}}(loc::tech) \\times area\\_per\\_energy\\_cap(loc::tech)
+            \\quad \\forall loc::tech \\in locs::techs_{area} \\text{ if } area\\_per\\_energy\\_cap(loc::tech)
     """
     area_per_energy_cap = get_param(backend_model, 'resource_area_per_energy_cap', loc_tech)
 
@@ -268,8 +268,8 @@ def resource_area_capacity_per_loc_constraint_rule(backend_model, loc):
 
         .. math::
 
-            \\sum_{tech} \\boldsymbol{resource_{area}}(loc::tech) \\leq available\_area
-            \\quad \\forall loc \in locs \\text{ if } available\_area(loc)
+            \\sum_{tech} \\boldsymbol{resource_{area}}(loc::tech) \\leq available\\_area
+            \\quad \\forall loc \\in locs \\text{ if } available\\_area(loc)
     """
     model_data_dict = backend_model.__calliope_model_data__['data']
     available_area = model_data_dict['available_area'][loc]

--- a/calliope/backend/pyomo/constraints/conversion.py
+++ b/calliope/backend/pyomo/constraints/conversion.py
@@ -43,8 +43,8 @@ def balance_conversion_constraint_rule(backend_model, loc_tech, timestep):
             \\times \\eta_{energy}(loc::tech, timestep)
             = \\boldsymbol{carrier_{prod}}(loc::tech::carrier, timestep)
             \\times \\eta_{energy}(loc::tech, timestep)
-            \\quad \\forall loc::tech \in locs::techs_{conversion},
-            \\forall timestep \in timesteps
+            \\quad \\forall loc::tech \\in locs::techs_{conversion},
+            \\forall timestep \\in timesteps
     """
     model_data_dict = backend_model.__calliope_model_data__['data']
 

--- a/calliope/backend/pyomo/constraints/conversion_plus.py
+++ b/calliope/backend/pyomo/constraints/conversion_plus.py
@@ -86,10 +86,10 @@ def balance_conversion_plus_primary_constraint_rule(backend_model, loc_tech, tim
 
             \\sum_{loc::tech::carrier \\in loc::tech::carriers_{out}}
             \\frac{\\boldsymbol{carrier_{prod}}(loc::tech::carrier, timestep)}{
-                carrier\_ratio(loc::tech::carrier, `out')} =
+                carrier\\_ratio(loc::tech::carrier, `out')} =
             -1 * \\sum_{loc::tech::carrier \\in loc::tech::carriers_{in}} (
             \\boldsymbol{carrier_{con}}(loc::tech::carrier, timestep)
-            * carrier\_ratio(loc::tech::carrier, `in') * \\eta_{energy}(loc::tech, timestep))
+            * carrier\\_ratio(loc::tech::carrier, `in') * \\eta_{energy}(loc::tech, timestep))
             \\quad \\forall loc::tech \\in loc::techs_{conversion^{+}}, \\forall timestep \\in timesteps
     """
     model_data_dict = backend_model.__calliope_model_data__['data']
@@ -125,9 +125,9 @@ def carrier_production_max_conversion_plus_constraint_rule(backend_model, loc_te
 
         .. math::
 
-            \sum_{loc::tech::carrier \\in loc::tech::carriers_{out}}
+            \\sum_{loc::tech::carrier \\in loc::tech::carriers_{out}}
             \\boldsymbol{carrier_{prod}}(loc::tech::carrier, timestep)
-            \\leq \\boldsymbol{energy_{cap}}(loc::tech) \\times timestep\_resolution(timestep)
+            \\leq \\boldsymbol{energy_{cap}}(loc::tech) \\times timestep\\_resolution(timestep)
             \\quad \\forall loc::tech \\in loc::techs_{conversion^{+}},
             \\forall timestep \\in timesteps
     """
@@ -152,9 +152,9 @@ def carrier_production_min_conversion_plus_constraint_rule(backend_model, loc_te
 
         .. math::
 
-            \sum_{loc::tech::carrier \\in loc::tech::carriers_{out}}
+            \\sum_{loc::tech::carrier \\in loc::tech::carriers_{out}}
             \\boldsymbol{carrier_{prod}}(loc::tech::carrier, timestep)
-            \\leq \\boldsymbol{energy_{cap}}(loc::tech) \\times timestep\_resolution(timestep)
+            \\leq \\boldsymbol{energy_{cap}}(loc::tech) \\times timestep\\_resolution(timestep)
             \\times energy_{cap, min use}(loc::tech)
             \\quad \\forall loc::tech \\in loc::techs_{conversion^{+}},
             \\forall timestep \\in timesteps
@@ -240,10 +240,10 @@ def balance_conversion_plus_tiers_constraint_rule(backend_model, tier, loc_tech,
 
             \\sum_{loc::tech::carrier \\in loc::tech::carriers_{out}} (
             \\frac{\\boldsymbol{carrier_{prod}}(loc::tech::carrier, timestep)}{
-                carrier\_ratio(loc::tech::carrier, `out')} =
+                carrier\\_ratio(loc::tech::carrier, `out')} =
             \\sum_{loc::tech::carrier \\in loc::tech::carriers_{tier}} (
             \\frac{\\boldsymbol{carrier_{prod}}(loc::tech::carrier, timestep)}{
-                carrier\_ratio(loc::tech::carrier, tier)}
+                carrier\\_ratio(loc::tech::carrier, tier)}
             \\quad \\forall \\text { tier } \\in [`out_2', `out_3'], \\forall loc::tech
                 \\in loc::techs_{conversion^{+}}, \\forall timestep \\in timesteps
 
@@ -255,10 +255,10 @@ def balance_conversion_plus_tiers_constraint_rule(backend_model, tier, loc_tech,
 
             \\sum_{loc::tech::carrier \\in loc::tech::carriers_{in}}
             \\frac{\\boldsymbol{carrier_{con}}(loc::tech::carrier, timestep)}{
-                carrier\_ratio(loc::tech::carrier, `in')} =
+                carrier\\_ratio(loc::tech::carrier, `in')} =
             \\sum_{loc::tech::carrier \\in loc::tech::carriers_{tier}}
             \\frac{\\boldsymbol{carrier_{prod}}(loc::tech::carrier, timestep)}{
-                carrier\_ratio(loc::tech::carrier, tier)}
+                carrier\\_ratio(loc::tech::carrier, tier)}
             \\quad \\forall \\text{ tier } \\in [`in_2', `in_3'], \\forall loc::tech
                 \\in loc::techs_{conversion^{+}}, \\forall timestep \\in timesteps
     """

--- a/calliope/backend/pyomo/constraints/dispatch.py
+++ b/calliope/backend/pyomo/constraints/dispatch.py
@@ -96,7 +96,7 @@ def carrier_production_max_constraint_rule(backend_model, loc_tech_carrier, time
         .. math::
 
             \\boldsymbol{carrier_{prod}}(loc::tech::carrier, timestep) \\leq energy_{cap}(loc::tech)
-            \\times timestep\_resolution(timestep) \\times parasitic\_eff(loc::tec)
+            \\times timestep\\_resolution(timestep) \\times parasitic\\_eff(loc::tec)
 
     """
     loc_tech = get_loc_tech(loc_tech_carrier)
@@ -118,7 +118,7 @@ def carrier_production_min_constraint_rule(backend_model, loc_tech_carrier, time
         .. math::
 
             \\boldsymbol{carrier_{prod}}(loc::tech::carrier, timestep) \\geq energy_{cap}(loc::tech)
-            \\times timestep\_resolution(timestep) \\times energy_{cap,min\_use}(loc::tec)
+            \\times timestep\\_resolution(timestep) \\times energy_{cap,min\\_use}(loc::tec)
 
     """
     loc_tech = get_loc_tech(loc_tech_carrier)
@@ -141,7 +141,7 @@ def carrier_consumption_max_constraint_rule(backend_model, loc_tech_carrier, tim
 
             \\boldsymbol{carrier_{con}}(loc::tech::carrier, timestep) \\geq
             -1 \\times energy_{cap}(loc::tech)
-            \\times timestep\_resolution(timestep)
+            \\times timestep\\_resolution(timestep)
 
     """
     loc_tech = get_loc_tech(loc_tech_carrier)
@@ -162,7 +162,7 @@ def resource_max_constraint_rule(backend_model, loc_tech, timestep):
         .. math::
 
             \\boldsymbol{resource_{con}}(loc::tech, timestep) \\leq
-            timestep\_resolution(timestep) \\times resource_{cap}(loc::tech)
+            timestep\\_resolution(timestep) \\times resource_{cap}(loc::tech)
 
     """
     timestep_resolution = backend_model.timestep_resolution[timestep]
@@ -194,7 +194,7 @@ def ramping_up_constraint_rule(backend_model, loc_tech_carrier, timestep):
 
         .. math::
 
-            diff(loc::tech::carrier, timestep) \\leq max\_ramping\_rate(loc::tech::carrier, timestep)
+            diff(loc::tech::carrier, timestep) \\leq max\\_ramping\\_rate(loc::tech::carrier, timestep)
 
     """
     return ramping_constraint(backend_model, loc_tech_carrier, timestep, direction=0)
@@ -208,7 +208,7 @@ def ramping_down_constraint_rule(backend_model, loc_tech_carrier, timestep):
 
         .. math::
 
-            -1 \\times max\_ramping\_rate(loc::tech::carrier, timestep) \\leq diff(loc::tech::carrier, timestep)
+            -1 \\times max\\_ramping\\_rate(loc::tech::carrier, timestep) \\leq diff(loc::tech::carrier, timestep)
 
     """
     return ramping_constraint(backend_model, loc_tech_carrier, timestep, direction=1)
@@ -224,14 +224,14 @@ def ramping_constraint(backend_model, loc_tech_carrier, timestep, direction=0):
 
         .. math::
 
-            \\boldsymbol{max\_ramping\_rate}(loc::tech::carrier, timestep) =
+            \\boldsymbol{max\\_ramping\\_rate}(loc::tech::carrier, timestep) =
             energy_{ramping}(loc::tech, timestep) \\times energy_{cap}(loc::tech)
 
             \\boldsymbol{diff}(loc::tech::carrier, timestep) =
             (carrier_{prod}(loc::tech::carrier, timestep) + carrier_{con}(loc::tech::carrier, timestep))
-            / timestep\_resolution(timestep) -
+            / timestep\\_resolution(timestep) -
             (carrier_{prod}(loc::tech::carrier, timestep-1) + carrier_{con}(loc::tech::carrier, timestep-1))
-            / timestep\_resolution(timestep-1)
+            / timestep\\_resolution(timestep-1)
 
     """
 
@@ -284,7 +284,7 @@ def storage_intra_max_rule(backend_model, loc_tech, timestep):
         .. math::
 
             \\boldsymbol{storage}(loc::tech, timestep) \\leq
-            \\boldsymbol{storage_{intra\_cluster, max}}(loc::tech, cluster(timestep))
+            \\boldsymbol{storage_{intra\\_cluster, max}}(loc::tech, cluster(timestep))
             \\quad \\forall loc::tech \\in loc::techs_{store}, \\forall timestep \\in timesteps
 
     Where :math:`cluster(timestep)` is the cluster number in which the timestep
@@ -308,7 +308,7 @@ def storage_intra_min_rule(backend_model, loc_tech, timestep):
         .. math::
 
             \\boldsymbol{storage}(loc::tech, timestep) \\geq
-            \\boldsymbol{storage_{intra\_cluster, min}}(loc::tech, cluster(timestep))
+            \\boldsymbol{storage_{intra\\_cluster, min}}(loc::tech, cluster(timestep))
             \\quad \\forall loc::tech \\in loc::techs_{store}, \\forall timestep \\in timesteps
 
     Where :math:`cluster(timestep)` is the cluster number in which the timestep
@@ -333,8 +333,8 @@ def storage_inter_max_rule(backend_model, loc_tech, datestep):
 
         .. math::
 
-            \\boldsymbol{storage_{inter\_cluster}}(loc::tech, datestep) +
-            \\boldsymbol{storage_{intra\_cluster, max}}(loc::tech, cluster(datestep))
+            \\boldsymbol{storage_{inter\\_cluster}}(loc::tech, datestep) +
+            \\boldsymbol{storage_{intra\\_cluster, max}}(loc::tech, cluster(datestep))
             \\leq \\boldsymbol{storage_{cap}}(loc::tech) \\quad \\forall
             loc::tech \\in loc::techs_{store}, \\forall datestep \\in datesteps
 
@@ -361,9 +361,9 @@ def storage_inter_min_rule(backend_model, loc_tech, datestep):
 
         .. math::
 
-            \\boldsymbol{storage_{inter\_cluster}}(loc::tech, datestep)
-            \\times (1 - storage\_loss(loc::tech, timestep))^{24} +
-            \\boldsymbol{storage_{intra\_cluster, min}}(loc::tech, cluster(datestep))
+            \\boldsymbol{storage_{inter\\_cluster}}(loc::tech, datestep)
+            \\times (1 - storage\\_loss(loc::tech, timestep))^{24} +
+            \\boldsymbol{storage_{intra\\_cluster, min}}(loc::tech, cluster(datestep))
             \\geq 0 \\quad \\forall loc::tech \\in loc::techs_{store},
             \\forall datestep \\in datesteps
 

--- a/calliope/backend/pyomo/constraints/energy_balance.py
+++ b/calliope/backend/pyomo/constraints/energy_balance.py
@@ -129,19 +129,19 @@ def balance_supply_constraint_rule(backend_model, loc_tech, timestep):
 
         .. math::
 
-            min\_use(loc::tech) \\times available\_resource(loc::tech, timestep) \\leq
+            min\\_use(loc::tech) \\times available\\_resource(loc::tech, timestep) \\leq
             \\frac{\\boldsymbol{carrier_{prod}}(loc::tech::carrier, timestep)}{\\eta_{energy}(loc::tech, timestep)}
-            \\geq available\_resource(loc::tech, timestep)
+            \\geq available\\_resource(loc::tech, timestep)
             \\quad \\forall loc::tech \\in loc::techs_{supply}, \\forall timestep \\in timesteps
 
-    If :math:`force\_resource(loc::tech)` is set:
+    If :math:`force\\_resource(loc::tech)` is set:
 
     .. container:: scrolling-wrapper
 
         .. math::
 
             \\frac{\\boldsymbol{carrier_{prod}}(loc::tech::carrier, timestep)}{\\eta_{energy}(loc::tech, timestep)}
-            = available\_resource(loc::tech, timestep)
+            = available\\_resource(loc::tech, timestep)
             \\quad \\forall loc::tech \\in loc::techs_{supply}, \\forall timestep \\in timesteps
 
     Where:
@@ -150,8 +150,8 @@ def balance_supply_constraint_rule(backend_model, loc_tech, timestep):
 
         .. math::
 
-            available\_resource(loc::tech, timestep) = resource(loc::tech, timestep)
-            \\times resource\_scale(loc::tech)
+            available\\_resource(loc::tech, timestep) = resource(loc::tech, timestep)
+            \\times resource\\_scale(loc::tech)
 
     if :math:`loc::tech` is in :math:`loc::techs_{area}`:
 
@@ -159,8 +159,8 @@ def balance_supply_constraint_rule(backend_model, loc_tech, timestep):
 
         .. math::
 
-            available\_resource(loc::tech, timestep) = resource(loc::tech, timestep)
-            \\times resource\_scale(loc::tech) \\times \\boldsymbol{resource_{area}}(loc::tech)
+            available\\_resource(loc::tech, timestep) = resource(loc::tech, timestep)
+            \\times resource\\_scale(loc::tech) \\times \\boldsymbol{resource_{area}}(loc::tech)
 
     """
     model_data_dict = backend_model.__calliope_model_data__['data']
@@ -202,17 +202,17 @@ def balance_demand_constraint_rule(backend_model, loc_tech, timestep):
         .. math::
 
             \\boldsymbol{carrier_{con}}(loc::tech::carrier, timestep) \\times \\eta_{energy}(loc::tech, timestep) \\geq
-            required\_resource(loc::tech, timestep) \\quad \\forall loc::tech \\in loc::techs_{demand},
+            required\\_resource(loc::tech, timestep) \\quad \\forall loc::tech \\in loc::techs_{demand},
             \\forall timestep \\in timesteps
 
-    If :math:`force\_resource(loc::tech)` is set:
+    If :math:`force\\_resource(loc::tech)` is set:
 
     .. container:: scrolling-wrapper
 
         .. math::
 
             \\boldsymbol{carrier_{con}}(loc::tech::carrier, timestep) \\times \\eta_{energy}(loc::tech, timestep) =
-            required\_resource(loc::tech, timestep)
+            required\\_resource(loc::tech, timestep)
             \\quad \\forall loc::tech \\in loc::techs_{demand}, \\forall timestep \\in timesteps
 
     Where:
@@ -221,8 +221,8 @@ def balance_demand_constraint_rule(backend_model, loc_tech, timestep):
 
         .. math::
 
-            required\_resource(loc::tech, timestep) = resource(loc::tech, timestep)
-            \\times resource\_scale(loc::tech)
+            required\\_resource(loc::tech, timestep) = resource(loc::tech, timestep)
+            \\times resource\\_scale(loc::tech)
 
     if :math:`loc::tech` is in :math:`loc::techs_{area}`:
 
@@ -230,8 +230,8 @@ def balance_demand_constraint_rule(backend_model, loc_tech, timestep):
 
         .. math::
 
-            required\_resource(loc::tech, timestep) = resource(loc::tech, timestep)
-            \\times resource\_scale(loc::tech) \\times \\boldsymbol{resource_{area}}(loc::tech)
+            required\\_resource(loc::tech, timestep) = resource(loc::tech, timestep)
+            \\times resource\\_scale(loc::tech) \\times \\boldsymbol{resource_{area}}(loc::tech)
 
     """
     model_data_dict = backend_model.__calliope_model_data__['data']
@@ -267,17 +267,17 @@ def resource_availability_supply_plus_constraint_rule(backend_model, loc_tech, t
         .. math::
 
             \\boldsymbol{resource_{con}}(loc::tech, timestep)
-            \\leq available\_resource(loc::tech, timestep)
+            \\leq available\\_resource(loc::tech, timestep)
             \\quad \\forall loc::tech \\in loc::techs_{supply^{+}}, \\forall timestep \\in timesteps
 
-    If :math:`force\_resource(loc::tech)` is set:
+    If :math:`force\\_resource(loc::tech)` is set:
 
     .. container:: scrolling-wrapper
 
         .. math::
 
             \\boldsymbol{resource_{con}}(loc::tech, timestep)
-            = available\_resource(loc::tech, timestep)
+            = available\\_resource(loc::tech, timestep)
             \\quad \\forall loc::tech \\in loc::techs_{supply^{+}}, \\forall timestep \\in timesteps
 
     Where:
@@ -286,7 +286,7 @@ def resource_availability_supply_plus_constraint_rule(backend_model, loc_tech, t
 
         .. math::
 
-            available\_resource(loc::tech, timestep) = resource(loc::tech, timestep)
+            available\\_resource(loc::tech, timestep) = resource(loc::tech, timestep)
             \\times resource_{scale}(loc::tech)
 
     if :math:`loc::tech` is in :math:`loc::techs_{area}`:
@@ -295,7 +295,7 @@ def resource_availability_supply_plus_constraint_rule(backend_model, loc_tech, t
 
         .. math::
 
-            available\_resource(loc::tech, timestep) = resource(loc::tech, timestep)
+            available\\_resource(loc::tech, timestep) = resource(loc::tech, timestep)
             \\times resource_{scale}(loc::tech)
             \\times resource_{area}(loc::tech)
 
@@ -329,8 +329,8 @@ def balance_transmission_constraint_rule(backend_model, loc_tech, timestep):
             -1 * \\boldsymbol{carrier_{con}}(loc_{from}::tech:loc_{to}::carrier, timestep)
             \\times \\eta_{energy}(loc::tech, timestep)
             = \\boldsymbol{carrier_{prod}}(loc_{to}::tech:loc_{from}::carrier, timestep)
-            \\quad \\forall loc::tech:loc \in locs::techs:locs_{transmission},
-            \\forall timestep \in timesteps
+            \\quad \\forall loc::tech:loc \\in locs::techs:locs_{transmission},
+            \\forall timestep \\in timesteps
 
     Where a link is the connection between :math:`loc_{from}::tech:loc_{to}`
     and :math:`loc_{to}::tech:loc_{from}` for locations `to` and `from`.
@@ -367,7 +367,7 @@ def balance_supply_plus_constraint_rule(backend_model, loc_tech, timestep):
 
             \\boldsymbol{storage}(loc::tech, timestep) =
             \\boldsymbol{storage}(loc::tech, timestep_{previous})
-            \\times (1 - storage\_loss(loc::tech, timestep))^{timestep\_resolution(timestep)} +
+            \\times (1 - storage\\_loss(loc::tech, timestep))^{timestep\\_resolution(timestep)} +
             \\boldsymbol{resource_{con}}(loc::tech, timestep) \\times \\eta_{resource}(loc::tech, timestep) -
             \\frac{\\boldsymbol{carrier_{prod}}(loc::tech::carrier, timestep)}{\\eta_{energy}(loc::tech, timestep) \\times \\eta_{parasitic}(loc::tech, timestep)}
             \\quad \\forall loc::tech \\in loc::techs_{supply^{+}}, \\forall timestep \\in timesteps
@@ -443,7 +443,7 @@ def balance_storage_constraint_rule(backend_model, loc_tech, timestep):
 
             \\boldsymbol{storage}(loc::tech, timestep) =
             \\boldsymbol{storage}(loc::tech, timestep_{previous})
-            \\times (1 - storage\_loss(loc::tech, timestep))^{resolution(timestep)}
+            \\times (1 - storage\\_loss(loc::tech, timestep))^{resolution(timestep)}
             - \\boldsymbol{carrier_{con}}(loc::tech::carrier, timestep)
             \\times \\eta_{energy}(loc::tech, timestep)
             - \\frac{\\boldsymbol{carrier_{prod}}(loc::tech::carrier, timestep)}{\\eta_{energy}(loc::tech, timestep)}
@@ -500,9 +500,9 @@ def balance_storage_inter_cluster_rule(backend_model, loc_tech, datestep):
 
         .. math::
 
-            \\boldsymbol{storage_{inter\_cluster}}(loc::tech, datestep) =
-            \\boldsymbol{storage_{inter\_cluster}}(loc::tech, datestep_{previous})
-            \\times (1 - storage\_loss(loc::tech, timestep))^{24}
+            \\boldsymbol{storage_{inter\\_cluster}}(loc::tech, datestep) =
+            \\boldsymbol{storage_{inter\\_cluster}}(loc::tech, datestep_{previous})
+            \\times (1 - storage\\_loss(loc::tech, timestep))^{24}
             + \\boldsymbol{storage}(loc::tech, timestep_{final, cluster(datestep))})
             \\quad \\forall loc::tech \\in loc::techs_{store}, \\forall datestep \\in datesteps
 
@@ -549,7 +549,7 @@ def storage_initial_rule(backend_model, loc_tech):
 
         .. math::
 
-            \\boldsymbol{storage_{inter\_cluster}}(loc::tech, datestep_{final})
+            \\boldsymbol{storage_{inter\\_cluster}}(loc::tech, datestep_{final})
             \\times ((1 - storage_loss) ** 24) = storage_{initial}(loc::tech)
             \\quad \\forall loc::tech \\in loc::techs_{store}, \\forall datestep \\in datesteps
 

--- a/calliope/backend/pyomo/constraints/export.py
+++ b/calliope/backend/pyomo/constraints/export.py
@@ -75,8 +75,8 @@ def export_balance_constraint_rule(backend_model, loc_tech_carrier, timestep):
 
             \\boldsymbol{carrier_{prod}}(loc::tech::carrier, timestep)
             \\geq \\boldsymbol{carrier_{export}}(loc::tech::carrier, timestep)
-            \\quad \\forall loc::tech::carrier \in locs::tech::carriers_{export},
-            \\forall timestep \in timesteps
+            \\quad \\forall loc::tech::carrier \\in locs::tech::carriers_{export},
+            \\forall timestep \\in timesteps
     """
 
     return (backend_model.carrier_prod[loc_tech_carrier, timestep] >=

--- a/calliope/backend/pyomo/constraints/export.py
+++ b/calliope/backend/pyomo/constraints/export.py
@@ -123,8 +123,8 @@ def export_max_constraint_rule(backend_model, loc_tech_carrier, timestep):
 
             \\boldsymbol{carrier_{export}}(loc::tech::carrier, timestep)
             \\leq export_{cap}(loc::tech)
-            \\quad \\forall loc::tech::carrier \in locs::tech::carriers_{export},
-            \\forall timestep \in timesteps
+            \\quad \\forall loc::tech::carrier \\in locs::tech::carriers_{export},
+            \\forall timestep \\in timesteps
 
     If the technology is defined by integer units, not a continuous capacity,
     this constraint becomes:

--- a/calliope/backend/pyomo/constraints/milp.py
+++ b/calliope/backend/pyomo/constraints/milp.py
@@ -136,7 +136,7 @@ def unit_commitment_constraint_rule(backend_model, loc_tech, timestep):
 
         .. math::
 
-            \\boldsymbol{operating\_units}(loc::tech, timestep) \\leq
+            \\boldsymbol{operating\\_units}(loc::tech, timestep) \\leq
             \\boldsymbol{units}(loc::tech)
             \\quad \\forall loc::tech \\in loc::techs_{milp},
             \\forall timestep \\in timesteps
@@ -185,8 +185,8 @@ def carrier_production_max_milp_constraint_rule(backend_model, loc_tech_carrier,
         .. math::
 
             \\boldsymbol{carrier_{prod}}(loc::tech::carrier, timestep)
-            \\leq energy_{cap, per unit}(loc::tech) \\times timestep\_resolution(timestep)
-            \\times \\boldsymbol{operating\_units}(loc::tech, timestep)
+            \\leq energy_{cap, per unit}(loc::tech) \\times timestep\\_resolution(timestep)
+            \\times \\boldsymbol{operating\\_units}(loc::tech, timestep)
             \\times \\eta_{parasitic}(loc::tech, timestep)
             \\quad \\forall loc::tech \\in loc::techs_{milp}, \\forall timestep \\in timesteps
 
@@ -213,10 +213,10 @@ def carrier_production_max_conversion_plus_milp_constraint_rule(backend_model, l
 
         .. math::
 
-            \sum_{loc::tech::carrier \\in loc::tech::carriers_{out}}
+            \\sum_{loc::tech::carrier \\in loc::tech::carriers_{out}}
             \\boldsymbol{carrier_{prod}}(loc::tech::carrier, timestep)
-            \\leq energy_{cap, per unit}(loc::tech) \\times timestep\_resolution(timestep)
-            \\times \\boldsymbol{operating\_units}(loc::tech, timestep)
+            \\leq energy_{cap, per unit}(loc::tech) \\times timestep\\_resolution(timestep)
+            \\times \\boldsymbol{operating\\_units}(loc::tech, timestep)
             \\times \\eta_{parasitic}(loc::tech, timestep)
             \\quad \\forall loc::tech \\in loc::techs_{milp, conversion^{+}}, \\forall timestep \\in timesteps
 
@@ -246,8 +246,8 @@ def carrier_production_min_milp_constraint_rule(backend_model, loc_tech_carrier,
         .. math::
 
             \\boldsymbol{carrier_{prod}}(loc::tech::carrier, timestep)
-            \\geq energy_{cap, per unit}(loc::tech) \\times timestep\_resolution(timestep)
-            \\times \\boldsymbol{operating\_units}(loc::tech, timestep)
+            \\geq energy_{cap, per unit}(loc::tech) \\times timestep\\_resolution(timestep)
+            \\times \\boldsymbol{operating\\_units}(loc::tech, timestep)
             \\times energy_{cap, min use}(loc::tech)
             \\quad \\forall loc::tech \\in loc::techs_{milp}, \\forall timestep \\in timesteps
     """
@@ -270,10 +270,10 @@ def carrier_production_min_conversion_plus_milp_constraint_rule(backend_model, l
     .. container:: scrolling-wrapper
 
         .. math::
-            \sum_{loc::tech::carrier \\in loc::tech::carriers_{out}}
+            \\sum_{loc::tech::carrier \\in loc::tech::carriers_{out}}
             \\boldsymbol{carrier_{prod}}(loc::tech::carrier, timestep)
-            \\geq energy_{cap, per unit}(loc::tech) \\times timestep\_resolution(timestep)
-            \\times \\boldsymbol{operating\_units}(loc::tech, timestep)
+            \\geq energy_{cap, per unit}(loc::tech) \\times timestep\\_resolution(timestep)
+            \\times \\boldsymbol{operating\\_units}(loc::tech, timestep)
             \\times energy_{cap, min use}(loc::tech)
             \\quad \\forall loc::tech \\in loc::techs_{milp, conversion^{+}},
             \\forall timestep \\in timesteps
@@ -305,8 +305,8 @@ def carrier_consumption_max_milp_constraint_rule(backend_model, loc_tech_carrier
         .. math::
 
             \\boldsymbol{carrier_{con}}(loc::tech::carrier, timestep)
-            \\geq -1 * energy_{cap, per unit}(loc::tech) \\times timestep\_resolution(timestep)
-            \\times \\boldsymbol{operating\_units}(loc::tech, timestep)
+            \\geq -1 * energy_{cap, per unit}(loc::tech) \\times timestep\\_resolution(timestep)
+            \\times \\boldsymbol{operating\\_units}(loc::tech, timestep)
             \\times \\eta_{parasitic}(loc::tech, timestep)
             \\quad \\forall loc::tech \\in loc::techs_{milp, con}, \\forall timestep \\in timesteps
 

--- a/calliope/backend/pyomo/objective.py
+++ b/calliope/backend/pyomo/objective.py
@@ -26,8 +26,8 @@ def minmax_cost_optimization(backend_model, cost_class, sense):
 
         .. math::
 
-            min: z = \sum_{loc::tech_{cost}} cost(loc::tech, cost=cost_{k})) + \sum_{loc::carrier,timestep} unmet\_demand(loc::carrier, timestep) \\times bigM
-            max: z = \sum_{loc::tech_{cost}} cost(loc::tech, cost=cost_{k})) - \sum_{loc::carrier,timestep} unmet\_demand(loc::carrier, timestep) \\times bigM
+            min: z = \\sum_{loc::tech_{cost}} cost(loc::tech, cost=cost_{k})) + \\sum_{loc::carrier,timestep} unmet\\_demand(loc::carrier, timestep) \\times bigM
+            max: z = \\sum_{loc::tech_{cost}} cost(loc::tech, cost=cost_{k})) - \\sum_{loc::carrier,timestep} unmet\\_demand(loc::carrier, timestep) \\times bigM
 
     """
     def obj_rule(backend_model):

--- a/calliope/backend/pyomo/variables.py
+++ b/calliope/backend/pyomo/variables.py
@@ -28,9 +28,9 @@ def initialize_decision_variables(backend_model):
     cost_investment      costs, loc_techs_investment_cost
     purchased            loc_techs_purchase
     units                loc_techs_milp
-    operating\_units     loc_techs_milp, timesteps
-    unmet\_demand        loc_carriers, timesteps
-    unused\_supply       loc_carriers, timesteps
+    operating\\_units     loc_techs_milp, timesteps
+    unmet\\_demand        loc_carriers, timesteps
+    unused\\_supply       loc_carriers, timesteps
     ==================== ========================================
 
     """

--- a/calliope/test/common/html_strings.yaml
+++ b/calliope/test/common/html_strings.yaml
@@ -9,7 +9,7 @@ national_scale:
         - '"x": ["2005-01-01", "2005-01-01 01:00:00",'
         - '"y": [27538.578, 26518.588, 25820.82,'
         - '"name": "Concentrating solar power"'
-        - '"title": "Carrier flow: power",'
+        - '"title": {"text": "Carrier flow: power"},'
         - '"showLink": false'
         - '"modeBarButtonsToRemove": ["sendDataToCloud"]'
     transmission:
@@ -56,5 +56,5 @@ clustering:
     timeseries:
         - '"type": "category"'
         - '"tickvals": [11.5, 35.5],'
-        - '"title": "Clusters"'
-        - '"title": "Storage at start of each day in unclustered timeseries"'
+        - '"title": {"text": "Clusters"}'
+        - '"title": {"text": "Storage at start of each day in unclustered timeseries"}'

--- a/calliope/test/common/html_strings.yaml
+++ b/calliope/test/common/html_strings.yaml
@@ -57,4 +57,4 @@ clustering:
         - '"type": "category"'
         - '"tickvals": [11.5, 35.5],'
         - '"title": {"text": "Clusters"}'
-        - '"title": {"text": "Storage at start of each day in unclustered timeseries"}'
+        - '"title": "Storage at start of each day in unclustered timeseries"'

--- a/calliope/test/common/html_strings.yaml
+++ b/calliope/test/common/html_strings.yaml
@@ -1,7 +1,7 @@
 national_scale:
     capacity:
         - '"type": "dropdown", "x": 0, "xanchor": "left", "y": 1.13'
-        - '"yaxis": {"showticklabels": true, "title": "Location"}'
+        - '"yaxis": {"showticklabels": true, "title": {"text": "Location"}}'
         - '"showLink": false'
         - '"modeBarButtonsToRemove": ["sendDataToCloud"]'
     timeseries:

--- a/calliope/test/common/test_model/model_minimal.yaml
+++ b/calliope/test/common/test_model/model_minimal.yaml
@@ -1,3 +1,6 @@
+import:
+    - scenarios.yaml
+
 model:
     name: Minimal test model
 

--- a/calliope/test/common/util.py
+++ b/calliope/test/common/util.py
@@ -23,9 +23,11 @@ python36_or_higher = pytest.mark.skipif(
 )
 
 
-def build_test_model(override_dict=None, scenario=None):
+def build_test_model(override_dict=None, scenario=None, minimal=False):
     this_path = os.path.dirname(__file__)
-    model_location = os.path.join(this_path, 'test_model', 'model.yaml')
+    model = 'model_minimal.yaml' if minimal is True else 'model.yaml'
+
+    model_location = os.path.join(this_path, 'test_model', model)
 
     return calliope.Model(
         model_location, override_dict=override_dict,


### PR DESCRIPTION
Summary of changes in this pull request:

* Changed a HTML text entry in plotly tests to deal with plotly 3.5.0
* Updated some constraint math to avoid some escape sequence warnings

- [ ] Test(s) added to cover contribution
- [ ] ~Documentation updated~
- [ ] Changelog updated
- [ ] Coverage maintained or improved