### PR TITLE
Let model_run and debug data roundtrip through NetCDF

### DIFF
--- a/calliope/core/io.py
+++ b/calliope/core/io.py
@@ -38,24 +38,35 @@ def read_netcdf(path):
     return model_data
 
 
-def save_netcdf(model_data, path):
+def save_netcdf(model_data, path, model=None):
     encoding = {k: {'zlib': True, 'complevel': 4} for k in model_data.data_vars}
+
+    original_model_data_attrs = model_data.attrs
+    model_data_attrs = model_data.attrs.copy()
+
+    if model is not None:
+        # Attach _model_run and _debug_data to _model_data
+        model_run_to_save = model._model_run.copy()
+        if 'timeseries_data' in model_run_to_save:
+            del model_run_to_save['timeseries_data']  # Can't be serialised!
+        model_data_attrs['_model_run'] = model_run_to_save.to_yaml()
+        model_data_attrs['_debug_data'] = model._debug_data.to_yaml()
 
     # Convert boolean attrs to ints
     bool_attrs = [
-        k for k, v in model_data.attrs.items()
+        k for k, v in model_data_attrs.items()
         if isinstance(v, bool)
     ]
     for k in bool_attrs:
-        model_data.attrs[k] = int(model_data.attrs[k])
+        model_data_attrs[k] = int(model_data_attrs[k])
 
     # Convert None attrs to 'None'
     none_attrs = [
-        k for k, v in model_data.attrs.items()
+        k for k, v in model_data_attrs.items()
         if v is None
     ]
     for k in none_attrs:
-        model_data.attrs[k] = 'None'
+        model_data_attrs[k] = 'None'
 
     # Convert `object` dtype coords to string
     # FIXME: remove once xarray issue https://github.com/pydata/xarray/issues/2404 is resolved
@@ -64,13 +75,11 @@ def save_netcdf(model_data, path):
             model_data[k] = v.astype('<U{}'.format(max([len(i.item()) for i in v])))
 
     try:
+        model_data.attrs = model_data_attrs
         model_data.to_netcdf(path, format='netCDF4', encoding=encoding)
         model_data.close()  # Force-close NetCDF file after writing
-    finally:  # Convert ints back to bools, 'None' back to None
-        for k in bool_attrs:
-            model_data.attrs[k] = bool(model_data.attrs[k])
-        for k in none_attrs:
-            model_data.attrs[k] = None
+    finally:  # Revert model_data.attrs back
+        model_data.attrs = original_model_data_attrs
 
 
 def save_csv(model_data, path, dropna=True):

--- a/calliope/core/model.py
+++ b/calliope/core/model.py
@@ -126,19 +126,17 @@ class Model(object):
             name='run_config', observer=self._model_data
         )
 
-        # Attach _model_run and _debug_data to _model_data
-        _model_run_to_save = self._model_run.copy()
-        del _model_run_to_save['timeseries_data']  # Can't be serialised!
-        self._model_data.attrs['_model_run'] = _model_run_to_save.to_yaml()
-        self._model_data.attrs['_debug_data'] = self._debug_data.to_yaml()
-
     def _init_from_model_data(self, model_data):
-        self._model_run = AttrDict.from_yaml_string(
-            model_data.attrs.get('_model_run', '{}')
-        )
-        self._debug_data = AttrDict.from_yaml_string(
-            model_data.attrs.get('_debug_data', '{}')
-        )
+        if '_model_run' in model_data.attrs:
+            self._model_run = AttrDict.from_yaml_string(
+                model_data.attrs['_model_run'])
+            del model_data.attrs['_model_run']
+
+        if '_debug_data' in model_data.attrs:
+            self._debug_data = AttrDict.from_yaml_string(
+                model_data.attrs['_debug_data'])
+            del model_data.attrs['_debug_data']
+
         self._model_data = model_data
         self.inputs = self._model_data.filter_by_attrs(is_result=0)
         self.model_config = UpdateObserverDict(
@@ -299,7 +297,7 @@ class Model(object):
         to a NetCDF file at the given ``path``.
 
         """
-        io.save_netcdf(self._model_data, path)
+        io.save_netcdf(self._model_data, path, model=self)
 
     def to_csv(self, path, dropna=True):
         """

--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,8 @@ Release History
 0.6.5 (dev)
 -----------
 
+|fixed| Models saved to NetCDF now include the fully built internal YAML model and debug data so that `Model.save_commented_model_yaml()` is available after loading a NetCDF model from disk
+
 |fixed| Fix an issue preventing the deprecated `charge_rate` constraint from working in 0.6.4.
 
 |fixed| Fix an issue that prevented 0.6.4 from loading NetCDF models saved with older versions of Calliope. It is still recommended to only load models with the same version of Calliope that they were saved with, as not all functionality will work when mixing versions.


### PR DESCRIPTION
Fixes issue(s) #245

Summary of changes in this pull request:

* Let model_run and debug data roundtrip through NetCDF

There seems to be no immediate limit on the size of strings in NetCDF attributes -- a test with a 20 MB large string did not reveal any performance or other issues (except that it adds 20 MB to the size of the resulting NetCDF file).

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved