### PR TITLE
Ignore pyomo deprecation warnings during test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
-filterwarnings= ignore:.*is deprecated.*:Warning:pyomo
+filterwarnings =
+    ignore:.*inspect.getargspec\(\) is deprecated.*:DeprecationWarning:pyomo

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+filterwarnings= ignore:.*is deprecated.*:Warning:pyomo


### PR DESCRIPTION
Summary of changes in this pull request:

* Ignore DeprecationWarnings of Pyomo during pytest execution.

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved