### PR TITLE
Fix retain data_var name in get_formatted_array

### DIFF
--- a/calliope/core/util/dataset.py
+++ b/calliope/core/util/dataset.py
@@ -117,6 +117,7 @@ def split_loc_techs(data_var, as_='DataArray'):
     elif as_ == "DataArray":
         updated_data_var = xr.DataArray.from_series(data_var_series)
         updated_data_var.attrs = data_var.attrs
+        updated_data_var.name = data_var.name
 
         return updated_data_var
 

--- a/calliope/test/test_core_util.py
+++ b/calliope/test/test_core_util.py
@@ -140,3 +140,24 @@ class TestGenerateRuns:
         assert runs[0].endswith(
             '--scenario milp --save_netcdf out_1_milp.nc --save_plots plots_1_milp.html'
         )
+
+
+class TestPandasExport:
+
+    @pytest.fixture(scope="module")
+    def model(self):
+        return calliope.examples.national_scale()
+
+    @pytest.mark.parametrize("variable_name", [
+        ("storage_loss"), ("energy_cap_max"), ("storage_cap_max"), ("resource_eff"), ("energy_con"),
+        ("charge_rate"), ("energy_ramping"), ("resource_area_max"), ("resource"), ("lifetime"),
+        ("energy_eff"), ("resource_unit"), ("force_resource"), ("energy_prod"), ("parasitic_eff"),
+        ("reserve_margin"), ("cost_energy_cap"), ("cost_storage_cap"), ("cost_resource_cap"),
+        ("cost_om_con"), ("cost_om_prod"), ("cost_resource_area"), ("cost_depreciation_rate"),
+        ("lookup_remotes"), ("loc_coordinates"), ("colors"), ("inheritance"), ("names"),
+        ("energy_cap_max_systemwide"), ("lookup_loc_carriers"), ("lookup_loc_techs"),
+        ("lookup_loc_techs_area"), ("timestep_resolution"), ("timestep_weights"),
+        ("max_demand_timesteps")
+    ])
+    def test_data_variables_can_be_exported_to_pandas(self, model, variable_name):
+        model.get_formatted_array(variable_name).to_dataframe()

--- a/changelog.rst
+++ b/changelog.rst
@@ -10,6 +10,8 @@ Release History
 
 |changed| Scenarios in YAML files defined as list of override names, not comma-separated strings: `fusion_scenario: cold_fusion,high_cost` becomes `fusion_scenario: ['cold_fusion', 'high_cost']`. No change to the command-line interface.
 
+|fixed| Name of data variables is retained when accessed through `model.get_formatted_array()`
+
 |fixed| Systemwide constraints work in models without transmission systems.
 
 |fixed| Updated documentation on amendments of abstract base technology groups.


### PR DESCRIPTION
Fixes #179.

Reviewer checklist:

- [x] Test(s) added to cover contribution
~~- [ ] Documentation updated~~
- [x] Changelog updated
- [x] Coverage maintained or improved