### PR TITLE
Set default solver to CBC

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,6 +22,10 @@ install:
   - "python utils\\conda_create.py requirements\\base.yml --python_version=%PYTHON_VERSION% --channels %CONDA_CHANS% --ignore %CONDA_IGNORE% --run"
   - activate calliope
   - pip install --no-cache-dir .
+  - ps: Start-FileDownload 'https://bintray.com/coin-or/download/download_file?file_path=Cbc-2.9.9-x86_64-w64-mingw32.zip'
+  - 7z a Cbc-2.9.9-x86_64-w64-mingw32.zip cbc
+  - SET PATH=cbc/bin;%PATH%
+
 
 test_script:
   - "py.test"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,7 +25,7 @@ install:
   - ps: Start-FileDownload 'https://bintray.com/coin-or/download/download_file?file_path=Cbc-2.9.9-win32-msvc14.zip' -FileName 'cbc.zip'
   - 7z x cbc.zip -ocbc
   - SET PATH=cbc/bin;%PATH%
-  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
+  - CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
 
 
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,7 +23,7 @@ install:
   - activate calliope
   - pip install --no-cache-dir .
   - ps: Start-FileDownload 'https://bintray.com/coin-or/download/download_file?file_path=Cbc-2.9.9-x86_64-w64-mingw32.zip'
-  - 7z a Cbc-2.9.9-x86_64-w64-mingw32.zip cbc
+  - 7z e Cbc-2.9.9-x86_64-w64-mingw32.zip cbc
   - SET PATH=cbc/bin;%PATH%
 
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,9 +22,10 @@ install:
   - "python utils\\conda_create.py requirements\\base.yml --python_version=%PYTHON_VERSION% --channels %CONDA_CHANS% --ignore %CONDA_IGNORE% --run"
   - activate calliope
   - pip install --no-cache-dir .
-  - ps: Start-FileDownload 'https://bintray.com/coin-or/download/download_file?file_path=Cbc-2.9.9-x86_64-w64-mingw32.zip' -FileName 'cbc.zip'
+  - ps: Start-FileDownload 'https://bintray.com/coin-or/download/download_file?file_path=Cbc-2.9.9-win32-msvc14.zip' -FileName 'cbc.zip'
   - 7z x cbc.zip -ocbc
   - SET PATH=cbc/bin;%PATH%
+  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
 
 
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,8 +22,8 @@ install:
   - "python utils\\conda_create.py requirements\\base.yml --python_version=%PYTHON_VERSION% --channels %CONDA_CHANS% --ignore %CONDA_IGNORE% --run"
   - activate calliope
   - pip install --no-cache-dir .
-  - ps: Start-FileDownload 'https://bintray.com/coin-or/download/download_file?file_path=Cbc-2.9.9-x86_64-w64-mingw32.zip'
-  - 7z e Cbc-2.9.9-x86_64-w64-mingw32.zip cbc
+  - ps: Start-FileDownload 'https://bintray.com/coin-or/download/download_file?file_path=Cbc-2.9.9-x86_64-w64-mingw32.zip' -FileName 'cbc.zip'
+  - 7z x cbc.zip -ocbc
   - SET PATH=cbc/bin;%PATH%
 
 

--- a/calliope/backend/pyomo/model.py
+++ b/calliope/backend/pyomo/model.py
@@ -175,10 +175,10 @@ def solve_model(backend_model, solver,
         })
         os.makedirs(save_logs, exist_ok=True)
         TempfileManager.tempdir = save_logs  # Sets log output dir
-    if 'warmstart' in solve_kwargs.keys() and solver == 'glpk':
+    if 'warmstart' in solve_kwargs.keys() and solver in ['glpk', 'cbc']:
         exceptions.ModelWarning(
-            'The chosen solver, GLPK, does not suport warmstart, which may '
-            'impact performance.'
+            'The chosen solver, {}, does not suport warmstart, which may '
+            'impact performance.'.format(solver)
         )
         del solve_kwargs['warmstart']
 

--- a/calliope/config/model.yaml
+++ b/calliope/config/model.yaml
@@ -23,7 +23,7 @@ run:
     save_logs: null  # Directory into which to save logs and temporary files. Also turns on symbolic solver labels in the Pyomo backend
     solver_io: null  # What method the Pyomo backend should use to communicate with the solver
     solver_options: null  # A list of options, which are passed on to the chosen solver, and are therefore solver-dependent
-    solver: glpk  # Which solver to use
+    solver: cbc  # Which solver to use
     zero_threshold: 1e-10 # Any value coming out of the backend that is smaller than this threshold (due to floating point errors, probably) will be set to zero
 
 model:

--- a/calliope/example_models/national_scale/model.yaml
+++ b/calliope/example_models/national_scale/model.yaml
@@ -17,7 +17,7 @@ model:
 
 # Run configuration: all settings that affect how the built model is run
 run:
-    solver: glpk
+    solver: cbc
 
     ensure_feasibility: true  # Switches on the "unmet demand" constraint
 

--- a/calliope/example_models/national_scale/scenarios.yaml
+++ b/calliope/example_models/national_scale/scenarios.yaml
@@ -13,7 +13,7 @@ overrides:
     profiling:
         model.name: 'National-scale example model (profiling run)'
         model.subset_time: ['2005-01-01', '2005-01-15']
-        run.solver: glpk
+        run.solver: cbc
 
     time_resampling:
         model.name: 'National-scale example model with time resampling'

--- a/calliope/example_models/urban_scale/model.yaml
+++ b/calliope/example_models/urban_scale/model.yaml
@@ -17,7 +17,7 @@ model:
 run:
     mode: plan  # Choices: plan, operate
 
-    solver: glpk
+    solver: cbc
 
     ensure_feasibility: true # Switching on unmet demand
 

--- a/calliope/test/common/test_model/model.yaml
+++ b/calliope/test/common/test_model/model.yaml
@@ -18,7 +18,7 @@ model:
 
 run:
     mode: plan
-    solver: glpk
+    solver: cbc
 
 techs:
     test_supply_gas:

--- a/calliope/test/common/test_model/model_demand_share.yaml
+++ b/calliope/test/common/test_model/model_demand_share.yaml
@@ -4,7 +4,7 @@ model:
 
 run:
     mode: plan
-    solver: glpk
+    solver: cbc
 
 techs:
     cheap_supply:

--- a/calliope/test/common/test_model/model_minimal.yaml
+++ b/calliope/test/common/test_model/model_minimal.yaml
@@ -8,7 +8,7 @@ model:
 
 run:
     mode: plan
-    solver: glpk
+    solver: cbc
 
 techs:
     test_supply_elec:

--- a/calliope/test/model_conversion/national_scale/run.yaml
+++ b/calliope/test/model_conversion/national_scale/run.yaml
@@ -12,7 +12,7 @@ output:  # Only used if run via the 'calliope run' command-line tool
 
 mode: plan  # Choices: plan, operate
 
-solver: glpk
+solver: cbc
 
 ##
 # PARALLEL RUN SETTINGS

--- a/calliope/test/test_constraint_results.py
+++ b/calliope/test/test_constraint_results.py
@@ -176,7 +176,7 @@ class TestGroupConstraints:
                                  .sum()
                                  .transform(lambda x: x / x.sum())
                                  .loc["cheap_supply"])
-        assert cheap_generation <= 0.4
+        assert round(cheap_generation, 1) <= 0.4
 
     def test_systemwide_demand_share_min_constraint(self):
         model = build_model(
@@ -192,7 +192,7 @@ class TestGroupConstraints:
                                      .sum()
                                      .transform(lambda x: x / x.sum())
                                      .loc["expensive_supply"])
