### PR TITLE
Fixes minor issues

### DIFF
--- a/calliope/backend/pyomo/constraints/costs.py
+++ b/calliope/backend/pyomo/constraints/costs.py
@@ -108,9 +108,9 @@ def cost_investment_constraint_rule(backend_model, cost, loc_tech):
 
             \\boldsymbol{cost_{investment}}(cost, loc::tech) =
             cost_{fractional\\_om}(cost, loc::tech) +
-            cost_{fixed\\_om}(cost, loc::tech) + cost_{con}(cost, loc::tech)
+            cost_{fixed\\_om}(cost, loc::tech) + cost_{cap}(cost, loc::tech)
 
-            cost_{con}(cost, loc::tech) =
+            cost_{cap}(cost, loc::tech) =
             depreciation\\_rate * ts\\_weight *
             (cost_{energy\\_cap}(cost, loc::tech) \\times \\boldsymbol{energy_{cap}}(loc::tech)
             + cost_{storage\\_cap}(cost, loc::tech) \\times \\boldsymbol{storage_{cap}}(loc::tech)
@@ -155,7 +155,7 @@ def cost_investment_constraint_rule(backend_model, cost, loc_tech):
     ts_weight = get_timestep_weight(backend_model)
     depreciation_rate = model_data_dict['data']['cost_depreciation_rate'].get((cost, loc_tech), 0)
 
-    cost_con = (
+    cost_cap = (
         depreciation_rate * ts_weight *
         (cost_energy_cap + cost_storage_cap + cost_resource_cap +
          cost_resource_area)
@@ -163,13 +163,13 @@ def cost_investment_constraint_rule(backend_model, cost, loc_tech):
 
     # Transmission technologies exist at two locations, thus their cost is divided by 2
     if loc_tech_is_in(backend_model, loc_tech, 'loc_techs_transmission'):
-            cost_con = cost_con / 2
+            cost_cap = cost_cap / 2
 
-    cost_fractional_om = cost_om_annual_investment_fraction * cost_con
+    cost_fractional_om = cost_om_annual_investment_fraction * cost_cap
     cost_fixed_om = cost_om_annual * backend_model.energy_cap[loc_tech] * ts_weight
 
     backend_model.cost_investment_rhs[cost, loc_tech].expr = (
-        cost_fractional_om + cost_fixed_om + cost_con
+        cost_fractional_om + cost_fixed_om + cost_cap
     )
 
     return (

--- a/calliope/config/defaults.yaml
+++ b/calliope/config/defaults.yaml
@@ -111,7 +111,7 @@ tech_groups:
             resource_unit: energy
     transmission:
         required_constraints: []
-        allowed_constraints: ['energy_cap_equals', 'energy_cap_max', 'energy_cap_per_unit', 'energy_cap_scale', 'energy_con', 'energy_eff', 'energy_eff_per_distance', 'energy_prod', 'force_asynchronous_prod_con', 'lifetime', 'one_way']
+        allowed_constraints: ['energy_cap_equals', 'energy_cap_min', 'energy_cap_max', 'energy_cap_per_unit', 'energy_cap_scale', 'energy_con', 'energy_eff', 'energy_eff_per_distance', 'energy_prod', 'force_asynchronous_prod_con', 'lifetime', 'one_way']
         allowed_group_constraints: [cost_max, cost_min, cost_equals, cost_var_max, cost_var_min, cost_var_equals, cost_investment_min, cost_investment_max, cost_investment_equals, energy_cap_min, energy_cap_max, net_import_share_min, net_import_share_max, net_import_share_equals]
         allowed_costs: ['depreciation_rate', 'energy_cap', 'energy_cap_per_distance', 'interest_rate', 'om_annual', 'om_annual_investment_fraction', 'om_prod', 'purchase', 'purchase_per_distance']
         essentials:

--- a/changelog.rst
+++ b/changelog.rst
@@ -12,6 +12,8 @@ Release History
 
 |new| New model-wide constraints `net_import_share_min`, `net_import_share_max`, and `net_import_share_equals` which restrict the net imported energy of a certain carrier into subgroups of locations.
 
+|changed| Allowed 'energy_cap_min' for transmission technologies.
+
 |changed| Minor additions made to troubleshooting and development documentation.
 
 |changed| |backwards-incompatible| The backend interface to update a parameter value (`Model.backend.update_param()`) has been updated to allow multiple values in a parameter to be updated at once, using a dictionary.

--- a/changelog.rst
+++ b/changelog.rst
@@ -8,7 +8,7 @@ Release History
 
 |new| New model-wide constraints `supply_min` and `supply_max` which restrict the absolute energy produced by a subgroup of technologies and locations.
 
-|new| Introduced a `storage_dod` constraint, which allows to set a minimum stored-energy level to be preserved by a storage technology.
+|new| Introduced a `storage_discharge_depth` constraint, which allows to set a minimum stored-energy level to be preserved by a storage technology.
 
 |new| New model-wide constraints `net_import_share_min`, `net_import_share_max`, and `net_import_share_equals` which restrict the net imported energy of a certain carrier into subgroups of locations.
 


### PR DESCRIPTION
Fixes issue(s) #

Summary of changes in this pull request:

* Fixed investment costs appearing with confusing (and used-elsewhere) name
* Fixed changelog reporting outdated name for storage_discharge_depth
* Fixed transmission techs not allowing 'energy_cap_min' without a reason 

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [x] Changelog updated
- [x] Coverage maintained or improved