### PR TITLE
Fix pyomo param domain warnings

### DIFF
--- a/calliope/backend/checks.py
+++ b/calliope/backend/checks.py
@@ -61,6 +61,11 @@ def check_operate_params(model_data):
             return False
 
     def _set_inf_and_warn(loc_tech, var, warnings, warning_text):
+        if model_data[var].dtype == int:
+            # int -> float to have a correctly defined inf
+            _attrs = model_data[var].attrs
+            model_data[var] = model_data[var].astype(float)
+            model_data[var].attrs = _attrs
         if np.isinf(model_data[var].loc[loc_tech].item()):
             return (np.inf, warnings)
         elif model_data[var].loc[loc_tech].isnull().item():

--- a/calliope/backend/checks.py
+++ b/calliope/backend/checks.py
@@ -61,11 +61,11 @@ def check_operate_params(model_data):
             return False
 
     def _set_inf_and_warn(loc_tech, var, warnings, warning_text):
-        if model_data[var].dtype == int:
-            # int -> float to have a correctly defined inf
-            _attrs = model_data[var].attrs
-            model_data[var] = model_data[var].astype(float)
-            model_data[var].attrs = _attrs
+        # inf will only work on float dtypes
+        # astype doesn't retain attributes: https://github.com/pydata/xarray/issues/2049
+        _attrs = model_data[var].attrs
+        model_data[var] = model_data[var].astype(float)
+        model_data[var].attrs = _attrs
         if np.isinf(model_data[var].loc[loc_tech].item()):
             return (np.inf, warnings)
         elif model_data[var].loc[loc_tech].isnull().item():

--- a/calliope/backend/pyomo/constraints/group.py
+++ b/calliope/backend/pyomo/constraints/group.py
@@ -14,7 +14,7 @@ import logging
 import numpy as np
 import pyomo.core as po  # pylint: disable=import-error
 
-from calliope.backend.pyomo.util import loc_tech_is_in, get_param
+from calliope.backend.pyomo.util import loc_tech_is_in, get_param, check_value
 
 logger = logging.getLogger(__name__)
 
@@ -256,7 +256,7 @@ def demand_share_constraint_rule(backend_model, group_name, carrier, what):
         backend_model, "group_demand_share_{}".format(what), (carrier, group_name)
     )
 
-    if share is None:
+    if check_value(share):
         return return_noconstraint("demand_share", group_name)
     else:
         (
@@ -308,7 +308,7 @@ def demand_share_per_timestep_constraint_rule(
         (carrier, group_name),
     )
 
-    if share is None:
+    if check_value(share):
         return return_noconstraint("demand_share_per_timestep", group_name)
     else:
         (
@@ -367,7 +367,7 @@ def demand_share_per_timestep_decision_main_constraint_rule(
         backend_model, "group_demand_share_per_timestep_decision", (carrier, group_name)
     )
 
-    if share_of_carrier_demand is None:
+    if check_value(share_of_carrier_demand):
         return return_noconstraint(
             "demand_share_per_timestep_decision_main", group_name
         )
@@ -439,7 +439,7 @@ def demand_share_per_timestep_decision_sum_constraint_rule(
     )
 
     # If inf was given that means that we don't limit the total share
-    if share_of_carrier_demand is None or np.isinf(share_of_carrier_demand):
+    if check_value(share_of_carrier_demand) or np.isinf(share_of_carrier_demand):
         return return_noconstraint("demand_share_per_timestep_decision_sum", group_name)
     else:
         lhs_loc_tech_carriers, _ = get_demand_share_lhs_and_rhs_loc_tech_carriers(
@@ -486,7 +486,7 @@ def carrier_prod_share_constraint_rule(backend_model, constraint_group, carrier,
         (carrier, constraint_group),
     )
 
-    if share is None:
+    if check_value(share):
         return return_noconstraint("supply_share", constraint_group)
     else:
         lhs_loc_techs, rhs_loc_techs = get_carrier_prod_share_lhs_and_rhs_loc_techs(
@@ -530,7 +530,7 @@ def carrier_prod_share_per_timestep_constraint_rule(
         (carrier, constraint_group),
     )
 
-    if share is None:
+    if check_value(share):
         return return_noconstraint("carrier_prod_share_per_timestep", constraint_group)
     else:
         lhs_loc_techs, rhs_loc_techs = get_carrier_prod_share_lhs_and_rhs_loc_techs(
@@ -571,7 +571,7 @@ def net_import_share_constraint_rule(backend_model, constraint_group, carrier, w
         (carrier, constraint_group),
     )
 
-    if share.value is None:
+    if check_value(share):
         return return_noconstraint("net_import_share", constraint_group)
     else:
         trans_loc_tech = getattr(
@@ -619,7 +619,7 @@ def carrier_prod_constraint_rule(backend_model, constraint_group, carrier, what)
         backend_model, "group_carrier_prod_{}".format(what), (carrier, constraint_group)
     )
 
-    if limit is None:
+    if check_value(limit):
         return return_noconstraint("carrier_prod", constraint_group)
     else:
         # We won't actually use the rhs techs
@@ -653,7 +653,7 @@ def energy_cap_share_constraint_rule(backend_model, constraint_group, what):
         backend_model, "group_energy_cap_share_{}".format(what), (constraint_group)
     )
 
-    if share is None:
+    if check_value(share):
         return return_noconstraint("energy_cap_share", constraint_group)
     else:
         lhs_loc_techs = getattr(
@@ -692,7 +692,7 @@ def energy_cap_constraint_rule(backend_model, constraint_group, what):
         backend_model, "group_energy_cap_{}".format(what), (constraint_group)
     )
 
-    if threshold is None:
+    if check_value(threshold):
         return return_noconstraint("energy_cap", constraint_group)
     else:
         lhs_loc_techs = getattr(
@@ -737,7 +737,7 @@ def cost_cap_constraint_rule(backend_model, group_name, cost, what):
         backend_model, "group_cost_{}".format(what), (cost, group_name)
     )
 
-    if cost_cap is None:
+    if check_value(cost_cap):
         return return_noconstraint("cost_cap", group_name)
     else:
         loc_techs = [
@@ -776,7 +776,7 @@ def cost_investment_cap_constraint_rule(backend_model, group_name, cost, what):
         backend_model, "group_cost_investment_{}".format(what), (cost, group_name)
     )
 
-    if cost_cap is None:
+    if check_value(cost_cap):
         return return_noconstraint("cost_investment_cap", group_name)
     else:
         loc_techs = [
@@ -817,7 +817,7 @@ def cost_var_cap_constraint_rule(backend_model, group_name, cost, what):
         backend_model, "group_cost_var_{}".format(what), (cost, group_name)
     )
 
-    if cost_cap is None:
+    if check_value(cost_cap):
         return return_noconstraint("cost_var_cap", group_name)
     else:
         loc_techs = [
@@ -855,7 +855,7 @@ def resource_area_constraint_rule(backend_model, constraint_group, what):
         backend_model, "group_resource_area_{}".format(what), (constraint_group)
     )
 
-    if threshold is None:
+    if check_value(threshold):
         return return_noconstraint("resource_area", constraint_group)
     else:
         lhs_loc_techs = getattr(

--- a/calliope/backend/pyomo/interface.py
+++ b/calliope/backend/pyomo/interface.py
@@ -68,11 +68,6 @@ def update_pyomo_param(backend_model, param, update_dict):
         raise TypeError("`update_dict` must be a dictionary")
 
     else:
-        print(
-            "Warning: we currently do not check that the updated value is the "
-            "correct data type for this Pyomo Parameter, this is your "
-            "responsibility to check!"
-        )
         getattr(backend_model, param).store_values(update_dict)
 
 

--- a/calliope/backend/pyomo/model.py
+++ b/calliope/backend/pyomo/model.py
@@ -21,7 +21,7 @@ import pyomo.environ  # pylint: disable=unused-import,import-error
 # TempfileManager is required to set log directory
 from pyutilib.services import TempfileManager  # pylint: disable=import-error
 
-from calliope.backend.pyomo.util import get_var
+from calliope.backend.pyomo.util import get_var, get_domain
 from calliope.backend.pyomo import constraints
 from calliope.core.util.tools import load_function
 from calliope.core.util.logging import LogWriter
@@ -62,6 +62,7 @@ def generate_model(model_data):
         "sets": list(model_data.coords),
         "attrs": {k: v for k, v in model_data.attrs.items() if k != "defaults"},
     }
+
     # Dims in the dict's keys are ordered as in model_data, which is enforced
     # in model_data generation such that timesteps are always last and the
     # remainder of dims are in alphabetic order
@@ -74,42 +75,23 @@ def generate_model(model_data):
     )
 
     for k, v in model_data_dict["data"].items():
-        if k in backend_model.__calliope_defaults.keys():
-            setattr(
-                backend_model,
-                k,
-                po.Param(
-                    *[getattr(backend_model, i) for i in model_data_dict["dims"][k]],
-                    initialize=v,
-                    mutable=True,
-                    default=backend_model.__calliope_defaults[k],
-                ),
-            )
+        _kwargs = {
+            "initialize": v,
+            "mutable": True,
+            "within": getattr(po, get_domain(model_data[k])),
+        }
+        if not pd.isnull(backend_model.__calliope_defaults.get(k, None)):
+            _kwargs["default"] = backend_model.__calliope_defaults[k]
         # In operate mode, e.g. energy_cap is a parameter, not a decision variable,
         # so add those in.
-        elif (
+        if (
             backend_model.__calliope_run_config["mode"] == "operate"
             and model_data[k].attrs.get("operate_param") == 1
         ):
-            setattr(
-                backend_model,
-                k,
-                po.Param(
-                    getattr(backend_model, model_data_dict["dims"][k][0]),
-                    initialize=v,
-                    mutable=True,
-                ),
-            )
-        else:  # no default value to look up
-            setattr(
-                backend_model,
-                k,
-                po.Param(
-                    *[getattr(backend_model, i) for i in model_data_dict["dims"][k]],
-                    initialize=v,
-                    mutable=True,
-                ),
-            )
+            dims = [getattr(backend_model, model_data_dict["dims"][k][0])]
+        else:
+            dims = [getattr(backend_model, i) for i in model_data_dict["dims"][k]]
+        setattr(backend_model, k, po.Param(*dims, **_kwargs))
 
     for option_name, option_val in backend_model.__calliope_run_config[
         "objective_options"
@@ -120,7 +102,10 @@ def generate_model(model_data):
             }
 
             backend_model.objective_cost_class = po.Param(
-                backend_model.costs, initialize=objective_cost_class, mutable=True
+                backend_model.costs,
+                initialize=objective_cost_class,
+                mutable=True,
+                within=po.Reals,
             )
         else:
             setattr(backend_model, "objective_" + option_name, option_val)

--- a/calliope/backend/pyomo/util.py
+++ b/calliope/backend/pyomo/util.py
@@ -8,7 +8,9 @@ import logging
 
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_numeric_dtype
 import xarray as xr
+import pyomo.core as po
 
 from calliope.core.util.tools import memoize
 from calliope import exceptions
@@ -199,3 +201,22 @@ def loc_tech_is_in(backend_model, loc_tech, model_set):
         return True
     else:
         return False
+
+
+def get_domain(var: xr.DataArray) -> str:
+    def check_sign(var):
+        if "cost" in var.name or var.name in ["resource", "loc_coordinates"]:
+            return ""
+        else:
+            return "NonNegative"
+
+    if var.dtype == bool:
+        return "Boolean"
+    elif is_numeric_dtype(var.dtype):
+        return check_sign(var) + "Reals"
+    else:
+        return "Any"
+
+
+def check_value(val: po.base.param._ParamData) -> bool:
+    return val._value == po.base.param._NotValid or po.value(val) is None

--- a/calliope/backend/pyomo/util.py
+++ b/calliope/backend/pyomo/util.py
@@ -5,6 +5,7 @@ Licensed under the Apache 2.0 License (see LICENSE file).
 """
 
 import logging
+import re
 
 import numpy as np
 import pandas as pd
@@ -205,12 +206,12 @@ def loc_tech_is_in(backend_model, loc_tech, model_set):
 
 def get_domain(var: xr.DataArray) -> str:
     def check_sign(var):
-        if "cost" in var.name or var.name in ["resource", "loc_coordinates"]:
+        if re.match("resource|loc_coordinates|cost*", var.name):
             return ""
         else:
             return "NonNegative"
 
-    if var.dtype == bool:
+    if var.dtype.kind == "b":
         return "Boolean"
     elif is_numeric_dtype(var.dtype):
         return check_sign(var) + "Reals"

--- a/calliope/config/defaults.yaml
+++ b/calliope/config/defaults.yaml
@@ -138,7 +138,7 @@ techs:
             primary_carrier_in: false  # Selects the primary input carrier to associate with costs & constraints (if multiple primary input carriers are assigned)
             primary_carrier_out: false  # Selects the primary output carrier to associate with costs & constraints (if multiple primary output carriers are assigned)
         constraints:
-            carrier_ratios: {}  # name: Carrier ratios ¦ unit: fraction ¦ Ratio of summed output of carriers in ['out_2', 'out_3'] / ['in_2', 'in_3'] to the summed output of carriers in 'out' / 'in'. given in a nested dictionary.
+            carrier_ratios: false  # name: Carrier ratios ¦ unit: fraction ¦ Ratio of summed output of carriers in ['out_2', 'out_3'] / ['in_2', 'in_3'] to the summed output of carriers in 'out' / 'in'. given in a nested dictionary.
             charge_rate: false # name: Charge rate ¦ unit: hour :sup:`-1` ¦ (do not use, replaced by energy_cap_per_storage_cap_max) ratio of maximum charge/discharge (kW) for a given maximum storage capacity (kWh).
             energy_cap_per_storage_cap_min: false # name: Minimum energy capacity per storage capacity ¦ unit: hour :sup:`-1` ¦ ratio of minimum charge/discharge (kW) for a given storage capacity (kWh).
             energy_cap_per_storage_cap_max: false # name: Maximum energy capacity per storage capacity ¦ unit: hour :sup:`-1` ¦ ratio of maximum charge/discharge (kW) for a given storage capacity (kWh).
@@ -160,7 +160,7 @@ techs:
             export_carrier: null  # name: Export carrier ¦ unit: N/A ¦ Name of carrier to be exported. Must be an output carrier of the technology
             force_asynchronous_prod_con: false  # name: Force asynchronous production consumption ¦ unit: boolean ¦ If True, carrier_prod and carrier_con cannot both occur in the same timestep
             force_resource: false  # name: Force resource ¦ unit: boolean ¦ Forces this technology to use all available ``resource``, rather than making it a maximum upper boundary (for production) or minimum lower boundary (for consumption). Static boolean, or from file as timeseries
-            lifetime: null  # name: Technology lifetime ¦ unit: years ¦ Must be defined if fixed capital costs are defined. A reasonable value for many technologies is around 20-25 years. 
+            lifetime: null  # name: Technology lifetime ¦ unit: years ¦ Must be defined if fixed capital costs are defined. A reasonable value for many technologies is around 20-25 years.
             one_way: false  # name: One way ¦ unit: boolean ¦ Forces a transmission technology to only move energy in one direction on the link, in this case from `default_location_from` to `default_location_to`
             parasitic_eff: 1.0  # name: Plant parasitic efficiency ¦ unit: fraction ¦ Additional losses as energy gets transferred from the plant to the carrier (static, or from file as timeseries), e.g. due to plant parasitic consumption
             resource: 0  # name: Available resource ¦ unit: kWh | kWh/m\ :sup:`2` | kWh/kW ¦ Maximum available resource (static, or from file as timeseries). Unit dictated by ``resource_unit``

--- a/calliope/test/test_backend_pyomo_util.py
+++ b/calliope/test/test_backend_pyomo_util.py
@@ -1,0 +1,110 @@
+import pytest  # pylint: disable=unused-import
+
+import pyomo.core as po
+
+from calliope.test.common.util import build_test_model as build_model
+from calliope.backend.pyomo.util import get_domain, get_param, check_value
+
+
+@pytest.fixture(scope="class")
+def model():
+    return build_model({}, "simple_supply,two_hours,investment_costs")
+
+
+class TestGetParam:
+    def test_get_param_with_timestep_existing(self):
+        """
+        """
+        m = build_model({}, "simple_supply,two_hours,investment_costs")
+        m.run()
+        param = get_param(
+            m._backend_model,
+            "resource",
+            ("1::test_demand_elec", m._backend_model.timesteps[1]),
+        )
+        assert po.value(param) == -5  # see demand_elec.csv
+
+    def test_get_param_no_timestep_existing(self):
+        """
+        """
+        m = build_model({}, "simple_supply,two_hours,investment_costs")
+        m.run()
+        param = get_param(
+            m._backend_model,
+            "energy_eff",
+            ("1::test_supply_elec", m._backend_model.timesteps[1]),
+        )
+        assert po.value(param) == 0.9  # see test model.yaml
+
+    def test_get_param_no_timestep_possible(self):
+        """
+        """
+        m = build_model({}, "simple_supply,two_hours,investment_costs")
+        m.run()
+        param = get_param(m._backend_model, "energy_cap_max", ("1::test_supply_elec"))
+        assert po.value(param) == 10  # see test model.yaml
+
+        param = get_param(
+            m._backend_model, "cost_energy_cap", ("monetary", "0::test_supply_elec")
+        )
+        assert po.value(param) == 10
+
+    def test_get_param_from_default(self):
+        """
+        """
+        m = build_model({}, "simple_supply_and_supply_plus,two_hours,investment_costs")
+        m.run()
+
+        param = get_param(
+            m._backend_model,
+            "parasitic_eff",
+            ("1::test_supply_plus", m._backend_model.timesteps[1]),
+        )
+        assert po.value(param) == 1  # see defaults.yaml
+
+        param = get_param(m._backend_model, "resource_cap_min", ("0::test_supply_plus"))
+        assert po.value(param) == 0  # see defaults.yaml
+
+        param = get_param(
+            m._backend_model, "cost_resource_cap", ("monetary", "1::test_supply_plus")
+        )
+        assert po.value(param) == 0  # see defaults.yaml
+
+    def test_get_param_no_default_defined(self):
+        """
+        If a default is not defined, raise KeyError
+        """
+        m = build_model({}, "simple_supply,two_hours,investment_costs")
+        m.run()
+        with pytest.raises(KeyError):
+            get_param(
+                m._backend_model,
+                "random_param",
+                ("1::test_demand_elec", m._backend_model.timesteps[1]),
+            )
+            get_param(m._backend_model, "random_param", ("1::test_supply_elec"))
+
+
+class TestGetDomain:
+    @pytest.mark.parametrize(
+        "var, domain",
+        (
+            ("energy_cap_max", "NonNegativeReals"),
+            ("resource", "Reals"),
+            ("cost_energy_cap", "Reals"),
+            ("force_resource", "Boolean"),
+            ("names", "Any"),
+        ),
+    )
+    def test_dtypes(self, model, var, domain):
+        assert get_domain(model._model_data[var]) == domain
+
+
+class TestCheckValue:
+    def test_check_values(self):
+        pyomo_model = po.ConcreteModel()
+        pyomo_model.new_set = po.Set(initialize=['a', 'b'])
+        pyomo_model.new_param = po.Param(pyomo_model.new_set, initialize={'a': 1}, mutable=True, within=po.NonNegativeReals)
+
+        assert check_value(pyomo_model.new_param['a']) is False
+        assert check_value(pyomo_model.new_param['b']) is True

--- a/calliope/test/test_backend_pyomo_util.py
+++ b/calliope/test/test_backend_pyomo_util.py
@@ -103,8 +103,13 @@ class TestGetDomain:
 class TestCheckValue:
     def test_check_values(self):
         pyomo_model = po.ConcreteModel()
-        pyomo_model.new_set = po.Set(initialize=['a', 'b'])
-        pyomo_model.new_param = po.Param(pyomo_model.new_set, initialize={'a': 1}, mutable=True, within=po.NonNegativeReals)
+        pyomo_model.new_set = po.Set(initialize=["a", "b"])
+        pyomo_model.new_param = po.Param(
+            pyomo_model.new_set,
+            initialize={"a": 1},
+            mutable=True,
+            within=po.NonNegativeReals,
+        )
 
-        assert check_value(pyomo_model.new_param['a']) is False
-        assert check_value(pyomo_model.new_param['b']) is True
+        assert check_value(pyomo_model.new_param["a"]) is False
+        assert check_value(pyomo_model.new_param["b"]) is True

--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,8 @@ Release History
 0.6.6 (dev)
 -----------
 
+|changed| Parameters are assigned a domain in Pyomo based on their dtype in `model_data`
+
 |changed| |backwards-incompatible| Plotting is no longer part of Calliope itself, but in a separate module, calliope_plot. FIXME: documentation needs to be updated.
 
 |changed| Internal code reorganisation.


### PR DESCRIPTION
Fixes issue(s) #309 

Summary of changes in this pull request:

* Pyomo `Param`objects are assigned a domain based on the variable dtype in `model_data`
* Domains now make it difficult to use None and np.nan as default values, so I've cleaned that up slightly
* Fixed an issue where updating values to `np.inf` in operate checks leads to large negative integer values if the variable`model_data` dtype is `int`. Those variables instead get assigned a float type.

Reviewer checklist:

- [x] Test(s) added to cover contribution
~- [ ] Documentation updated~
- [x] Changelog updated
- [ ] Coverage maintained or improved