### PR TITLE
Updates for Python 3.8 compatibility

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -16,13 +16,16 @@ strategy:
     linux-py3.7:
       IMAGE_NAME: ubuntu-latest
       PYTHON_VERSION: 3.7
+    linux-py3.8:
+      IMAGE_NAME: ubuntu-latest
+      PYTHON_VERSION: 3.8
       CODECOV: True  # Only run on one build
-    macos-py3.7:
+    macos-py3.8:
       IMAGE_NAME: macOS-latest
-      PYTHON_VERSION: 3.7
-    windows-py3.7:
+      PYTHON_VERSION: 3.8
+    windows-py3.8:
       IMAGE_NAME: windows-latest
-      PYTHON_VERSION: 3.7
+      PYTHON_VERSION: 3.8
 
 steps:
   - bash: echo "##vso[task.prependpath]$CONDA/bin"

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -53,7 +53,7 @@ steps:
       python utils/conda_create.py requirements/base.yml requirements/unix.yml --python_version=$(PYTHON_VERSION) --channels conda-forge defaults --run
       source activate calliope
       pip install --no-cache-dir --verbose -e .
-      py.test --junitxml=junit/test-results.xml --cov=calliope --cov-report=term-missing --cov-report=xml -W ignore::FutureWarning
+      py.test -n 2 --junitxml=junit/test-results.xml --cov=calliope --cov-report=term-missing --cov-report=xml -W ignore::FutureWarning
     displayName: Set up environment and run tests (UNIX)
     condition: ne( variables['Agent.OS'], 'Windows_NT' )
 
@@ -65,7 +65,7 @@ steps:
       python utils/conda_create.py requirements/base.yml --python_version=$(PYTHON_VERSION) --channels conda-forge defaults --run
       call activate calliope
       pip install --no-cache-dir --verbose -e .
-      py.test --junitxml=junit/test-results.xml --cov=calliope --cov-report=term-missing --cov-report=xml -W ignore::FutureWarning
+      py.test -n 2 --junitxml=junit/test-results.xml --cov=calliope --cov-report=term-missing --cov-report=xml -W ignore::FutureWarning
     displayName: Set up environment and run tests (Windows)
     condition: eq( variables['Agent.OS'], 'Windows_NT' )
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -10,9 +10,6 @@ pool:
 strategy:
   maxParallel: 8
   matrix:
-    linux-py3.6:
-      IMAGE_NAME: ubuntu-latest
-      PYTHON_VERSION: 3.6
     linux-py3.7:
       IMAGE_NAME: ubuntu-latest
       PYTHON_VERSION: 3.7

--- a/calliope/analysis/postprocess.py
+++ b/calliope/analysis/postprocess.py
@@ -208,7 +208,7 @@ def clean_results(results, zero_threshold, timings):
             results.get('unmet_demand', 0) + results.get('unused_supply', 0)
         )
 
-        results = results.drop('unused_supply')
+        results = results.drop_vars('unused_supply')
 
         if not results.unmet_demand.sum():
 
@@ -216,6 +216,6 @@ def clean_results(results, zero_threshold, timings):
                 logger, timings, 'delete_unmet_demand',
                 comment='Postprocessing: Model was feasible, deleting unmet_demand variable'
             )
-            results = results.drop('unmet_demand')
+            results = results.drop_vars('unmet_demand')
 
     return results

--- a/calliope/core/time/funcs.py
+++ b/calliope/core/time/funcs.py
@@ -109,7 +109,7 @@ def _drop_timestep_vars(data, timesteps):
     if timesteps is not None:
         timeseries_data = timeseries_data.loc[{'timesteps': timesteps}]
 
-    timeseries_data = timeseries_data.drop([
+    timeseries_data = timeseries_data.drop_vars([
         varname for varname, vardata in data.data_vars.items()
         if 'timesteps' not in vardata.dims
     ])
@@ -159,7 +159,7 @@ def apply_clustering(data, timesteps, clustering_func, how, normalize=True,
     # and get all coordinates of the original dataset, to reinstate later
     data_to_cluster, data_coords = _drop_timestep_vars(data, timesteps)
 
-    data_to_cluster = data_to_cluster.drop(['timestep_weights', 'timestep_resolution'])
+    data_to_cluster = data_to_cluster.drop_vars(['timestep_weights', 'timestep_resolution'])
 
     for dim in data_to_cluster.dims:
         data_to_cluster[dim] = data[dim]
@@ -231,7 +231,7 @@ def apply_clustering(data, timesteps, clustering_func, how, normalize=True,
 
     if timesteps is not None:
         data_new = _copy_non_t_vars(data, data_new)
-        data_new = _combine_datasets(data.drop(timesteps, dim='timesteps'), data_new)
+        data_new = _combine_datasets(data.drop_sel(timesteps=timesteps), data_new)
         data_new = _copy_non_t_vars(data, data_new)
 
 
@@ -298,7 +298,7 @@ def resample(data, timesteps, resolution):
                     'float is expected for timeseries resampling.'
                     .format(var, data_rs[var].dtype)
                 )
-                data_rs = data_rs.drop(var)
+                data_rs = data_rs.drop_vars(var)
 
     # Get rid of the filled-in NaN timestamps
     data_rs = data_rs.dropna(dim='timesteps', how='all')
@@ -313,7 +313,7 @@ def resample(data, timesteps, resolution):
 
     if timesteps is not None:
         # Combine leftover parts of passed in data with new data
-        data_rs = _combine_datasets(data.drop(timesteps, dim='timesteps'), data_rs)
+        data_rs = _combine_datasets(data.drop_sel(timesteps=timesteps), data_rs)
         data_rs = _copy_non_t_vars(data, data_rs)
         # Having timesteps with different lengths does not permit operational mode
         data_rs.attrs['allow_operate_mode'] = 0
@@ -347,7 +347,7 @@ def drop(data, timesteps):
     # 'Distribute weight' of the dropped timesteps onto the remaining ones
     dropped_weight = data.timestep_weights.loc[{'timesteps': timesteps_pd}].sum()
 
-    data = data.drop(timesteps_pd, dim='timesteps')
+    data = data.drop_sel(timesteps=timesteps_pd)
 
     data['timestep_weights'] = data['timestep_weights'] + (dropped_weight / len(data['timestep_weights']))
 

--- a/calliope/core/util/observed_dict.py
+++ b/calliope/core/util/observed_dict.py
@@ -5,7 +5,7 @@ Licensed under the Apache 2.0 License (see LICENSE file).
 
 """
 
-from collections import Mapping
+from collections.abc import Mapping
 from calliope.core.attrdict import AttrDict
 
 

--- a/calliope/test/test_analysis.py
+++ b/calliope/test/test_analysis.py
@@ -41,7 +41,7 @@ class TestPlotting:
 
         # Testing that the model can handle not having supply_plus technologies
         # Wrapped in temporary directory as we can't stop it saving an HTML file
-        model._model_data = model._model_data.drop('resource_con')
+        model._model_data = model._model_data.drop_vars('resource_con')
         with tempfile.TemporaryDirectory() as tempdir:
             out_path = os.path.join(tempdir, 'test_plot.html')
             model.plot.timeseries(
@@ -63,7 +63,7 @@ class TestPlotting:
 
         # Testing that the model catches an expected error on the model not
         # defining coordinates
-        model._model_data = model._model_data.drop('loc_coordinates')
+        model._model_data = model._model_data.drop_vars('loc_coordinates')
         with pytest.raises(ValueError) as error:
             model.plot.flows()
             model.plot.transmission()

--- a/calliope/test/test_core_attrdict.py
+++ b/calliope/test/test_core_attrdict.py
@@ -99,7 +99,7 @@ class TestAttrDict:
 
     def test_from_yaml_string_dot_strings_duplicate(self):
         yaml_string = 'a.b.c: 1\na.b.c: 2'
-        with pytest.warns(ruamel_yaml.constructor.DuplicateKeyFutureWarning):
+        with pytest.raises(ruamel_yaml.constructor.DuplicateKeyError):
             AttrDict.from_yaml_string(yaml_string)
 
     def test_simple_invalid_yaml(self):

--- a/calliope/test/test_example_models.py
+++ b/calliope/test/test_example_models.py
@@ -210,48 +210,48 @@ class TestNationalScaleClusteredExampleModelSenseChecks:
     def example_tester_closest(self, solver='cbc', solver_io=None):
         model = self.model_runner(solver=solver, solver_io=solver_io, how='closest')
         # Full 1-hourly model run: 22312488.670967
-        assert float(model.results.cost.sum()) == approx(51711873.203096)
+        assert float(model.results.cost.sum()) == approx(49670627.15297682)
 
         # Full 1-hourly model run: 0.296973
         assert float(
             model.results.systemwide_levelised_cost.loc[{'carriers': 'power', 'techs': 'battery'}].item()
-        ) == approx(0.111456, abs=0.000001)
+        ) == approx(0.137105, abs=0.000001)
 
         # Full 1-hourly model run: 0.064362
         assert float(
             model.results.systemwide_capacity_factor.loc[{'carriers': 'power', 'techs': 'battery'}].item()
-        ) == approx(0.074809, abs=0.000001)
+        ) == approx(0.064501, abs=0.000001)
 
     def example_tester_mean(self, solver='cbc', solver_io=None):
         model = self.model_runner(solver=solver, solver_io=solver_io, how='mean')
         # Full 1-hourly model run: 22312488.670967
-        assert float(model.results.cost.sum()) == approx(45110415.5627)
+        assert float(model.results.cost.sum()) == approx(22172253.328)
 
         # Full 1-hourly model run: 0.296973
         assert float(
             model.results.systemwide_levelised_cost.loc[{'carriers': 'power', 'techs': 'battery'}].item()
-        ) == approx(0.126099, abs=0.000001)
+        ) == approx(0.127783, abs=0.000001)
 
         # Full 1-hourly model run: 0.064362
         assert float(
             model.results.systemwide_capacity_factor.loc[dict(carriers='power')].to_pandas().T['battery']
-        ) == approx(0.047596, abs=0.000001)
+        ) == approx(0.044458, abs=0.000001)
 
     def example_tester_storage_inter_cluster(self):
         model = self.model_runner(storage_inter_cluster=True)
 
         # Full 1-hourly model run: 22312488.670967
-        assert float(model.results.cost.sum()) == approx(33353390.222036)
+        assert float(model.results.cost.sum()) == approx(21825515.304)
 
         # Full 1-hourly model run: 0.296973
         assert float(
             model.results.systemwide_levelised_cost.loc[{'carriers': 'power', 'techs': 'battery'}].item()
-        ) == approx(0.115866, abs=0.000001)
+        ) == approx(0.100760, abs=0.000001)
 
         # Full 1-hourly model run: 0.064362
         assert float(
             model.results.systemwide_capacity_factor.loc[{'carriers': 'power', 'techs': 'battery'}].item()
-        ) == approx(0.074167, abs=0.000001)
+        ) == approx(0.091036, abs=0.000001)
 
     def test_nationalscale_clustered_example_closest_results_cbc(self):
         self.example_tester_closest()
@@ -278,17 +278,17 @@ class TestNationalScaleClusteredExampleModelSenseChecks:
     def test_storage_inter_cluster_cyclic(self):
         model = self.model_runner(storage_inter_cluster=True, cyclic=True)
         # Full 1-hourly model run: 22312488.670967
-        assert float(model.results.cost.sum()) == approx(18838244.087694)
+        assert float(model.results.cost.sum()) == approx(18904055.722)
 
         # Full 1-hourly model run: 0.296973
         assert float(
             model.results.systemwide_levelised_cost.loc[{'carriers': 'power', 'techs': 'battery'}].item()
-        ) == approx(0.133111, abs=0.000001)
+        ) == approx(0.122564, abs=0.000001)
 
         # Full 1-hourly model run: 0.064362
         assert float(
             model.results.systemwide_capacity_factor.loc[{'carriers': 'power', 'techs': 'battery'}].item()
-        ) == approx(0.071411, abs=0.000001)
+        ) == approx(0.075145, abs=0.000001)
 
     def test_storage_inter_cluster_no_storage(self):
         with pytest.warns(calliope.exceptions.ModelWarning) as excinfo:

--- a/changelog.rst
+++ b/changelog.rst
@@ -40,6 +40,8 @@ Release History
 
 |fixed| Fix an issue that prevented 0.6.4 from loading NetCDF models saved with older versions of Calliope. It is still recommended to only load models with the same version of Calliope that they were saved with, as not all functionality will work when mixing versions.
 
+|fixed| Updated to require pandas 0.25, xarray 0.14, and scikit-learn 0.22, and verified Python 3.8 compatibility. Because of a bugfix in scikit-learn 0.22, models using k-means clustering with a specified random seed may return different clusters from Calliope 0.6.5 on.
+
 0.6.4 (2019-05-27)
 ------------------
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -40,7 +40,7 @@ Release History
 
 |fixed| Fix an issue that prevented 0.6.4 from loading NetCDF models saved with older versions of Calliope. It is still recommended to only load models with the same version of Calliope that they were saved with, as not all functionality will work when mixing versions.
 
-|fixed| Updated to require pandas 0.25, xarray 0.14, and scikit-learn 0.22, and verified Python 3.8 compatibility. Because of a bugfix in scikit-learn 0.22, models using k-means clustering with a specified random seed may return different clusters from Calliope 0.6.5 on.
+|fixed| |backwards-incompatible| Updated to require pandas 0.25, xarray 0.14, and scikit-learn 0.22, and verified Python 3.8 compatibility. Because of a bugfix in scikit-learn 0.22, models using k-means clustering with a specified random seed may return different clusters from Calliope 0.6.5 on.
 
 0.6.4 (2019-05-27)
 ------------------

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    patch: off
+
+comment:
+  layout: "diff, flags, files"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
 filterwarnings =
+    ignore:.*inspect.getargspec\(\) is deprecated.*:DeprecationWarning:pyomo
     ignore:.*`group_share` constraints will be removed in v0.7.0.*:FutureWarning:
     ignore:.*There will be no default cost class for the objective function in v0.7.0.*:FutureWarning:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
 filterwarnings =
-    ignore:.*inspect.getargspec\(\) is deprecated.*:DeprecationWarning:pyomo
     ignore:.*`group_share` constraints will be removed in v0.7.0.*:FutureWarning:
     ignore:.*There will be no default cost class for the objective function in v0.7.0.*:FutureWarning:

--- a/requirements/base.yml
+++ b/requirements/base.yml
@@ -16,12 +16,12 @@ dependencies:
     - netcdf4
     - numexpr
     - numpy
-    - pandas<0.26
+    - pandas=0.25
     - plotly<4.0
-    - pyomo<5.7
-    - pytest<5.3  # 5.3 fails with KeyError: '__name__' when collecting items
+    - pyomo=5.6
+    - pytest=5.2  # 5.3 fails with KeyError: '__name__' when collecting items
     - pytest-cov
     - pytest-xdist  # pytest distributed testing plugin
-    - ruamel.yaml<0.17
-    - scikit-learn<0.23
-    - xarray<0.15
+    - ruamel.yaml=0.16
+    - scikit-learn
+    - xarray=0.14

--- a/requirements/base.yml
+++ b/requirements/base.yml
@@ -5,7 +5,7 @@ channels:
 
 dependencies:
     - bottleneck
-    - click<8
+    - click
     - glpk=4.61
     - hdf5
     - ipython
@@ -16,11 +16,12 @@ dependencies:
     - netcdf4
     - numexpr
     - numpy
-    - pandas<0.25
+    - pandas<0.26
     - plotly<4.0
     - pyomo<5.7
     - pytest<5.3  # 5.3 fails with KeyError: '__name__' when collecting items
     - pytest-cov
-    - ruamel.yaml<0.16
-    - scikit-learn<0.21
-    - xarray<0.13
+    - pytest-xdist  # pytest distributed testing plugin
+    - ruamel.yaml<0.17
+    - scikit-learn<0.23
+    - xarray<0.15

--- a/requirements/dev_tools.yml
+++ b/requirements/dev_tools.yml
@@ -8,7 +8,6 @@ dependencies:
     - line_profiler
     - memory_profiler
     - pylint
-    - pytest-xdist  # pytest distributed testing plugin
     - snakeviz
     - twine
     - pip:

--- a/setup.py
+++ b/setup.py
@@ -56,12 +56,12 @@ setup(
         "netcdf4 >= 1.2.2",
         "numexpr >= 2.3.1",
         "numpy >= 1.15",
-        "pandas >= 0.24, < 0.25",
+        "pandas >= 0.25, < 0.26",
         "plotly >= 3.3, < 4.0",
         "pyomo >= 5.6, < 5.7",
-        "ruamel.yaml >= 0.15.71, < 0.16",
-        "scikit-learn >= 0.20, < 0.21",
-        "xarray >= 0.12, < 0.13",
+        "ruamel.yaml >= 0.16",
+        "scikit-learn >= 0.22",
+        "xarray >= 0.14, < 0.15",
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Updates for Python 3.8 compatibility

Summary of changes in this pull request:

* Update dependencies for Python 3.8 on conda-forge
* Move pytest-xdist to base requirements and parallelise tests on Azure
* Requires changes to clustering example model tests due to a [fix in scikit-learn 0.22](https://scikit-learn.org/stable/whats_new/v0.22.html#sklearn-cluster) changing the behaviour of kmeans with a given random seed

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved