### PR TITLE
Change exit code to no success when infeasible

### DIFF
--- a/calliope/cli.py
+++ b/calliope/cli.py
@@ -1,5 +1,5 @@
 """
-Copyright (C) 2013-2018 Calliope contributors listed in AUTHORS.
+Copyright (C) 2013-2019 Calliope contributors listed in AUTHORS.
 Licensed under the Apache 2.0 License (see LICENSE file).
 
 cli.py
@@ -25,6 +25,7 @@ from calliope import AttrDict, Model, examples, read_netcdf
 from calliope._version import __version__
 from calliope.core.util.generate_runs import generate
 from calliope.core.util.logging import logger, set_log_level
+from calliope.exceptions import BackendError
 
 _time_format = '%Y-%m-%d %H:%M:%S'
 
@@ -55,6 +56,13 @@ _profile_filename = click.option(
     '--profile_filename', type=str,
     help='Filename to save profile to if enabled --profile.'
 )
+
+
+_fail_when_infeasible = click.option(
+    '--fail_when_infeasible/--no_fail_when_infeasible', is_flag=True, default=True,
+    help='Return fail on command line when problem is infeasible (default True).'
+)
+
 
 if logger.hasHandlers():
     for handler in logger.handlers:
@@ -178,9 +186,10 @@ def new(path, template, debug):
 @_pdb
 @_profile
 @_profile_filename
+@_fail_when_infeasible
 def run(model_file, scenario, save_netcdf, save_csv, save_plots,
         save_logs, model_format, override_dict,
-        debug, quiet, pdb, profile, profile_filename):
+        debug, quiet, pdb, profile, profile_filename, fail_when_infeasible):
     """
     Execute the given model. Tries to guess from the file extension whether
     ``model_file`` is a YAML file or a pre-built model saved to NetCDF.
@@ -259,7 +268,10 @@ def run(model_file, scenario, save_netcdf, save_csv, save_plots,
                     'Model termination condition non-optimal. Not saving plots',
                     fg='red', bold=True
                 )
-        print_end_time(start_time)
+        if fail_when_infeasible and termination != 'optimal':
+            raise BackendError("Problem is infeasible.")
+        else:
+            print_end_time(start_time)
 
 
 @cli.command(short_help='Generate a script to run multiple models.')

--- a/calliope/test/test_cli.py
+++ b/calliope/test/test_cli.py
@@ -12,6 +12,9 @@ _MODEL_NATIONAL = os.path.join(
     _THIS_DIR,
     '..', 'example_models', 'national_scale', 'model.yaml'
 )
+_MINIMAL_TEST_MODEL = os.path.join(
+    _THIS_DIR, 'common', 'test_model', 'model_minimal.yaml'
+)
 
 
 class TestCLI:
@@ -120,3 +123,22 @@ class TestCLI:
             assert scenarios['scenarios']['scenario_1'] == [
                 'cold_fusion', 'run1', 'group_share_cold_fusion_cap'
             ]
+
+    def test_no_success_exit_code_when_infeasible(self):
+        runner = CliRunner()
+        result = runner.invoke(cli.run, [
+            _MINIMAL_TEST_MODEL,
+            "--scenario=supply_purchase,investment_costs",  # without these, the model cannot run
+            "--override_dict={techs.test_supply_elec.constraints.energy_cap_max: 1}"  # elec supply too low
+        ])
+        assert result.exit_code != 0
+
+    def test_success_exit_code_when_infeasible_and_demanded(self):
+        runner = CliRunner()
+        result = runner.invoke(cli.run, [
+            _MINIMAL_TEST_MODEL,
+            "--no_fail_when_infeasible",
+            "--scenario=supply_purchase,investment_costs",  # without these, the model cannot run
+            "--override_dict={techs.test_supply_elec.constraints.energy_cap_max: 1}"  # elec supply too low
+        ])
+        assert result.exit_code == 0

--- a/calliope/test/test_cli.py
+++ b/calliope/test/test_cli.py
@@ -128,7 +128,7 @@ class TestCLI:
         runner = CliRunner()
         result = runner.invoke(cli.run, [
             _MINIMAL_TEST_MODEL,
-            "--scenario=supply_purchase,investment_costs",  # without these, the model cannot run
+            "--scenario=investment_costs",  # without these, the model cannot run
             "--override_dict={techs.test_supply_elec.constraints.energy_cap_max: 1}"  # elec supply too low
         ])
         assert result.exit_code != 0
@@ -138,7 +138,7 @@ class TestCLI:
         result = runner.invoke(cli.run, [
             _MINIMAL_TEST_MODEL,
             "--no_fail_when_infeasible",
-            "--scenario=supply_purchase,investment_costs",  # without these, the model cannot run
+            "--scenario=investment_costs",  # without these, the model cannot run
             "--override_dict={techs.test_supply_elec.constraints.energy_cap_max: 1}"  # elec supply too low
         ])
         assert result.exit_code == 0

--- a/changelog.rst
+++ b/changelog.rst
@@ -8,6 +8,8 @@ Release History
 
 |new| Documentation for developers has been improved to include an overview of the internal package structure and a guide to contributing code via a pull request.
 
+|changed| Exit code for infeasible problems now is 1 (no sucess). This is a breaking change when relying on the exit code.
+
 |changed| Default value of resource_area_max now is ``inf`` instead of ``0``, deactivating the constraint by default.
 
 |changed| Scenarios in YAML files defined as list of override names, not comma-separated strings: `fusion_scenario: cold_fusion,high_cost` becomes `fusion_scenario: ['cold_fusion', 'high_cost']`. No change to the command-line interface.

--- a/changelog.rst
+++ b/changelog.rst
@@ -8,7 +8,7 @@ Release History
 
 |new| Documentation for developers has been improved to include an overview of the internal package structure and a guide to contributing code via a pull request.
 
-|changed| Exit code for infeasible problems now is 1 (no sucess). This is a breaking change when relying on the exit code.
+|changed| Exit code for infeasible problems now is 1 (no success). This is a breaking change when relying on the exit code.
 
 |changed| Default value of resource_area_max now is ``inf`` instead of ``0``, deactivating the constraint by default.
 


### PR DESCRIPTION
This is a breaking change.
This fixes https://github.com/calliope-project/calliope/issues/182.

Fixes issue(s) #182 

Reviewer checklist:

- [x] Test(s) added to cover contribution
- [ ] ~~Documentation updated~~
- [x] Changelog updated
- [x] Coverage maintained or improved