### PR TITLE
Fix spaces in link names

### DIFF
--- a/calliope/core/preprocess/locations.py
+++ b/calliope/core/preprocess/locations.py
@@ -178,7 +178,7 @@ def process_locations(model_config, modelrun_techs):
     # Generate all transmission links
     processed_links = AttrDict()
     for link in links_in:
-        loc_from, loc_to = link.split(',')
+        loc_from, loc_to = [i.strip() for i in link.split(',')]
         # Skip this link entirely if it has been told not to exist
         if not links_in[link].get('exists', True):
             continue

--- a/calliope/test/test_core_preprocess.py
+++ b/calliope/test/test_core_preprocess.py
@@ -379,6 +379,14 @@ class TestModelRun:
         assert 'carbon' not in m._model_run.locations['1'].techs.test_supply_elec.costs.keys()
         assert 'carbon' not in m._model_data.coords['costs'].values
 
+    def test_strip_link(self):
+        override = {
+            'links.0, 2.techs': {'test_transmission_elec': None},
+            'locations.2.techs': {'test_supply_elec': None}
+        }
+        m = build_model(override_dict=override, scenario='simple_supply,one_day')
+        assert '2' in m._model_run.locations['0'].links.keys()
+
 
 class TestChecks:
 
@@ -563,6 +571,7 @@ class TestChecks:
         """
         Abstract base technology groups can be overridden
         """
+
         override = AttrDict.from_yaml_string(
             """
             tech_groups:

--- a/changelog.rst
+++ b/changelog.rst
@@ -42,6 +42,8 @@ Release History
 
 |changed| Additional and improved pre-processing checks and errors for common model mistakes.
 
+|fixed| If a space is left between two locations in a link (i.e. `A, B` instead of `A,B`), the space is stripped, instead of leading to the expectation of a location existing with the name ` B`.
+
 |fixed| Total levelised cost of energy considers all costs, but energy generation only from ``supply``, ``supply_plus``, ``conversion``, and ``conversion_plus``.
 
 |fixed| Timeseries efficiencies can be included in operate mode without failing on preprocessing checks.


### PR DESCRIPTION
Partially fixes issue(s) #166

Summary of changes in this pull request:

* If a link should be `A,B` but is defined as `A, B`, the space is stripped early on in preprocessing
* Test to check this

Reviewer checklist:

- [x] Test(s) added to cover contribution
~- [ ] Documentation updated~
- [x] Changelog updated
- [x] Coverage maintained or improved