### PR TITLE
Fix silent override of nested dicts when parsing YAML

### DIFF
--- a/calliope/core/attrdict.py
+++ b/calliope/core/attrdict.py
@@ -217,7 +217,11 @@ class AttrDict(dict):
                 else:
                     raise KeyError("Cannot set nested key on non-dict key.")
         else:
-            self[key] = value
+            if key in self and isinstance(value, AttrDict):
+                for k, v in value.items():
+                    self[key].set_key(k, v)
+            else:
+                self[key] = value
 
     def get_key(self, key, default=_MISSING):
         """

--- a/calliope/preprocess/checks.py
+++ b/calliope/preprocess/checks.py
@@ -334,13 +334,6 @@ def check_initial(config_model):
             'use e.g. "{monetary: 1}", which gives the monetary cost class a weight '
             "of 1 in the objective, and ignores any other cost classes."
         )
-    elif len(_cost_class.keys()) == 0:
-        errors.append(
-            "No cost classes defined for use in the objective. "
-            'Expecting a dict of "{cost_class: weight}" for all cost classes '
-            "to be considered in the objective function."
-        )
-
     else:
         # This next check is only run if we have confirmed that cost_class is
         # a dict, as it errors otherwise

--- a/calliope/test/common/test_model/weighted_obj_func.yaml
+++ b/calliope/test/common/test_model/weighted_obj_func.yaml
@@ -71,8 +71,6 @@ locations:
 overrides:
     illegal_string_cost_class:
         run.objective_options.cost_class: 'monetary'
-    empty_cost_class:
-        run.objective_options.cost_class: {}
     emissions_objective_without_removing_monetary_default:
         run.objective_options.cost_class: {'emissions': 0.1}
     monetary_objective:

--- a/calliope/test/test_core_attrdict.py
+++ b/calliope/test/test_core_attrdict.py
@@ -115,6 +115,17 @@ class TestAttrDict:
             """
             )
 
+    def test_order_of_subdicts(self):
+        d = AttrDict.from_yaml_string(
+            """
+            A.B.C: 10
+            A.B:
+                E: 20
+        """
+        )
+        assert d.A.B.C == 10
+        assert d.A.B.E == 20
+
     def test_dot_access_first(self, attr_dict):
         d = attr_dict
         assert d.a == 1

--- a/calliope/test/test_core_preprocess.py
+++ b/calliope/test/test_core_preprocess.py
@@ -1412,16 +1412,6 @@ class TestChecks:
             exception, "`run.objective_options.cost_class` must be a dictionary."
         )
 
-    def test_fail_on_empty(self):
-        with pytest.raises(calliope.exceptions.ModelError) as exception:
-            build_model(
-                model_file="weighted_obj_func.yaml", scenario="empty_cost_class"
-            )
-
-        assert check_error_or_warning(
-            exception, "No cost classes defined for use in the objective."
-        )
-
     def test_warn_on_using_default(self):
         with pytest.warns(exceptions.ModelWarning) as warn:
             build_model(

--- a/changelog.rst
+++ b/changelog.rst
@@ -22,6 +22,8 @@ Release History
 
 |fixed| One-way transmission technologies can have `om` costs
 
+|fixed| Silent override of nested dicts when parsing YAML strings
+
 0.6.5 (2020-01-14)
 ------------------
 


### PR DESCRIPTION
Fixes issue(s) #300

Summary of changes in this pull request:

* Fix silent override of nested dicts when parsing YAML

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved