### PR TITLE
Fix conda environment creation statement

### DIFF
--- a/doc/user/develop.rst
+++ b/doc/user/develop.rst
@@ -30,7 +30,7 @@ Then install all development requirements for Calliope into a new environment, c
 
   .. code-block:: fishshell
 
-   $ conda env create -f requirements.yml -n calliope_dev
+   $ conda create -f requirements.yml -n calliope_dev
    $ conda activate calliope_dev
 
 Finally install Calliope itself as an editable installation with pip:


### PR DESCRIPTION
I think it should be `conda create` instead of `conda env create`; or at least, in my version of conda that's how it works. It doesn't work if I try to use the statement suggested in the documentation.

Fixes issue(s) #

Summary of changes in this pull request:

* just edited the documentation about how to install a developer version


Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved