### PR TITLE
Fix double logging when using Gurobi

### DIFF
--- a/calliope/backend/pyomo/model.py
+++ b/calliope/backend/pyomo/model.py
@@ -193,6 +193,8 @@ def solve_model(backend_model, solver,
 
     with redirect_stdout(LogWriter(logger, 'debug', strip=True)):
         with redirect_stderr(LogWriter(logger, 'error', strip=True)):
+            # Ignore most of gurobipy's logging, as it's output is
+            # already captured through STDOUT
             logging.getLogger('gurobipy').setLevel(logging.ERROR)
             results = opt.solve(backend_model, tee=True, **solve_kwargs)
     return results

--- a/calliope/backend/pyomo/model.py
+++ b/calliope/backend/pyomo/model.py
@@ -6,6 +6,7 @@ Licensed under the Apache 2.0 License (see LICENSE file).
 
 import logging
 import os
+import io
 from contextlib import redirect_stdout, redirect_stderr
 
 import numpy as np
@@ -191,10 +192,10 @@ def solve_model(backend_model, solver,
         )
         del solve_kwargs['warmstart']
 
-    with redirect_stdout(LogWriter(logger, 'debug', strip=True)):
+    stdout_eater = LogWriter(logger, 'debug', strip=True) if solver != "gurobi" else io.StringIO()
+    with redirect_stdout(stdout_eater):
         with redirect_stderr(LogWriter(logger, 'error', strip=True)):
             results = opt.solve(backend_model, tee=True, **solve_kwargs)
-
     return results
 
 

--- a/calliope/backend/pyomo/model.py
+++ b/calliope/backend/pyomo/model.py
@@ -6,7 +6,6 @@ Licensed under the Apache 2.0 License (see LICENSE file).
 
 import logging
 import os
-import io
 from contextlib import redirect_stdout, redirect_stderr
 
 import numpy as np

--- a/calliope/backend/pyomo/model.py
+++ b/calliope/backend/pyomo/model.py
@@ -192,9 +192,9 @@ def solve_model(backend_model, solver,
         )
         del solve_kwargs['warmstart']
 
-    stdout_eater = LogWriter(logger, 'debug', strip=True) if solver != "gurobi" else io.StringIO()
-    with redirect_stdout(stdout_eater):
+    with redirect_stdout(LogWriter(logger, 'debug', strip=True)):
         with redirect_stderr(LogWriter(logger, 'error', strip=True)):
+            logging.getLogger('gurobipy').setLevel(logging.ERROR)
             results = opt.solve(backend_model, tee=True, **solve_kwargs)
     return results
 


### PR DESCRIPTION
Fixes #272 (a regression introduced in #248)

Summary of changes in this pull request:

* add a test for double logging with Gurobi
* mute Gurobi's direct stdout logging

While I think it's totally fine to mute Gurobi's direct stdout printing and rely on their additional logging (why do they do both?), this solution is not consistent with other loggers. This way, Gurobi logs will be INFO level rather than DEBUG level.

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved