### PR TITLE
Update install docs

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,9 +1,37 @@
 trigger:
-  - master
-  - "*"
+  branches:
+    include:
+      - master
+      - "0.6"
+  paths:
+    exclude:
+      - doc
+      - paper
+      - "*.md"
+      - LICENSE
+      - Makefile
+      - CITATION
+      - AUTHORS
+      - .hound.yml
+      - .pre-commit-config.yaml
 
 pr:
-  - master
+  autoCancel: true
+  branches:
+    include:
+      - master
+      - "0.6"
+  paths:
+    exclude:
+      - doc
+      - paper
+      - "*.md"
+      - LICENSE
+      - Makefile
+      - CITATION
+      - AUTHORS
+      - .hound.yml
+      - .pre-commit-config.yaml
 
 pool:
   vmImage: $(IMAGE_NAME)

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -5,15 +5,15 @@ trigger:
       - "0.6"
   paths:
     exclude:
-      - doc
-      - paper
+      - "doc/*"
+      - "paper/*"
       - "*.md"
-      - LICENSE
-      - Makefile
-      - CITATION
-      - AUTHORS
-      - .hound.yml
-      - .pre-commit-config.yaml
+      - "LICENSE"
+      - "Makefile"
+      - "CITATION"
+      - "AUTHORS"
+      - ".hound.yml"
+      - ".pre-commit-config.yaml"
 
 pr:
   autoCancel: true
@@ -23,15 +23,15 @@ pr:
       - "0.6"
   paths:
     exclude:
-      - doc
-      - paper
+      - "doc/*"
+      - "paper/*"
       - "*.md"
-      - LICENSE
-      - Makefile
-      - CITATION
-      - AUTHORS
-      - .hound.yml
-      - .pre-commit-config.yaml
+      - "LICENSE"
+      - "Makefile"
+      - "CITATION"
+      - "AUTHORS"
+      - ".hound.yml"
+      - ".pre-commit-config.yaml"
 
 pool:
   vmImage: $(IMAGE_NAME)

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -5,15 +5,21 @@ trigger:
       - "0.6"
   paths:
     exclude:
-      - "doc/*"
-      - "paper/*"
+      - ".gitattributes"
+      - ".github/*"
+      - ".gitignore"
+      - ".hound.yml"
+      - ".pre-commit-config.yaml"
+      - ".readthedocs.yml"
+      - "AUTHORS"
+      - "CITATION"
       - "*.md"
       - "LICENSE"
       - "Makefile"
-      - "CITATION"
-      - "AUTHORS"
-      - ".hound.yml"
-      - ".pre-commit-config.yaml"
+      - "changelog.rst"
+      - "doc/*"
+      - "paper/*"
+      - "requirements_docs.yml"
 
 pr:
   autoCancel: true
@@ -23,15 +29,24 @@ pr:
       - "0.6"
   paths:
     exclude:
-      - "doc/*"
-      - "paper/*"
+      - ".gitattributes"
+      - ".github/*"
+      - ".gitignore"
+      - ".hound.yml"
+      - ".pre-commit-config.yaml"
+      - ".readthedocs.yml"
+      - "AUTHORS"
+      - "CITATION"
       - "*.md"
       - "LICENSE"
       - "Makefile"
-      - "CITATION"
-      - "AUTHORS"
-      - ".hound.yml"
-      - ".pre-commit-config.yaml"
+      - "changelog.rst"
+      - "doc/*"
+      - "paper/*"
+      - "requirements_docs.yml"
+
+
+
 
 pool:
   vmImage: $(IMAGE_NAME)

--- a/doc/user/develop.rst
+++ b/doc/user/develop.rst
@@ -30,7 +30,8 @@ Then install all development requirements for Calliope into a new environment, c
 
   .. code-block:: fishshell
 
-   $ conda env create -f requirements.yml -n calliope_dev
+   $ conda create -n calliope_dev python=3.9
+   $ conda env update -f requirements.yml -n calliope_dev
    $ conda activate calliope_dev
 
 Finally install Calliope itself as an editable installation with pip:

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -42,11 +42,13 @@ You are now ready to use Calliope together with the free and open source GLPK so
 
 .. note::
 
-    If you are having trouble with the recommended installation method, you can try the following troubleshooting methods:
+    Windows users may have trouble with the recommended installation method, due to conda not solving the environment successfully.
+    If this occurs, we recommend using ``mamba``, which is a drop-in, more performant replacement for ``conda``.
+    First install mamba in your base conda environment (``conda install mamba -n base -c conda-forge``), then proceed with the installation as before, simply using ``mamba`` in place of ``conda`` (``mamba create -c conda-forge -n calliope calliope``).
 
-    1. Instead of using ``conda``, use ``mamba`` (a more efficient implementation of ``conda``). First install mamba in your base conda environment (``conda install mamba -n base -c conda-forge``), then proceed with the installation as before, simply using ``mamba`` in place of ``conda`` (``mamba create -c conda-forge -n calliope calliope``).
+.. warning::
 
-    2. Install calliope via ``pip`` after creating an empty conda environment. First, create an empty environment and name it 'calliope' (``conda create -n calliope python=3.9``). Then, activate the ``calliope`` environment before installing the calliope package via ``pip`` (``pip install calliope``).
+    Although possible, installing directly via pip (``pip install calliope``) can lead to downstream issues since necessary non-python binaries are not installed (e.g., `glpk`, `libnetcdf`, and `hdf5`).
 
 Updating an existing installation
 =================================

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -49,7 +49,7 @@ You are now ready to use Calliope together with the free and open source GLPK so
 .. warning::
 
     Although possible, we do not recommend installing Calliope directly via ``pip`` (``pip install calliope``).
-    With ``pip``, non-python binaries are not installed, some of which are necessary for stable operation (e.g., `libnetcdf`).
+    Non-python binaries are not installed with ``pip``, some of which are necessary for stable operation (e.g., `libnetcdf`).
 
 Updating an existing installation
 =================================

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -44,11 +44,12 @@ You are now ready to use Calliope together with the free and open source GLPK so
 
     Windows users may have trouble with the recommended installation method, due to conda not solving the environment successfully.
     If this occurs, we recommend using the more efficient reimplementation of ``conda``: `Mamba <https://mamba.readthedocs.io/en/latest/index.html>`_.
-    First install mamba in your base conda environment (``conda install mamba -n base -c conda-forge``), then proceed with the installation as before, simply using ``mamba`` in place of ``conda`` (``mamba create -c conda-forge -n calliope calliope``).
+    First install mamba in your base conda environment (``conda install -c conda-forge -n base mamba``), then proceed with the installation as before, simply using ``mamba`` in place of ``conda`` (``mamba create -c conda-forge -n calliope calliope``).
 
 .. warning::
 
-    Although possible, we do not recommend installing Calliope directly via pip (``pip install calliope``) since non-python binaries are not installed, some of which are necessary for stable operation (e.g., `libnetcdf`).
+    Although possible, we do not recommend installing Calliope directly via ``pip`` (``pip install calliope``).
+    With ``pip``, non-python binaries are not installed, some of which are necessary for stable operation (e.g., `libnetcdf`).
 
 Updating an existing installation
 =================================

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -43,12 +43,12 @@ You are now ready to use Calliope together with the free and open source GLPK so
 .. note::
 
     Windows users may have trouble with the recommended installation method, due to conda not solving the environment successfully.
-    If this occurs, we recommend using ``mamba``, which is a drop-in, more performant replacement for ``conda``.
+    If this occurs, we recommend using the more efficient reimplementation of ``conda``: `Mamba <https://mamba.readthedocs.io/en/latest/index.html>`_.
     First install mamba in your base conda environment (``conda install mamba -n base -c conda-forge``), then proceed with the installation as before, simply using ``mamba`` in place of ``conda`` (``mamba create -c conda-forge -n calliope calliope``).
 
 .. warning::
 
-    Although possible, installing directly via pip (``pip install calliope``) can lead to downstream issues since necessary non-python binaries are not installed (e.g., `glpk`, `libnetcdf`, and `hdf5`).
+    Although possible, we do not recommend installing Calliope directly via pip (``pip install calliope``) since non-python binaries are not installed, some of which are necessary for stable operation (e.g., `libnetcdf`).
 
 Updating an existing installation
 =================================


### PR DESCRIPTION
Additional fix for issue #378 

Having done some testing myself with different install methods, I have removed the pip-based recommendation (i.e., install an empty conva env then install calliope via pip within it). Some non-python binaries aren't installed and this can make saving to NetCDF fragile. In our conda-forge package we include them (`libnetcdf`, `hdf5`), but since they are not available via pip I would not recommend a user to install by this method. Of course, they could be referenced in the docs (i.e, install a conda env with just python and those non-python binaries) but since using `mamba` is a viable workaround on windows, it seems better to not muddy the waters.

I've also added an explicit python version in the dev docs since we are a bit behind the current Python version (latest 3.11, we are at 3.9).

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved