### PR TITLE
Fix warning demand cost

### DIFF
--- a/calliope/config/defaults.yaml
+++ b/calliope/config/defaults.yaml
@@ -67,7 +67,7 @@ tech_groups:
     demand:
         required_constraints: ['resource']
         allowed_constraints: ['energy_con', 'force_resource', 'resource', 'resource_area_equals', 'resource_scale', 'resource_unit']
-        allowed_group_constraints: []
+        allowed_group_constraints: [cost_max, cost_min, cost_equals, cost_var_max, cost_var_min, cost_var_equals]
         allowed_costs: [om_con]
         essentials:
             parent: null


### PR DESCRIPTION
Fixes issue(s) related to the recently allowed om_con cost for demand techs. In fact, also group constraint defaults need to be updated to allow generic and variable costs group constraints for demand techs.
Otherwise, demand variable costs will be allowed in general but, if a cost group constraint is defined, checks in the preprocess will exclude demand costs from the cost group constraint and raise a warning.

Summary of changes in this pull request:

* Added generic costs and variable costs to group constraints allowed by demand techs
* Existing tests should cover this change already
*

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved