### PR TITLE
Checks and tests to warn on empty cost class

### DIFF
--- a/calliope/core/preprocess/locations.py
+++ b/calliope/core/preprocess/locations.py
@@ -400,6 +400,14 @@ def process_per_distance_constraints(tech_name, tech_settings, locations, locati
 def compute_depreciation_rates(tech_id, tech_config, warnings, errors):
     cost_classes = list(tech_config.get('costs', {}).keys())
     for cost in cost_classes:
+        # If the cost class is empty, delete it now and warn about it
+        if not isinstance(tech_config.costs[cost], dict):
+            warnings.append(
+                'Deleting empty cost class `{}` for technology `{}`.'.format(cost, tech_id)
+            )
+            tech_config.costs.del_key(cost)
+            continue
+
         plant_life = tech_config.constraints.get_key('lifetime', 0)
         interest = tech_config.costs[cost].get_key('interest_rate', None)
 

--- a/calliope/test/test_core_preprocess.py
+++ b/calliope/test/test_core_preprocess.py
@@ -360,6 +360,24 @@ class TestModelRun:
         m = build_model(override_dict=override1, scenario='simple_supply,one_day')
         assert 'loc_techs_cost' not in m._model_data.dims
 
+    def test_empty_cost_class(self):
+        """
+        If cost is defined, but its value is not a dictionary, ensure it is
+        deleted
+        """
+        override1 = {
+            'techs.test_supply_elec.costs.carbon': None
+        }
+        with pytest.warns(exceptions.ModelWarning) as warn_info:
+            m = build_model(override_dict=override1, scenario='simple_supply,one_day,investment_costs')
+
+        assert check_error_or_warning(
+            warn_info, 'Deleting empty cost class `carbon` for technology `test_supply_elec`.'
+        )
+
+        assert 'carbon' not in m._model_run.locations['1'].techs.test_supply_elec.costs.keys()
+        assert 'carbon' not in m._model_data.coords['costs'].values
+
 
 class TestChecks:
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -34,6 +34,8 @@ Release History
 
 |changed| |backwards-incompatible| Scenarios in YAML files defined as list of override names, not comma-separated strings: `fusion_scenario: cold_fusion,high_cost` becomes `fusion_scenario: ['cold_fusion', 'high_cost']`. No change to the command-line interface.
 
+|fixed| Loc::techs with empty cost classes (i.e. value == None) are handled by a warning and cost class deletion, instead of messy failure.
+
 |fixed| Name of data variables is retained when accessed through `model.get_formatted_array()`
 
 |fixed| Systemwide constraints work in models without transmission systems.


### PR DESCRIPTION
Fixes issue(s) #190

Summary of changes in this pull request:

* per loc::tech check for `locations[loc].techs[tech].costs[cost] is None` 
* warning and deletion of offending cost class
* Added test

Reviewer checklist:

- [x] Test(s) added to cover contribution
- [x] Documentation updated
- [x] Changelog updated
- [x] Coverage maintained or improved