### PR TITLE
Fixed systemwide constraint when modelling without transmission

### DIFF
--- a/calliope/backend/pyomo/constraints/capacity.py
+++ b/calliope/backend/pyomo/constraints/capacity.py
@@ -336,7 +336,7 @@ def energy_capacity_systemwide_constraint_rule(backend_model, tech):
 
     """
 
-    if tech in backend_model.techs_transmission_names:
+    if tech in getattr(backend_model, 'techs_transmission_names', []):
         all_loc_techs = [
             i for i in backend_model.loc_techs_transmission
             if i.split('::')[1].split(':')[0] == tech

--- a/calliope/backend/pyomo/constraints/milp.py
+++ b/calliope/backend/pyomo/constraints/milp.py
@@ -566,7 +566,7 @@ def unit_capacity_systemwide_constraint_rule(backend_model, tech):
 
     """
 
-    if tech in backend_model.techs_transmission_names:
+    if tech in getattr(backend_model, 'techs_transmission_names', []):
         all_loc_techs = [
             i for i in backend_model.loc_techs_transmission
             if i.split('::')[1].split(':')[0] == tech

--- a/calliope/test/test_backend_pyomo.py
+++ b/calliope/test/test_backend_pyomo.py
@@ -728,6 +728,14 @@ class TestCapacityConstraints:
         m.run(build_only=True)
         assert hasattr(m._backend_model, 'energy_capacity_systemwide_constraint')
 
+        # Check that a model without transmission techs doesn't cause an error
+        m = build_model(
+            {'techs.test_supply_elec.constraints.energy_cap_equals_systemwide': 20},
+            'simple_supply,two_hours,investment_costs', minimal=True
+        )
+        m.run(build_only=True)
+        assert hasattr(m._backend_model, 'energy_capacity_systemwide_constraint')
+
 
 class TestDispatchConstraints:
     # dispatch.py
@@ -1298,6 +1306,10 @@ class TestMILPConstraints:
                 'purchase': 1, 'interest_rate': 0.1
             }
         }
+        override_no_transmission = {
+            'techs.test_supply_elec.constraints.units_equals_systemwide': 1,
+            'locations.1.techs.test_supply_elec.costs.monetary.purchase': 1
+        }
 
         m = build_model(override_max, 'conversion_plus_milp,two_hours,investment_costs')
         m.run(build_only=True)
@@ -1319,6 +1331,10 @@ class TestMILPConstraints:
         m.run(build_only=True)
         assert hasattr(m._backend_model, 'unit_capacity_systemwide_constraint')
         assert m._backend_model.unit_capacity_systemwide_constraint['test_transmission_elec'].upper() == 2
+
+        m = build_model(override_no_transmission, 'simple_supply,two_hours,investment_costs', minimal=True)
+        m.run(build_only=True)
+        assert hasattr(m._backend_model, 'unit_capacity_systemwide_constraint')
 
 
 class TestConversionConstraints:

--- a/changelog.rst
+++ b/changelog.rst
@@ -10,7 +10,9 @@ Release History
 
 |changed| Scenarios in YAML files defined as list of override names, not comma-separated strings: `fusion_scenario: cold_fusion,high_cost` becomes `fusion_scenario: ['cold_fusion', 'high_cost']`. No change to the command-line interface.
 
-|fixed| Updated documentation on amendments of abstract base technology groups
+|fixed| Systemwide constraints work in models without transmission systems.
+
+|fixed| Updated documentation on amendments of abstract base technology groups.
 
 |fixed| Models without time series data fail gracefully.
 


### PR DESCRIPTION
Fixes issue(s) #157

Summary of changes in this pull request:

* Changed expectation for there to be transmission technologies when defining systemwide constraints

 Reviewer checklist:

- [x] Test(s) added to cover contribution
- [x] Documentation updated
- [x] Changelog updated
- [x] Coverage maintained or improved