-        assert expensive_generation >= 0.6
+        assert round(expensive_generation, 1) >= 0.6
 
     def test_location_specific_demand_share_max_constraint(self):
         model = build_model(
@@ -206,7 +206,7 @@ class TestGroupConstraints:
         cheap_generation0 = generation.loc[("0", "cheap_supply", "electricity")]
         expensive_generation0 = generation.loc[("0", "expensive_supply", "electricity")]
         expensive_generation1 = generation.loc[("1", "expensive_supply", "electricity")]
-        assert cheap_generation0 / (cheap_generation0 + expensive_generation0) <= 0.4
+        assert round(cheap_generation0 / (cheap_generation0 + expensive_generation0), 1) <= 0.4
         assert expensive_generation1 == 0
 
     def test_location_specific_demand_share_min_constraint(self):
@@ -221,5 +221,5 @@ class TestGroupConstraints:
         cheap_generation0 = generation.loc[("0", "cheap_supply", "electricity")]
         expensive_generation0 = generation.loc[("0", "expensive_supply", "electricity")]
         expensive_generation1 = generation.loc[("1", "expensive_supply", "electricity")]
-        assert expensive_generation0 / (cheap_generation0 + expensive_generation0) >= 0.6
+        assert round(expensive_generation0 / (cheap_generation0 + expensive_generation0), 1) >= 0.6
         assert expensive_generation1 == 0

--- a/calliope/test/test_example_models.py
+++ b/calliope/test/test_example_models.py
@@ -109,7 +109,7 @@ class TestNationalScaleExampleModelInfeasibility:
 
         model.run()
 
-        assert model.results.attrs['termination_condition'] in ['infeasible']  # glpk gives 'other' as result
+        assert model.results.attrs['termination_condition'] in ['infeasible', 'other']  # glpk gives 'other' as result
 
         assert 'systemwide_levelised_cost' not in model.results.data_vars
         assert 'systemwide_capacity_factor' not in model.results.data_vars

--- a/calliope/test/test_example_models.py
+++ b/calliope/test/test_example_models.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 
 import pytest
@@ -61,7 +60,7 @@ class TestNationalScaleExampleModelSenseChecks:
             model.results.systemwide_capacity_factor.loc[dict(carriers='power')].to_pandas().T['battery']
         ) == approx(0.2642256, abs=0.000001)
 
-    def test_nationalscale_example_results_glpk(self):
+    def test_nationalscale_example_results_cbc(self):
         self.example_tester()
 
     def test_nationalscale_example_results_gurobi(self):
@@ -171,7 +170,7 @@ class TestNationalScaleResampledExampleModelSenseChecks:
             model.results.systemwide_capacity_factor.loc[dict(carriers='power')].to_pandas().T['battery']
         ) == approx(0.25, abs=0.000001)
 
-    def test_nationalscale_resampled_example_results_glpk(self):
+    def test_nationalscale_resampled_example_results_cbc(self):
         self.example_tester()
 
     def test_nationalscale_resampled_example_results_glpk(self):
@@ -253,7 +252,7 @@ class TestNationalScaleClusteredExampleModelSenseChecks:
             model.results.systemwide_capacity_factor.loc[dict(carriers='power')].to_pandas().T['battery']
         ) == approx(0.074167, abs=0.000001)
 
-    def test_nationalscale_clustered_example_closest_results_glpk(self):
+    def test_nationalscale_clustered_example_closest_results_cbc(self):
         self.example_tester_closest()
 
     def test_nationalscale_clustered_example_closest_results_glpk(self):
@@ -263,7 +262,7 @@ class TestNationalScaleClusteredExampleModelSenseChecks:
         else:
             pytest.skip('GLPK not installed')
 
-    def test_nationalscale_clustered_example_mean_results_glpk(self):
+    def test_nationalscale_clustered_example_mean_results_cbc(self):
         self.example_tester_mean()
 
     def test_nationalscale_clustered_example_mean_results_glpk(self):

--- a/calliope/test/test_example_models.py
+++ b/calliope/test/test_example_models.py
@@ -65,7 +65,7 @@ class TestNationalScaleExampleModelSenseChecks:
 
     def test_nationalscale_example_results_gurobi(self):
         try:
-            import gurobipy
+            import gurobipy  # pylint: disable=unused-import
             self.example_tester(solver='gurobi', solver_io='python')
         except ImportError:
             pytest.skip('Gurobi not installed')
@@ -337,7 +337,7 @@ class TestUrbanScaleExampleModelSenseChecks:
 
     def test_urban_example_results_area_gurobi(self):
         try:
-            import gurobipy
+            import gurobipy  # pylint: disable=unused-import
             self.example_tester('per_area', solver='gurobi', solver_io='python')
         except ImportError:
             pytest.skip('Gurobi not installed')
@@ -347,7 +347,7 @@ class TestUrbanScaleExampleModelSenseChecks:
 
     def test_urban_example_results_cap_gurobi(self):
         try:
-            import gurobipy
+            import gurobipy  # pylint: disable=unused-import
             self.example_tester('per_cap', solver='gurobi', solver_io='python')
         except ImportError:
             pytest.skip('Gurobi not installed')

--- a/calliope/test/test_example_models.py
+++ b/calliope/test/test_example_models.py
@@ -33,7 +33,7 @@ class TestModelPreproccesing:
 
 
 class TestNationalScaleExampleModelSenseChecks:
-    def example_tester(self, solver='glpk', solver_io=None):
+    def example_tester(self, solver='cbc', solver_io=None):
         override = {
             'model.subset_time': '2005-01-01',
             'run.solver': solver,
@@ -78,12 +78,12 @@ class TestNationalScaleExampleModelSenseChecks:
         else:
             pytest.skip('CPLEX not installed')
 
-    def test_nationalscale_example_results_cbc(self):
+    def test_nationalscale_example_results_glpk(self):
         # Check for existence of the `cbc` command
-        if shutil.which('cbc'):
-            self.example_tester(solver='cbc')
+        if shutil.which('glpk'):
+            self.example_tester(solver='glpk')
         else:
-            pytest.skip('CBC not installed')
+            pytest.skip('GLPK not installed')
 
     def test_fails_gracefully_without_timeseries(self):
         override = {
@@ -143,7 +143,7 @@ class TestNationalScaleExampleModelOperate:
 
 
 class TestNationalScaleResampledExampleModelSenseChecks:
-    def example_tester(self, solver='glpk', solver_io=None):
+    def example_tester(self, solver='cbc', solver_io=None):
         override = {
             'model.subset_time': '2005-01-01',
             'run.solver': solver,
@@ -174,16 +174,16 @@ class TestNationalScaleResampledExampleModelSenseChecks:
     def test_nationalscale_resampled_example_results_glpk(self):
         self.example_tester()
 
-    def test_nationalscale_resampled_example_results_cbc(self):
-        # Check for existence of the `cbc` command
-        if shutil.which('cbc'):
-            self.example_tester(solver='cbc')
+    def test_nationalscale_resampled_example_results_glpk(self):
+        # Check for existence of the `glpk` command
+        if shutil.which('glpk'):
+            self.example_tester(solver='glpk')
         else:
-            pytest.skip('CBC not installed')
+            pytest.skip('GLPK not installed')
 
 
 class TestNationalScaleClusteredExampleModelSenseChecks:
-    def model_runner(self, solver='glpk', solver_io=None,
+    def model_runner(self, solver='cbc', solver_io=None,
                      how='closest', storage_inter_cluster=False,
                      cyclic=False, storage=True):
         override = {
@@ -207,7 +207,7 @@ class TestNationalScaleClusteredExampleModelSenseChecks:
 
         return model
 
-    def example_tester_closest(self, solver='glpk', solver_io=None):
+    def example_tester_closest(self, solver='cbc', solver_io=None):
         model = self.model_runner(solver=solver, solver_io=solver_io, how='closest')
         # Full 1-hourly model run: 22312488.670967
         assert float(model.results.cost.sum()) == approx(51711873.203096)
@@ -222,7 +222,7 @@ class TestNationalScaleClusteredExampleModelSenseChecks:
             model.results.systemwide_capacity_factor.loc[dict(carriers='power')].to_pandas().T['battery']
         ) == approx(0.074809, abs=0.000001)
 
-    def example_tester_mean(self, solver='glpk', solver_io=None):
+    def example_tester_mean(self, solver='cbc', solver_io=None):
         model = self.model_runner(solver=solver, solver_io=solver_io, how='mean')
         # Full 1-hourly model run: 22312488.670967
         assert float(model.results.cost.sum()) == approx(45110415.5627)
@@ -256,22 +256,22 @@ class TestNationalScaleClusteredExampleModelSenseChecks:
     def test_nationalscale_clustered_example_closest_results_glpk(self):
         self.example_tester_closest()
 
-    def test_nationalscale_clustered_example_closest_results_cbc(self):
-        # Check for existence of the `cbc` command
-        if shutil.which('cbc'):
-            self.example_tester_closest(solver='cbc')
+    def test_nationalscale_clustered_example_closest_results_glpk(self):
+        # Check for existence of the `glpk` command
+        if shutil.which('glpk'):
+            self.example_tester_closest(solver='glpk')
         else:
-            pytest.skip('CBC not installed')
+            pytest.skip('GLPK not installed')
 
     def test_nationalscale_clustered_example_mean_results_glpk(self):
         self.example_tester_mean()
 
-    def test_nationalscale_clustered_example_mean_results_cbc(self):
-        # Check for existence of the `cbc` command
-        if shutil.which('cbc'):
-            self.example_tester_mean(solver='cbc')
+    def test_nationalscale_clustered_example_mean_results_glpk(self):
+        # Check for existence of the `glpk` command
+        if shutil.which('glpk'):
+            self.example_tester_mean(solver='glpk')
         else:
-            pytest.skip('CBC not installed')
+            pytest.skip('GLPK not installed')
 
     def test_nationalscale_clustered_example_storage_inter_cluster(self):
         self.example_tester_storage_inter_cluster()
@@ -303,7 +303,7 @@ class TestNationalScaleClusteredExampleModelSenseChecks:
 
 
 class TestUrbanScaleExampleModelSenseChecks:
-    def example_tester(self, resource_unit, solver='glpk'):
+    def example_tester(self, resource_unit, solver='cbc'):
         unit_override = {
             'techs.pv.constraints': {
                 'resource': 'file=pv_resource.csv:{}'.format(resource_unit),

--- a/calliope/test/test_example_models.py
+++ b/calliope/test/test_example_models.py
@@ -71,14 +71,12 @@ class TestNationalScaleExampleModelSenseChecks:
             pytest.skip('Gurobi not installed')
 
     def test_nationalscale_example_results_cplex(self):
-        # Check for existence of the `cplex` command
         if shutil.which('cplex'):
             self.example_tester(solver='cplex')
         else:
             pytest.skip('CPLEX not installed')
 
     def test_nationalscale_example_results_glpk(self):
-        # Check for existence of the `cbc` command
         if shutil.which('glpsol'):
             self.example_tester(solver='glpk')
         else:
@@ -174,7 +172,6 @@ class TestNationalScaleResampledExampleModelSenseChecks:
         self.example_tester()
 
     def test_nationalscale_resampled_example_results_glpk(self):
-        # Check for existence of the `glpk` command
         if shutil.which('glpsol'):
             self.example_tester(solver='glpk')
         else:
@@ -256,7 +253,6 @@ class TestNationalScaleClusteredExampleModelSenseChecks:
         self.example_tester_closest()
 
     def test_nationalscale_clustered_example_closest_results_glpk(self):
-        # Check for existence of the `glpk` command
         if shutil.which('glpsol'):
             self.example_tester_closest(solver='glpk')
         else:
@@ -266,7 +262,6 @@ class TestNationalScaleClusteredExampleModelSenseChecks:
         self.example_tester_mean()
 
     def test_nationalscale_clustered_example_mean_results_glpk(self):
-        # Check for existence of the `glpk` command
         if shutil.which('glpsol'):
             self.example_tester_mean(solver='glpk')
         else:
@@ -341,7 +336,6 @@ class TestUrbanScaleExampleModelSenseChecks:
         self.example_tester('per_area')
 
     def test_urban_example_results_area_gurobi(self):
-        # Check for existence of the `gurobi` solver
         try:
             import gurobipy
             self.example_tester('per_area', solver='gurobi', solver_io='python')
@@ -352,7 +346,6 @@ class TestUrbanScaleExampleModelSenseChecks:
         self.example_tester('per_cap')
 
     def test_urban_example_results_cap_gurobi(self):
-        # Check for existence of the `gurobi` solver
         try:
             import gurobipy
             self.example_tester('per_cap', solver='gurobi', solver_io='python')

--- a/calliope/test/test_objective.py
+++ b/calliope/test/test_objective.py
@@ -14,11 +14,11 @@ class TestNationalScaleObjectives:
         model.run()
 
         assert model.results.energy_cap.to_pandas()['region1-2::csp'] == approx(10000.0)
-        assert model.results.energy_cap.to_pandas()['region1::ac_transmission:region2'] == approx(3731.92)
+        assert model.results.energy_cap.to_pandas()['region1::ac_transmission:region2'] == approx(10000.0)
 
         assert model.results.carrier_prod.sum('timesteps').to_pandas()['region1::ccgt::power'] == approx(66530.36492823533)
 
-        assert float(model.results.cost.sum()) == approx(13462543.177688833)
+        assert float(model.results.cost.loc[{'costs': 'emissions'}].sum()) == approx(13129619.1)
 
     def test_nationalscale_maximize_utility(self):
         model = calliope.examples.national_scale(
@@ -34,4 +34,4 @@ class TestNationalScaleObjectives:
 
         assert model.results.carrier_prod.sum('timesteps').to_pandas()['region1::ccgt::power'] == approx(115569.4354)
 
-        assert float(model.results.cost.sum()) == approx(66293103.91792595)
+        assert float(model.results.cost.sum()) > 6.6e7

--- a/changelog.rst
+++ b/changelog.rst
@@ -10,6 +10,8 @@ Release History
 
 |new| Documentation for developers has been improved to include an overview of the internal package structure and a guide to contributing code via a pull request.
 
+|changed| All tests and example models have been updated to solve with Coin-CBC, instead of GLPK. Documentation has been updated to reflect this, and aid in installing CBC (which is not simple for Windows users).
+
 |changed| |backwards-incompatible| Exit code for infeasible problems now is 1 (no success). This is a breaking change when relying on the exit code.
 
 |changed| Default value of resource_area_max now is ``inf`` instead of ``0``, deactivating the constraint by default.

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -27,15 +27,11 @@ With Miniconda installed, you can create a new Python 3.6 environment called ``"
 
    $ conda create -c conda-forge -n calliope python=3.6 calliope
 
-To use Calliope, you need to activate the ``calliope`` environment each time. On Linux and macOS::
+To use Calliope, you need to activate the ``calliope`` environment each time]::
 
-   $ source activate calliope
+   $ conda activate calliope#
 
-On Windows::
-
-   $ activate calliope
-
-You are now ready to use Calliope together with the free and open source GLPK solver. Read the next section for more information on alternative solvers.
+You are now ready to use Calliope together with the free and open source GLPK solver. However, we recommend to not use this solver where possible, since it performs relatively poorly (both in solution time and stability of result). Indeed, our example models use the free and open source CBC solver instead. Read the next section for more information on installing alternative solvers.
 
 Updating an existing installation
 =================================
@@ -57,7 +53,7 @@ GLPK
 CBC
 ---
 
-`CBC <https://projects.coin-or.org/Cbc>`_ is another free and open-source option. CBC can be installed via conda on Linux and macOS by running ``conda install -c conda-forge coincbc``. Windows binary packages and further documentation are available at `the CBC website <https://projects.coin-or.org/Cbc>`_.
+`CBC <https://projects.coin-or.org/Cbc>`_ is another free and open-source option. CBC can be installed via conda on Linux and macOS by running ``conda install -c conda-forge coincbc``. Windows binary packages are somewhat more difficult to install, due to limited information on `the CBC website <https://projects.coin-or.org/Cbc>`_. We recommend you download the relevant binary for `CBC 2.9.9 <https://bintray.com/coin-or/download/Cbc/2.9.9>`_ and add `cbc.exe` to a directory known to PATH (e.g. an Anaconda environment 'bin' directory).
 
 Gurobi
 ------

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -13,7 +13,7 @@ Running Calliope requires four things:
 
 1. The Python programming language, version 3.6 or higher.
 2. A number of Python add-on modules (see :ref:`below for the complete list <python_module_requirements>`).
-3. A solver: Calliope has been tested with GLPK, CBC, Gurobi, and CPLEX. Any other solver that is compatible with Pyomo should also work.
+3. A solver: Calliope has been tested with CBC, GLPK, Gurobi, and CPLEX. Any other solver that is compatible with Pyomo should also work.
 4. The Calliope software itself.
 
 Recommended installation method
@@ -27,11 +27,11 @@ With Miniconda installed, you can create a new Python 3.6 environment called ``"
 
    $ conda create -c conda-forge -n calliope python=3.6 calliope
 
-To use Calliope, you need to activate the ``calliope`` environment each time]::
+To use Calliope, you need to activate the ``calliope`` environment each time::
 
-   $ conda activate calliope#
+   $ conda activate calliope
 
-You are now ready to use Calliope together with the free and open source GLPK solver. However, we recommend to not use this solver where possible, since it performs relatively poorly (both in solution time and stability of result). Indeed, our example models use the free and open source CBC solver instead. Read the next section for more information on installing alternative solvers.
+You are now ready to use Calliope together with the free and open source GLPK solver. However, we recommend to not use this solver where possible, since it performs relatively poorly (both in solution time and stability of result). Indeed, our example models use the free and open source CBC solver instead, but installing it on Windows requires an extra step. Read the next section for more information on installing alternative solvers.
 
 Updating an existing installation
 =================================
@@ -43,22 +43,22 @@ If following the recommended installation method above, the following command, a
 Solvers
 =======
 
-You need at least one of the solvers supported by Pyomo installed. CPLEX or Gurobi are recommended for large problems, and have been confirmed to work with Calliope. Refer to the documentation of your solver on how to install it.
+You need at least one of the solvers supported by Pyomo installed. CBC (open-source) or Gurobi (commercial) are recommended for large problems, and have been confirmed to work with Calliope. Refer to the documentation of your solver on how to install it.
+
+CBC
+---
+
+`CBC <https://projects.coin-or.org/Cbc>`_ is our recommended option if you want a free and open-source solver. CBC can be installed via conda on Linux and macOS by running ``conda install -c conda-forge coincbc``. Windows binary packages are somewhat more difficult to install, due to limited information on `the CBC website <https://projects.coin-or.org/Cbc>`_. We recommend you download the relevant binary for `CBC 2.9.9 <https://bintray.com/coin-or/download/Cbc/2.9.9>`_ and add `cbc.exe` to a directory known to PATH (e.g. an Anaconda environment 'bin' directory).
 
 GLPK
 ----
 
 `GLPK <https://www.gnu.org/software/glpk/>`_ is free and open-source, but can take too much time and/or too much memory on larger problems. If using the recommended installation approach  above, GLPK is already installed in the ``calliope`` environment. To install GLPK manually, refer to the `GLPK website <https://www.gnu.org/software/glpk/>`_.
 
-CBC
----
-
-`CBC <https://projects.coin-or.org/Cbc>`_ is another free and open-source option. CBC can be installed via conda on Linux and macOS by running ``conda install -c conda-forge coincbc``. Windows binary packages are somewhat more difficult to install, due to limited information on `the CBC website <https://projects.coin-or.org/Cbc>`_. We recommend you download the relevant binary for `CBC 2.9.9 <https://bintray.com/coin-or/download/Cbc/2.9.9>`_ and add `cbc.exe` to a directory known to PATH (e.g. an Anaconda environment 'bin' directory).
-
 Gurobi
 ------
 
-`Gurobi <https://www.gurobi.com/>`_ is commercial but significantly faster than GLPK and CBC, which is relevant for larger problems. It needs a license to work, which can be obtained for free for academic use by creating an account on gurobi.com.
+`Gurobi <https://www.gurobi.com/>`_ is commercial but significantly faster than CBC and GLPK, which is relevant for larger problems. It needs a license to work, which can be obtained for free for academic use by creating an account on gurobi.com.
 
 While Gurobi can be installed via conda (``conda install -c gurobi gurobi``) we recommend downloading and installing the installer from the `Gurobi website <https://www.gurobi.com/>`_, as the conda package has repeatedly shown various issues.
 


### PR DESCRIPTION
Fixes issue(s) #204 

Summary of changes in this pull request:

* Update Appveyor install instructions such that CBC can be installed on Windows.
* Update docs to inform users on how to install CBC on their OS (conda forge for all but Windows).
* Update example and models to default to CBC as the solver.

NOTE: I'm not certain the Windows install instructions are correct, since I don't have access to a Windows machine to check... All I remember is that the CBC instructions for Windows don't work out of the box.

Reviewer checklist:

- [x] Test(s) added to cover contribution
- [x] Documentation updated
- [x] Changelog updated
- [x] Coverage maintained or improved