### PR TITLE
Raise exception when technology defined twice on the same link

### DIFF
--- a/calliope/test/test_core_preprocess.py
+++ b/calliope/test/test_core_preprocess.py
@@ -801,17 +801,56 @@ class TestChecks:
         A tech defined directly within a location rather than within techs
         inside that location is probably an oversight.
         """
-        override = AttrDict.from_yaml_string(
-            """
-            locations.1.test_supply_elec.costs.storage_cap: 10
-            """
+        override = {'locations.1.test_supply_elec.costs.storage_cap': 10}
+
+        with pytest.raises(exceptions.ModelError) as excinfo:
+            build_model(override_dict=override, scenario='simple_supply,one_day')
+
+        assert check_error_or_warning(
+            excinfo, 'Location `1` contains tech `test_supply_elec` at its top level'
         )
+
+    def test_tech_defined_twice_in_links(self):
+        """
+        A technology can only be defined once for a link, even if that link is
+        defined twice (i.e. `A,B` and `B,A`).
+        """
+
+        override = {
+            'links.0,1.techs.test_transmission_elec': None,
+            'links.1,0.techs.test_transmission_elec': None
+        }
         with pytest.raises(exceptions.ModelError) as excinfo:
             build_model(override_dict=override, scenario='simple_supply,one_day')
 
         assert check_error_or_warning(
             excinfo,
-            'Location `1` contains tech `test_supply_elec` at its top level')
+            'Technology test_transmission_elec defined twice on a link defined '
+            'in both directions (e.g. `A,B` and `B,A`)'
+        )
+
+        override = {
+            'links.0,1.techs': {'test_transmission_elec': None, 'test_transmission_heat': None},
+            'links.1,0.techs': {'test_transmission_elec': None, 'test_transmission_heat': None}
+        }
+        with pytest.raises(exceptions.ModelError) as excinfo:
+            build_model(override_dict=override, scenario='simple_supply,one_day')
+
+        assert check_error_or_warning(
+            excinfo, ['test_transmission_elec', 'test_transmission_heat']
+        )
+
+        # We do allow a link to be defined twice, so long as the same tech isn't in both
+        override = {
+            'techs.test_transmission_heat_2': {
+                'essentials.name': 'Transmission heat tech',
+                'essentials.carrier': 'heat',
+                'essentials.parent': 'transmission'
+            },
+            'links.0,1.techs': {'test_transmission_elec': None},
+            'links.1,0.techs': {'test_transmission_heat_2': None}
+        }
+        build_model(override_dict=override, scenario='simple_supply,one_day')
 
     def test_allowed_time_varying_constraints(self):
         """

--- a/changelog.rst
+++ b/changelog.rst
@@ -26,6 +26,8 @@ Release History
 
 |new| The ratio of energy capacity and storage capacity can be constrained with a new `energy_cap_per_storage_cap_min` constraint.
 
+|changed| Error on defining a technology in both directions of the same link.
+
 |changed| Error on required column not existing in CSV is more explicit.
 
 |changed| `charge_rate` has been renamed to `energy_cap_per_storage_cap_max`. `charge_rate` will be removed in Calliope 0.7.0.


### PR DESCRIPTION
Fixes issue(s) #215 

Summary of changes in this pull request:

* Find instances of technologies defined in both directions of a link (e.g. `A,B` and `B,A`) and raise exception if they exist. Ignore instances of links being defined twice, but with different technologies.

Reviewer checklist:

- [x] Test(s) added to cover contribution
~- [ ] Documentation updated~
- [x] Changelog updated
- [x] Coverage maintained or improved