### PR TITLE
Fix broken link to Jupyter notebooks

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -141,7 +141,7 @@ mathjax_path = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?
 
 numpydoc_show_class_members = False  # numpydoc: don't do autosummary
 
-nbviewer_url = "https://nbviewer.ipython.org/url/calliope.readthedocs.io/"
+nbviewer_url = "https://nbviewer.org/url/calliope.readthedocs.io/"
 
 extlinks = {"nbviewer_docs": (nbviewer_url + docs_base_url + "%s", None)}
 

--- a/requirements_docs.yml
+++ b/requirements_docs.yml
@@ -11,4 +11,4 @@ dependencies:
     - nbconvert  # To generate HTML files from example notebooks
     - pip
     - pip:
-        - "git+https://github.com/readthedocs/readthedocs-sphinx-search@master"
+        - "git+https://github.com/readthedocs/readthedocs-sphinx-search@main"

--- a/requirements_docs.yml
+++ b/requirements_docs.yml
@@ -5,7 +5,7 @@ channels:
 
 dependencies:
     - python=3.7  # https://docs.readthedocs.io/en/stable/config-file/v2.html#python-version
-    - sphinx=4.1.2
+    - sphinx=4.2
     - numpydoc
     - ruamel.yaml
     - nbconvert  # To generate HTML files from example notebooks


### PR DESCRIPTION
Removed the ".ipython" part of the link to the jupyter notebooks that was causing the issue.

Fixes issue(s) #

Summary of changes in this pull request:

* Modified the con.py file in the doc to fix the broken link
*
*

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved