### PR TITLE
Add per-timestep group constraints

### DIFF
--- a/calliope/config/defaults.yaml
+++ b/calliope/config/defaults.yaml
@@ -23,7 +23,7 @@
 file_allowed: ['clustering_func', 'energy_con', 'energy_eff', 'energy_prod', 'energy_ramping', 'export', 'force_resource', 'om_con', 'om_prod', 'parasitic_eff', 'resource', 'resource_eff', 'storage_loss']
 
 allowed_group_constraints:
-    per_carrier: ['demand_share_min', 'demand_share_max', 'supply_share_min', 'supply_share_max']
+    per_carrier: ['demand_share_min', 'demand_share_max', 'demand_share_equals', 'demand_share_per_timestep_min', 'demand_share_per_timestep_max', 'demand_share_per_timestep_equals', 'supply_share_min', 'supply_share_max', 'supply_share_equals', 'supply_share_per_timestep_min', 'supply_share_per_timestep_max', 'supply_share_per_timestep_equals']
     per_cost: ['cost_max', 'cost_min', 'cost_equals', 'cost_var_max', 'cost_var_min', 'cost_var_equals', 'cost_investment_min', 'cost_investment_max', 'cost_investment_equals']
     general: ['energy_cap_share_min', 'energy_cap_share_max', 'energy_cap_min', 'energy_cap_max', 'resource_area_min', 'resource_area_max']
 

--- a/calliope/test/common/test_model/demand_share.yaml
+++ b/calliope/test/common/test_model/demand_share.yaml
@@ -151,6 +151,16 @@ overrides:
             locs: ["0"]
             demand_share_max:
                 electricity: 0.4
+    demand_share_per_timestep_equals:
+        group_constraints.example_demand_share_per_timestep_equals_constraint:
+            techs: ["cheap_elec_supply"]
+            demand_share_per_timestep_equals:
+                electricity: 0.3
+    demand_share_per_timestep_min:
+        group_constraints.example_demand_share_per_timestep_min_constraint:
+            techs: ["expensive_elec_supply"]
+            demand_share_per_timestep_equals:
+                electricity: 0.8
 
 
 scenarios:

--- a/calliope/test/common/test_model/supply_share.yaml
+++ b/calliope/test/common/test_model/supply_share.yaml
@@ -75,3 +75,8 @@ overrides:
             techs: ["expensive_supply"]
             supply_share_min:
                 electricity: 0.6
+    supply_share_per_timestep_equals:
+        group_constraints.example_supply_share_per_timestep_equals_constraint:
+            techs: ["expensive_supply"]
+            supply_share_per_timestep_equals:
+                electricity: 0.7

--- a/calliope/test/test_constraint_results.py
+++ b/calliope/test/test_constraint_results.py
@@ -396,6 +396,39 @@ class TestDemandShareGroupConstraints:
 
         assert round(cheap_elec_supply_0 / demand_0, 5) <= 0.4
 
+    def test_demand_share_per_timestep_equals(self):
+        model = build_model(
+            model_file='demand_share.yaml',
+            scenario='demand_share_per_timestep_equals'
+        )
+        model.run()
+        cheap_generation = model.get_formatted_array("carrier_prod").loc[{'techs': "cheap_elec_supply", 'carriers': "electricity"}].sum('locs')
+        demand = -1 * model.get_formatted_array("carrier_con").sum('locs')
+        # assert share in each timestep is 0.3
+        assert ((cheap_generation / demand).round(5) == 0.3).all()
+
+    def test_demand_share_per_timestep_min(self):
+        model = build_model(
+            model_file='demand_share.yaml',
+            scenario='demand_share_per_timestep_min'
+        )
+        model.run()
+        expensive_generation = model.get_formatted_array("carrier_prod").loc[{'techs': "expensive_elec_supply", 'carriers': "electricity"}].sum('locs')
+        demand = -1 * model.get_formatted_array("carrier_con").sum('locs')
+        # assert share in each timestep is 0.8
+        assert ((expensive_generation / demand).round(5) == 0.8).all()
+
+    def test_supply_share_per_timestep_equals(self):
+        model = build_model(
+            model_file='supply_share.yaml',
+            scenario='supply_share_per_timestep_equals'
+        )
+        model.run()
+        expensive_supply = model.get_formatted_array("carrier_prod").loc[{'techs': "expensive_supply", 'carriers': "electricity"}].sum('locs')
+        supply = model.get_formatted_array("carrier_prod").loc[{'carriers': "electricity"}].sum('locs').sum('techs')
+        # assert share in each timestep is 0.7
+        assert ((expensive_supply / supply).round(5) == 0.7).all()
+
 
 class TestResourceAreaGroupConstraints:
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -12,7 +12,7 @@ Release History
 
 |new| New model-wide constraint that can be applied to all, or a subset of, locations and technologies in a model, covering:
 
-* `demand_share_min` and `demand_share_max`, `energy_cap_share_min`, `energy_cap_share_max`, `supply_share_min`, `supply_share_max`, `demand_share_min`, and `demand_share_max`. These supersede the `group_share` constraints, which are now deprecated and will be removed in v0.7.0.
+* `demand_share`, `supply_share`, `demand_share_per_timestep`, `supply_share_per_timestep`, each of which can specify `min`, `max`, and `equals`, as well as `energy_cap_share_min` and `energy_cap_share_max`. These supersede the `group_share` constraints, which are now deprecated and will be removed in v0.7.0.
 * `cost_max`, `cost_min`, `cost_equals`, `cost_var_max`, `cost_var_min`, `cost_var_equals`, `cost_investment_max`, `cost_investment_min`, `cost_investment_equals`, which allow a user to constrain costs, including those not used in the objective.
 * `energy_cap_min`, `energy_cap_max`, `resource_area_min`, `resource_area_max` which allow to constrain installed capacities of groups of technologies in specific locations.
 

--- a/doc/user/advanced_constraints.rst
+++ b/doc/user/advanced_constraints.rst
@@ -248,6 +248,8 @@ When specifying group constraints, a named group must give at least one constrai
 
 The below table lists all available group constraints.
 
+Note that when computing the share for ``demand_share`` constraints, only ``demand`` technologies are counted, and that when computing the share for ``supply_share`` constraints, ``supply`` and ``supply_plus`` technologies are counted.
+
 .. list-table:: Group constraints
    :widths: 15 15 60
    :header-rows: 1
@@ -257,16 +259,40 @@ The below table lists all available group constraints.
      - Description
    * - ``demand_share_min``
      - carriers
-     - Minimum share of carrier demand met from a set of technologies across a set of locations.
+     - Minimum share of carrier demand met from a set of technologies across a set of locations, on average over the entire model period.
    * - ``demand_share_max``
      - carriers
-     - Maximum share of carrier demand met from a set of technologies across a set of locations.
+     - Maximum share of carrier demand met from a set of technologies across a set of locations, on average over the entire model period.
+   * - ``demand_share_equals``
+     - carriers
+     - Share of carrier demand met from a set of technologies across a set of locations, on average over the entire model period.
+   * - ``demand_share_per_timestep_min``
+     - carriers
+     - Minimum share of carrier demand met from a set of technologies across a set of locations, in each individual timestep.
+   * - ``demand_share_per_timestep_max``
+     - carriers
+     - Maximum share of carrier demand met from a set of technologies across a set of locations, in each individual timestep.
+   * - ``demand_share_per_timestep_equals``
+     - carriers
+     - Share of carrier demand met from a set of technologies across a set of locations, in each individual timestep.
    * - ``supply_share_min``
      - carriers
-     - Minimum share of carrier production met from a set of technologies across a set of locations.
+     - Minimum share of carrier production met from a set of technologies across a set of locations, on average over the entire model period.
    * - ``supply_share_max``
      - carriers
-     - Maximum share of carrier production met from a set of technologies across a set of locations.
+     - Maximum share of carrier production met from a set of technologies across a set of locations, on average over the entire model period.
+   * - ``supply_share_equals``
+     - carriers
+     - Share of carrier production met from a set of technologies across a set of locations, on average over the entire model period.
+   * - ``supply_share_per_timestep_min``
+     - carriers
+     - Minimum share of carrier production met from a set of technologies across a set of locations, in each individual timestep.
+   * - ``supply_share_per_timestep_max``
+     - carriers
+     - Maximum share of carrier production met from a set of technologies across a set of locations, in each individual timestep.
+   * - ``supply_share_per_timestep_equals``
+     - carriers
+     - Share of carrier production met from a set of technologies across a set of locations, in each individual timestep.
    * - ``cost_max``
      - costs
      - Maximum total cost from a set of technologies across a set of locations.


### PR DESCRIPTION
Partially fixes issue(s) #153

Summary of changes in this pull request:

* Add per-timestep group constraints
* Add equals options for demand_share and supply_share group constraints

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved