### PR TITLE
Calculate costs when only `om_annual` defined

### DIFF
--- a/calliope/backend/pyomo/constraints/costs.py
+++ b/calliope/backend/pyomo/constraints/costs.py
@@ -16,6 +16,7 @@ from calliope.backend.pyomo.util import (
     get_timestep_weight,
     loc_tech_is_in,
     invalid,
+    get_depreciation_rate,
 )
 
 ORDER = 10  # order in which to invoke constraints relative to other constraint files
@@ -165,9 +166,7 @@ def cost_investment_constraint_rule(backend_model, cost, loc_tech):
     cost_om_annual = get_param(backend_model, "cost_om_annual", (cost, loc_tech))
 
     ts_weight = get_timestep_weight(backend_model)
-    depreciation_rate = model_data_dict["data"]["cost_depreciation_rate"].get(
-        (cost, loc_tech), 0
-    )
+    depreciation_rate = get_depreciation_rate(backend_model, (cost, loc_tech))
 
     cost_cap = (
         depreciation_rate

--- a/calliope/backend/pyomo/constraints/milp.py
+++ b/calliope/backend/pyomo/constraints/milp.py
@@ -19,6 +19,7 @@ from calliope.backend.pyomo.util import (
     split_comma_list,
     loc_tech_is_in,
     apply_equals,
+    get_depreciation_rate,
 )
 
 from calliope.backend.pyomo.constraints.capacity import get_capacity_constraint
@@ -558,12 +559,8 @@ def update_costs_investment_units_milp_constraint(backend_model, cost, loc_tech)
             \\times cost_{purchase}(cost, loc::tech) * timestep_{weight} * depreciation
             \\quad \\forall cost \\in costs, \\forall loc::tech \\in loc::techs_{cost_{investment}, milp}
     """
-    model_data_dict = backend_model.__calliope_model_data
     ts_weight = get_timestep_weight(backend_model)
-    depreciation_rate = model_data_dict["data"]["cost_depreciation_rate"][
-        (cost, loc_tech)
-    ]
-
+    depreciation_rate = get_depreciation_rate(backend_model, (cost, loc_tech))
     cost_purchase = get_param(backend_model, "cost_purchase", (cost, loc_tech))
     cost_of_purchase = (
         backend_model.units[loc_tech] * cost_purchase * ts_weight * depreciation_rate
@@ -590,11 +587,8 @@ def update_costs_investment_purchase_milp_constraint(backend_model, cost, loc_te
             \\quad \\forall cost \\in costs, \\forall loc::tech \\in loc::techs_{cost_{investment}, purchase}
 
     """
-    model_data_dict = backend_model.__calliope_model_data
     ts_weight = get_timestep_weight(backend_model)
-    depreciation_rate = model_data_dict["data"]["cost_depreciation_rate"][
-        (cost, loc_tech)
-    ]
+    depreciation_rate = get_depreciation_rate(backend_model, (cost, loc_tech))
 
     cost_purchase = get_param(backend_model, "cost_purchase", (cost, loc_tech))
     cost_of_purchase = (

--- a/calliope/backend/pyomo/util.py
+++ b/calliope/backend/pyomo/util.py
@@ -59,6 +59,15 @@ def get_previous_timestep(timesteps, timestep):
     return timesteps.at(timesteps.ord(timestep) - 1)
 
 
+def get_depreciation_rate(backend_model, idx):
+    """Safely extract depreciation rate data"""
+    depreciation_rates = getattr(backend_model, "cost_depreciation_rate", None)
+    if depreciation_rates is not None and idx in depreciation_rates.index_set():
+        return depreciation_rates[idx]
+    else:
+        return 1
+
+
 @memoize
 def get_loc_tech_carriers(backend_model, loc_carrier):
     """

--- a/calliope/preprocess/locations.py
+++ b/calliope/preprocess/locations.py
@@ -440,7 +440,7 @@ def check_costs_and_compute_depreciation_rates(
         plant_life = tech_config.constraints.get_key("lifetime", 0)
         interest = tech_config.costs[cost].get_key("interest_rate", None)
 
-        # Only need depreciation rate for technologies that have investment costs
+        # Only need depreciation rate for technologies that have non-annualised investment costs
         if any(
             any(j in i for j in ["_area", "_cap", "purchase"])
             for i in tech_config.costs[cost].keys()

--- a/calliope/preprocess/model_data.py
+++ b/calliope/preprocess/model_data.py
@@ -243,7 +243,10 @@ def costs_to_dataset(model_run):
         """
         return the set of loc_techs over which the given cost should be built
         """
-        if any(i in cost for i in ["_cap", "depreciation_rate", "purchase", "area"]):
+        if any(
+            i in cost
+            for i in ["_cap", "depreciation_rate", "purchase", "area", "om_annual"]
+        ):
             return "loc_techs_investment_cost"
         elif any(i in cost for i in ["om_", "export"]):
             return "loc_techs_om_cost"
@@ -545,6 +548,7 @@ def add_attributes(model_run):
                 "cost_{}".format(k): v
                 for k, v in default_tech_dict["costs"]["default_cost"].items()
             },
+            **{"cost_depreciation_rate": 1},  # we generate this parameter internally
             **default_location_dict,
             **default_group_constraint_dict,
         }

--- a/calliope/preprocess/sets.py
+++ b/calliope/preprocess/sets.py
@@ -447,7 +447,7 @@ def generate_loc_tech_sets(model_run, simple_sets):
         k
         for k in loc_techs_costs
         if any(
-            "_cap" in i or ".purchase" in i or "_area" in i
+            "_cap" in i or ".purchase" in i or "_area" in i or "om_annual" in i
             for i in loc_techs_config[k].costs.keys_nested()
         )
     )
@@ -455,7 +455,7 @@ def generate_loc_tech_sets(model_run, simple_sets):
         k
         for k in loc_techs_transmission_costs
         if any(
-            "_cap" in i or ".purchase" in i or "_area" in i
+            "_cap" in i or ".purchase" in i or "_area" in i or "om_annual" in i
             for i in loc_techs_transmission_config[k].costs.keys_nested()
         )
     )
@@ -465,13 +465,17 @@ def generate_loc_tech_sets(model_run, simple_sets):
         k
         for k in loc_techs_costs
         if any(
-            "om_" in i or "export" in i for i in loc_techs_config[k].costs.keys_nested()
+            ("om_" in i or "export" in i) and "om_annual" not in i
+            for i in loc_techs_config[k].costs.keys_nested()
         )
     )
     loc_techs_transmission_om_costs = set(
         k
         for k in loc_techs_transmission_costs
-        if any("om_" in i for i in loc_techs_transmission_config[k].costs.keys_nested())
+        if any(
+            "om_" in i and "om_annual" not in i
+            for i in loc_techs_transmission_config[k].costs.keys_nested()
+        )
     )
 
     # Any export costs

--- a/calliope/test/common/constraint_sets.yaml
+++ b/calliope/test/common/constraint_sets.yaml
@@ -36,7 +36,7 @@ model_urban: # checked
     loc_techs_carrier_production_max_conversion_plus_constraint: ['X1::chp']
     loc_techs_cost_constraint: ['N1::heat_pipes:X1', 'N1::heat_pipes:X2', 'N1::heat_pipes:X3', 'X1::chp', 'X1::heat_pipes:N1', 'X1::power_lines:X2', 'X1::power_lines:X3', 'X1::pv', 'X1::supply_gas', 'X1::supply_grid_power', 'X2::boiler', 'X2::heat_pipes:N1', 'X2::power_lines:X1', 'X2::pv', 'X2::supply_gas', 'X3::boiler', 'X3::heat_pipes:N1', 'X3::power_lines:X1', 'X3::pv', 'X3::supply_gas']
     loc_techs_cost_investment_constraint: ['N1::heat_pipes:X1', 'N1::heat_pipes:X2', 'N1::heat_pipes:X3', 'X1::chp', 'X1::heat_pipes:N1', 'X1::power_lines:X2', 'X1::power_lines:X3', 'X1::pv', 'X1::supply_gas', 'X1::supply_grid_power', 'X2::boiler', 'X2::heat_pipes:N1', 'X2::power_lines:X1', 'X2::pv', 'X2::supply_gas', 'X3::boiler', 'X3::heat_pipes:N1', 'X3::power_lines:X1', 'X3::pv', 'X3::supply_gas']
-    loc_techs_cost_var_constraint: ['X1::supply_gas', 'X1::supply_grid_power', 'X2::pv', 'X2::supply_gas', 'X3::pv', 'X3::supply_gas']
+    loc_techs_cost_var_constraint: ['X1::supply_gas', 'X1::supply_grid_power', 'X2::pv', 'X2::supply_gas', 'X3::supply_gas']
     loc_techs_cost_var_conversion_constraint: ['X2::boiler', 'X3::boiler']
     loc_techs_cost_var_conversion_plus_constraint: ['X1::chp']
     loc_techs_energy_capacity_constraint: ['N1::heat_pipes:X1', 'N1::heat_pipes:X2', 'N1::heat_pipes:X3', 'X1::chp', 'X1::demand_electricity', 'X1::demand_heat', 'X1::heat_pipes:N1', 'X1::power_lines:X2', 'X1::power_lines:X3', 'X1::pv', 'X1::supply_gas', 'X1::supply_grid_power', 'X2::boiler', 'X2::demand_electricity', 'X2::demand_heat', 'X2::heat_pipes:N1', 'X2::power_lines:X1', 'X2::pv', 'X2::supply_gas', 'X3::boiler', 'X3::demand_electricity', 'X3::demand_heat', 'X3::heat_pipes:N1', 'X3::power_lines:X1', 'X3::pv', 'X3::supply_gas']
@@ -45,7 +45,7 @@ model_urban: # checked
     loc_techs_resource_availability_supply_plus_constraint: ['X1::pv', 'X2::pv', 'X3::pv']
     loc_techs_resource_max_constraint: ['X1::pv', 'X2::pv', 'X3::pv']
     loc_techs_symmetric_transmission_constraint: ['N1::heat_pipes:X1', 'N1::heat_pipes:X2', 'N1::heat_pipes:X3', 'X1::heat_pipes:N1', 'X1::power_lines:X2', 'X1::power_lines:X3', 'X2::heat_pipes:N1', 'X2::power_lines:X1', 'X3::heat_pipes:N1', 'X3::power_lines:X1']
-    loc_techs_update_costs_var_constraint: ['X1::chp', 'X2::pv', 'X3::pv']
+    loc_techs_update_costs_var_constraint: ['X1::chp', 'X2::pv']
     locs_resource_area_capacity_per_loc_constraint: ['X1', 'X2', 'X3']
 
 model_milp: # checked
@@ -64,7 +64,7 @@ model_milp: # checked
     loc_techs_carrier_production_min_conversion_plus_milp_constraint: ['X1::chp']
     loc_techs_cost_constraint: ['N1::heat_pipes:X1', 'N1::heat_pipes:X2', 'N1::heat_pipes:X3', 'X1::chp', 'X1::heat_pipes:N1', 'X1::power_lines:X2', 'X1::power_lines:X3', 'X1::pv', 'X1::supply_gas', 'X1::supply_grid_power', 'X2::boiler', 'X2::heat_pipes:N1', 'X2::power_lines:X1', 'X2::pv', 'X2::supply_gas', 'X3::boiler', 'X3::heat_pipes:N1', 'X3::power_lines:X1', 'X3::pv', 'X3::supply_gas']
     loc_techs_cost_investment_constraint: ['N1::heat_pipes:X1', 'N1::heat_pipes:X2', 'N1::heat_pipes:X3', 'X1::chp', 'X1::heat_pipes:N1', 'X1::power_lines:X2', 'X1::power_lines:X3', 'X1::pv', 'X1::supply_gas', 'X1::supply_grid_power', 'X2::boiler', 'X2::heat_pipes:N1', 'X2::power_lines:X1', 'X2::pv', 'X2::supply_gas', 'X3::boiler', 'X3::heat_pipes:N1', 'X3::power_lines:X1', 'X3::pv', 'X3::supply_gas']
-    loc_techs_cost_var_constraint: ['X1::supply_gas', 'X1::supply_grid_power', 'X2::pv', 'X2::supply_gas', 'X3::pv', 'X3::supply_gas']
+    loc_techs_cost_var_constraint: ['X1::supply_gas', 'X1::supply_grid_power', 'X2::pv', 'X2::supply_gas', 'X3::supply_gas']
     loc_techs_cost_var_conversion_constraint: ['X2::boiler', 'X3::boiler']
     loc_techs_cost_var_conversion_plus_constraint: ['X1::chp']
     loc_techs_energy_capacity_constraint: ['N1::heat_pipes:X1', 'N1::heat_pipes:X2', 'N1::heat_pipes:X3', 'X1::demand_electricity', 'X1::demand_heat', 'X1::heat_pipes:N1', 'X1::power_lines:X2', 'X1::power_lines:X3', 'X1::pv', 'X1::supply_gas', 'X1::supply_grid_power', 'X2::demand_electricity', 'X2::demand_heat', 'X2::heat_pipes:N1', 'X2::power_lines:X1', 'X2::pv', 'X2::supply_gas', 'X3::demand_electricity', 'X3::demand_heat', 'X3::heat_pipes:N1', 'X3::power_lines:X1', 'X3::pv', 'X3::supply_gas']
@@ -80,5 +80,5 @@ model_milp: # checked
     loc_techs_update_costs_investment_purchase_milp_constraint: ['X2::boiler', 'X3::boiler']
     loc_techs_update_costs_investment_units_milp_constraint: ['X1::chp']
     loc_techs_asynchronous_prod_con_milp_constraint: ['N1::heat_pipes:X1', 'X2::heat_pipes:N1', 'N1::heat_pipes:X3', 'X3::heat_pipes:N1', 'N1::heat_pipes:X2', 'X1::heat_pipes:N1']
-    loc_techs_update_costs_var_constraint: ['X1::chp', 'X2::pv', 'X3::pv']
+    loc_techs_update_costs_var_constraint: ['X1::chp', 'X2::pv']
     locs_resource_area_capacity_per_loc_constraint: ['X1', 'X2', 'X3']

--- a/calliope/test/common/test_model/scenarios.yaml
+++ b/calliope/test/common/test_model/scenarios.yaml
@@ -313,6 +313,23 @@ overrides:
                         interest_rate: 0.1
                         energy_cap: 10
 
+    om_annual_costs_with_depreciation:
+        tech_groups:
+            supply:
+                constraints:
+                    lifetime: 25
+                costs:
+                    monetary:
+                        interest_rate: 0.1
+                        om_annual: 10
+
+    om_annual_costs_without_depreciation:
+        tech_groups:
+            supply:
+                costs:
+                    monetary:
+                        om_annual: 10
+
     explicit_cost_class:
         run.objective_options.cost_class.monetary: 1
 

--- a/calliope/test/common/test_model/scenarios.yaml
+++ b/calliope/test/common/test_model/scenarios.yaml
@@ -330,6 +330,13 @@ overrides:
                     monetary:
                         om_annual: 10
 
+    om_annual_fraction_costs:
+        tech_groups:
+            supply:
+                costs:
+                    monetary:
+                        om_annual_investment_fraction: 10
+
     explicit_cost_class:
         run.objective_options.cost_class.monetary: 1
 

--- a/calliope/test/test_backend_pyomo.py
+++ b/calliope/test/test_backend_pyomo.py
@@ -579,6 +579,19 @@ class TestCostConstraints:
         m.run(build_only=True)
         assert hasattr(m._backend_model, "cost_investment_constraint")
 
+    @pytest.mark.parametrize(
+        "scenario",
+        ["om_annual_costs_with_depreciation", "om_annual_costs_without_depreciation"],
+    )
+    def test_loc_techs_om_annual_cost_investment_constraint(self, scenario):
+        """
+        sets.loc_techs_investment_cost,
+        """
+        m = build_model({}, f"simple_supply,two_hours,{scenario}")
+        m.run(build_only=True)
+        assert hasattr(m._backend_model, "cost_investment_constraint")
+        assert not hasattr(m._backend_model, "cost_var_constraint")
+
     @pytest.mark.filterwarnings("ignore:(?s).*Integer:calliope.exceptions.ModelWarning")
     def test_loc_techs_cost_investment_milp_constraint(self):
         m = build_model(

--- a/calliope/test/test_backend_pyomo.py
+++ b/calliope/test/test_backend_pyomo.py
@@ -581,7 +581,7 @@ class TestCostConstraints:
 
     @pytest.mark.parametrize(
         "scenario",
-        ["om_annual_costs_with_depreciation", "om_annual_costs_without_depreciation"],
+        ["om_annual_costs_with_depreciation", "om_annual_costs_without_depreciation", "om_annual_fraction_costs"],
     )
     def test_loc_techs_om_annual_cost_investment_constraint(self, scenario):
         """

--- a/calliope/test/test_core_preprocess.py
+++ b/calliope/test/test_core_preprocess.py
@@ -1627,6 +1627,20 @@ class TestDataset:
         with pytest.raises(exceptions.ModelError):
             build_model(override_dict=override, scenario="simple_storage,one_day")
 
+    @pytest.mark.parametrize(
+        "scenario",
+        ["om_annual_costs_with_depreciation", "om_annual_costs_without_depreciation"],
+    )
+    def test_om_annual_without_depreciation_captured_in_set(self, scenario):
+        """
+        It should be possible to have loc_techs_investment without depreciation_rate
+        if only defining om_annual for a technology.
+        """
+        m = build_model({}, f"simple_supply,two_hours,{scenario}")
+
+        assert "0::test_supply_elec" in m._model_data.loc_techs_investment_cost
+        assert "depreciation_rate" not in m._model_data.data_vars.keys()
+
     # FIXME: What are the *required* arrays?
     def test_missing_array(self):
         """

--- a/changelog.rst
+++ b/changelog.rst
@@ -10,6 +10,8 @@ Release History
 
 |fixed| Spurious negative values in `storage_inital` in operate mode are ignored in subsequent optimisation runs (#379). Negative values are a result of optimisation tolerances allowing a strictly positive decision variable to end up with (very small in magnitude) negative values. Forcing these to zero between operate mode runs ensures that Pyomo doesn't raise an exception that input values are outside the valid domain (NonNegativeReals).
 
+|fixed| `om_annual` investment costs will be calculated for technologies with only an `om_annual` cost defined in their configuration (#373). Previously, no investment costs would be calculated in this edge case.
+
 
 0.6.8 (2022-02-07)
 ------------------


### PR DESCRIPTION
Fixes issue(s) #373 

Summary of changes in this pull request:

* `om_annual` checked for in generating the `cost_investment` constraint sets, so `loc:tech`s defining only this investment cost are included in the cost constraint generation.
* Depreciation rate is accessed from the `backend_model` object directly, instead of `model_data_dict`, using a helper function.
* Depreciation rate defaults to 1, not 0 (to not impact the result), although this should have no practical effect as its value is checked for all relevant technologies during pre-processing.

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved