### PR TITLE
Remove inexistent locations/techs from group constraints

### DIFF
--- a/calliope/core/preprocess/checks.py
+++ b/calliope/core/preprocess/checks.py
@@ -171,21 +171,6 @@ def check_initial(config_model):
                     'will be ignored - possibly a misspelling?'.format(key, group)
                 )
 
-    # Warn if loc/tech is defined in group constraint that doesn't exist in the model
-    for i in ['locs', 'techs']:
-        config_i = 'locations' if i == 'locs' else i
-        _missing = set()
-        for group, group_vals in config_model.get('group_constraints', {}).items():
-            if i in group_vals.keys() and set(group_vals[i]).difference(config_model[config_i].keys()):
-                _missing.update(set(group_vals[i]).difference(config_model[config_i].keys()))
-                group_vals[i] = list(set(group_vals[i]).intersection(config_model[config_i].keys()))
-        if _missing:
-            model_warnings.append(
-                'Possible misspelling in group constraints: {0} {1} given in '
-                'group constraints, but not defined as {0} in the model. They '
-                'will be ignored in the optimisation run'.format(i, _missing)
-            )
-
     # No techs may have the same identifier as a tech_group
     name_overlap = (
         set(config_model.tech_groups.keys()) &
@@ -569,6 +554,30 @@ def check_final(model_run):
     for k, df in model_run['timeseries_data'].items():
         if df.index.duplicated().any():
             errors.append('Time series `{}` contains non-unique timestamp values.'.format(k))
+
+    # Warn if loc/tech is defined in group constraint that doesn't exist in the model
+    for i in ['locs', 'techs']:
+        config_i = 'locations' if i == 'locs' else i
+        _missing = set()
+        for group, group_vals in model_run.get('group_constraints', {}).items():
+            if i in group_vals.keys() and set(group_vals[i]).difference(model_run[config_i].keys()):
+                _missing.update(set(group_vals[i]).difference(model_run[config_i].keys()))
+                model_run['group_constraints'][group][i] = (
+                    list(set(group_vals[i]).intersection(model_run[config_i].keys()))
+                )
+                if model_run['group_constraints'][group][i] == []:
+                    model_warnings.append(
+                        'Constraint group `{}` will be completely ignored since '
+                        'none of the defined {} are valid for this model.'
+                        .format(group, i)
+                    )
+                    model_run['group_constraints'][group]['exists'] = False
+        if _missing:
+            model_warnings.append(
+                'Possible misspelling in group constraints: {0} {1} given in '
+                'group constraints, but not defined as {0} in the model. They '
+                'will be ignored in the optimisation run'.format(i, _missing)
+            )
 
     # FIXME:
     # make sure `comments` is at the the base level:

--- a/calliope/core/preprocess/checks.py
+++ b/calliope/core/preprocess/checks.py
@@ -171,6 +171,21 @@ def check_initial(config_model):
                     'will be ignored - possibly a misspelling?'.format(key, group)
                 )
 
+    # Warn if loc/tech is defined in group constraint that doesn't exist in the model
+    for i in ['locs', 'techs']:
+        config_i = 'locations' if i == 'locs' else i
+        _missing = set()
+        for group, group_vals in config_model.get('group_constraints', {}).items():
+            if i in group_vals.keys() and set(group_vals[i]).difference(config_model[config_i].keys()):
+                _missing.update(set(group_vals[i]).difference(config_model[config_i].keys()))
+                group_vals[i] = list(set(group_vals[i]).intersection(config_model[config_i].keys()))
+        if _missing:
+            model_warnings.append(
+                'Possible misspelling in group constraints: {0} {1} given in '
+                'group constraints, but not defined as {0} in the model. They '
+                'will be ignored in the optimisation run'.format(i, _missing)
+            )
+
     # No techs may have the same identifier as a tech_group
     name_overlap = (
         set(config_model.tech_groups.keys()) &

--- a/calliope/test/test_core_preprocess.py
+++ b/calliope/test/test_core_preprocess.py
@@ -542,13 +542,7 @@ class TestChecks:
         """
         Unkown group constraints raise a warning, but don't crash
         """
-        override = AttrDict.from_yaml_string(
-            """
-            group_constraints:
-                mygroup:
-                    foobar: 0
-            """
-        )
+        override = {'group_constraints.mygroup.foobar': 0}
 
         with pytest.warns(exceptions.ModelWarning) as excinfo:
             build_model(override_dict=override, scenario='simple_supply')
@@ -557,6 +551,26 @@ class TestChecks:
             excinfo,
             'Unrecognised group constraint `foobar` in group `mygroup`'
         )
+
+    @pytest.mark.parametrize('loc_tech', (
+        ({'locs': ['1', 'foo']}), ({'techs': ['test_supply_elec', 'bar']}),
+        ({'locs': ['1', 'foo'], 'techs': ['test_supply_elec', 'bar']})
+    ))
+    def test_inexistent_group_constraint_loc_tech(self, loc_tech):
+
+        override = {
+            'group_constraints.mygroup': {'energy_cap_max': 100, **loc_tech}
+        }
+
+        with pytest.warns(exceptions.ModelWarning) as excinfo:
+            m = build_model(override_dict=override, scenario='simple_supply', model_file='model.yaml')
+
+        assert check_error_or_warning(excinfo, 'Possible misspelling in group constraints:')
+
+        loc_techs = m._model_data.group_constraint_loc_techs_mygroup.values
+        assert 'foo:test_supply_elec' not in loc_techs
+        assert '1:bar' not in loc_techs
+        assert 'foo:bar' not in loc_techs
 
     @pytest.mark.filterwarnings("ignore:(?s).*Not building the link 0,1:calliope.exceptions.ModelWarning")
     def test_abstract_base_tech_group_override(self):

--- a/calliope/test/test_core_preprocess.py
+++ b/calliope/test/test_core_preprocess.py
@@ -563,7 +563,7 @@ class TestChecks:
         }
 
         with pytest.warns(exceptions.ModelWarning) as excinfo:
-            m = build_model(override_dict=override, scenario='simple_supply', model_file='model.yaml')
+            m = build_model(override_dict=override, scenario='simple_supply')
 
         assert check_error_or_warning(excinfo, 'Possible misspelling in group constraints:')
 
@@ -571,6 +571,19 @@ class TestChecks:
         assert 'foo:test_supply_elec' not in loc_techs
         assert '1:bar' not in loc_techs
         assert 'foo:bar' not in loc_techs
+
+    def test_inexistent_group_constraint_empty_loc_tech(self):
+
+        override = {
+            'group_constraints.mygroup': {'energy_cap_max': 100, 'locs': ['foo']}
+        }
+
+        with pytest.warns(exceptions.ModelWarning) as excinfo:
+            m = build_model(override_dict=override, scenario='simple_supply')
+
+        assert check_error_or_warning(excinfo, 'Constraint group `mygroup` will be completely ignored')
+
+        assert m._model_run.group_constraints.mygroup.get('exists', True) is False
 
     @pytest.mark.filterwarnings("ignore:(?s).*Not building the link 0,1:calliope.exceptions.ModelWarning")
     def test_abstract_base_tech_group_override(self):

--- a/changelog.rst
+++ b/changelog.rst
@@ -10,7 +10,7 @@ Release History
 
 |new| Multi-objective optimisation problems can be defined by linear scalarisation of cost classes, using `run.objective_options.cost_class` (e.g. `{'monetary': 1, 'emissions': 0.1}`, which models an emissions price of 0.1 units of currency per unit of emissions)
 
-|new| New model-wide constraint that can be applied to all or a subset of locations and technologies in a model, covering:
+|new| New model-wide constraint that can be applied to all, or a subset of, locations and technologies in a model, covering:
 
 * `demand_share_min` and `demand_share_max`, `energy_cap_share_min`, `energy_cap_share_max`, `supply_share_min`, `supply_share_max`, `demand_share_min`, and `demand_share_max`. These supersede the `group_share` constraints, which are now deprecated and will be removed in v0.7.0.
 * `cost_max`, `cost_min`, `cost_equals`, `cost_var_max`, `cost_var_min`, `cost_var_equals`, `cost_investment_max`, `cost_investment_min`, `cost_investment_equals`, which allow a user to constrain costs, including those not used in the objective.
@@ -25,6 +25,8 @@ Release History
 |new| Storage capacity can be tied to energy capacity with a new `energy_cap_per_storage_cap_equals` constraint.
 
 |new| The ratio of energy capacity and storage capacity can be constrained with a new `energy_cap_per_storage_cap_min` constraint.
+
+|changed| Any inexistent locations and / or technologies defined in model-wide (group) constraints will be caught and filtered out, raising a warning of their existence in the process.
 
 |changed| Error on required column not existing in CSV is more explicit.
 


### PR DESCRIPTION
Partially fixes issue(s) #198

Summary of changes in this pull request:

* Check for defined techs/locs in group constraints that don't exist elsewhere in the model definition
* Remove those inexistent techs from the definition of the constraint in `model_data` and warn the user that it has happened, in case it was a misspelling.

Reviewer checklist:

- [x] Test(s) added to cover contribution
~- [ ] Documentation updated~
- [x] Changelog updated
- [x] Coverage maintained or improved