### PR TITLE
Reduce number of test warnings in 0.6.8-dev

### DIFF
--- a/calliope/backend/pyomo/model.py
+++ b/calliope/backend/pyomo/model.py
@@ -215,7 +215,7 @@ def solve_model(
     if "warmstart" in solve_kwargs.keys() and solver in ["glpk", "cbc"]:
         if solve_kwargs.pop("warmstart") is True:
             exceptions.warn(
-                "The chosen solver, {}, does not suport warmstart, which may "
+                "The chosen solver, {}, does not support warmstart, which may "
                 "impact performance.".format(solver)
             )
 

--- a/calliope/backend/run.py
+++ b/calliope/backend/run.py
@@ -606,7 +606,7 @@ def run_operate(model_data, timings, backend, build_only):
 
         # Update relevent Pyomo Params in intermediate instances
         else:
-            warmstart = True
+            warmstart = False if solver in ["glpk", "cbc"] else True
             end_timestep = horizon_ends.index[i]
             timesteps = slice(start_timestep, end_timestep)
             window_model_data = model_data.loc[dict(timesteps=timesteps)]
@@ -644,7 +644,7 @@ def run_operate(model_data, timings, backend, build_only):
                 comment="Backend: iteration {}: sending model to solver".format(i + 1),
             )
             # After iteration 1, warmstart = True, which should speed up the process
-            # Note: Warmstart isn't possible with GLPK (dealt with later on)
+            # Note: Warmstart isn't possible with GLPK or CBC (dealt with later on)
             _results, _opt = backend.solve_model(
                 backend_model,
                 solver=solver,

--- a/calliope/preprocess/model_run.py
+++ b/calliope/preprocess/model_run.py
@@ -444,9 +444,9 @@ def load_overrides_from_scenario(config_model, scenario):
 
     if scenario in config_model.get("scenarios", {}).keys():
         if "," in scenario:
-            warnings.warn(
+            exceptions.print_warnings_and_raise_errors(warnings=[
                 f"Scenario name `{scenario}` includes commas that won't be parsed as a list of overrides."
-            )
+            ])
         logger.info("Loading overrides from scenario: {} ".format(scenario))
         scenario_list = _get_overrides(scenario)
     else:

--- a/calliope/preprocess/model_run.py
+++ b/calliope/preprocess/model_run.py
@@ -444,9 +444,11 @@ def load_overrides_from_scenario(config_model, scenario):
 
     if scenario in config_model.get("scenarios", {}).keys():
         if "," in scenario:
-            exceptions.print_warnings_and_raise_errors(warnings=[
-                f"Scenario name `{scenario}` includes commas that won't be parsed as a list of overrides."
-            ])
+            exceptions.print_warnings_and_raise_errors(
+                warnings=[
+                    f"Scenario name `{scenario}` includes commas that won't be parsed as a list of overrides."
+                ]
+            )
         logger.info("Loading overrides from scenario: {} ".format(scenario))
         scenario_list = _get_overrides(scenario)
     else:

--- a/calliope/test/test_backend_pyomo_interface.py
+++ b/calliope/test/test_backend_pyomo_interface.py
@@ -192,23 +192,24 @@ class TestBackendRerun:
             excinfo, "The results of rerunning the backend model are only available"
         )
 
+    @pytest.mark.filterwarnings(
+        "ignore:(?s).*The results of rerunning the backend model:calliope.exceptions.ModelWarning"
+    )
     def test_update_and_rerun(self, model):
         """
         test that the function rerun works
         """
         model.backend.update_param("energy_cap_max", {"1::test_supply_elec": 20})
-        with pytest.warns(exceptions.ModelWarning) as excinfo:
-            new_model = model.backend.rerun()
+        new_model = model.backend.rerun()
 
         assert (
             new_model.inputs.energy_cap_max.loc[{"loc_techs": "1::test_supply_elec"}]
             == 20
         )
 
-        assert check_error_or_warning(
-            excinfo, "The results of rerunning the backend model are only available"
-        )
-
+    @pytest.mark.filterwarnings(
+        "ignore:(?s).*The results of rerunning the backend model:calliope.exceptions.ModelWarning"
+    )
     def test_rerun_spores(self, model):
         model = calliope.examples.national_scale(
             override_dict={
@@ -335,6 +336,9 @@ class TestAddConstraint:
             excinfo, "Pyomo backend model object has no attribute 'not_a_set'"
         )
 
+    @pytest.mark.filterwarnings(
+        "ignore:(?s).*The results of rerunning the backend model:calliope.exceptions.ModelWarning"
+    )
     def test_added_constraint(self, model):
         """
         Test the successful addition of a constraint which only allows carrier

--- a/calliope/test/test_backend_pyomo_interface.py
+++ b/calliope/test/test_backend_pyomo_interface.py
@@ -210,6 +210,9 @@ class TestBackendRerun:
     @pytest.mark.filterwarnings(
         "ignore:(?s).*The results of rerunning the backend model:calliope.exceptions.ModelWarning"
     )
+    @pytest.mark.filterwarnings(
+        "ignore:(?s).*Monetary cost class with a weight of 1 is still included in the objective:calliope.exceptions.ModelWarning"
+    )
     def test_rerun_spores(self, model):
         model = calliope.examples.national_scale(
             override_dict={
@@ -225,6 +228,9 @@ class TestBackendRerun:
             assert hasattr(new_model, i)
         assert "spores" in new_model.results.dims
 
+    @pytest.mark.filterwarnings(
+        "ignore:(?s).*Monetary cost class with a weight of 1 is still included in the objective:calliope.exceptions.ModelWarning"
+    )
     def test_rerun_spores_fail_on_rerun_with_results(self, model):
         model = calliope.examples.national_scale(
             override_dict={

--- a/calliope/test/test_backend_pyomo_objective.py
+++ b/calliope/test/test_backend_pyomo_objective.py
@@ -62,6 +62,9 @@ class TestCostMinimisationObjective:
             for i in range(len(cost_class))
         ) == approx(po.value(model._backend_model.obj))
 
+    @pytest.mark.filterwarnings(
+        "ignore:(?s).*The results of rerunning the backend model:calliope.exceptions.ModelWarning"
+    )
     def test_update_cost_classes_weights(self):
         model = build_model(
             model_file="weighted_obj_func.yaml", scenario="weighted_objective"

--- a/calliope/test/test_cli.py
+++ b/calliope/test/test_cli.py
@@ -42,6 +42,9 @@ class TestCLI:
             assert os.path.isfile(os.path.join(tempdir, "output.nc"))
             assert os.path.isfile(os.path.join(tempdir, "results.html"))
 
+    @pytest.mark.filterwarnings(
+        "ignore:(?s).*Monetary cost class with a weight of 1 is still included in the objective:calliope.exceptions.ModelWarning"
+    )
     def test_save_per_spore(self):
         runner = CliRunner()
 

--- a/calliope/test/test_core_preprocess.py
+++ b/calliope/test/test_core_preprocess.py
@@ -1128,7 +1128,10 @@ class TestChecks:
             build_model(
                 override_dict=override(param), scenario="simple_storage,one_day"
             )
-    @pytest.mark.filterwarnings("ignore:(?s).*Updated from coordinate system.*:calliope.exceptions.ModelWarning")
+
+    @pytest.mark.filterwarnings(
+        "ignore:(?s).*Updated from coordinate system.*:calliope.exceptions.ModelWarning"
+    )
     def test_incorrect_location_coordinates(self):
         """
         Either all or no locations must have `coordinates` defined and, if all
@@ -1272,7 +1275,9 @@ class TestChecks:
             str(i) for i in excinfo.list
         ]
 
-    @pytest.mark.filterwarnings("ignore:(?s).*Cost classes `{'monetary'}` are defined in the objective options but not defined elsewhere in the model:calliope.exceptions.ModelWarning")
+    @pytest.mark.filterwarnings(
+        "ignore:(?s).*Cost classes `{'monetary'}` are defined in the objective options but not defined elsewhere in the model:calliope.exceptions.ModelWarning"
+    )
     def test_carrier_ratio_from_file(self):
         """
         It is possible to load a timeseries carrier_ratio from file

--- a/calliope/test/test_core_preprocess.py
+++ b/calliope/test/test_core_preprocess.py
@@ -627,6 +627,9 @@ class TestChecks:
             warn, "spores run mode is selected, but a number of 0 spores is requested"
         )
 
+    @pytest.mark.filterwarnings(
+        "ignore:(?s).*Monetary cost class with a weight of 1 is still included in the objective:calliope.exceptions.ModelWarning"
+    )
     def test_non_string_score_cost_class(self):
         """
         Check that the score_cost_class for spores scoring is a string
@@ -640,6 +643,9 @@ class TestChecks:
             excinfo, "`run.spores_options.score_cost_class` must be a string"
         )
 
+    @pytest.mark.filterwarnings(
+        "ignore:(?s).*Monetary cost class with a weight of 1 is still included in the objective:calliope.exceptions.ModelWarning"
+    )
     def test_no_spore_group_constraint(self):
         """
         Ensure an error is raised if pointing to a non-existent group constraint

--- a/calliope/test/test_core_preprocess.py
+++ b/calliope/test/test_core_preprocess.py
@@ -1122,7 +1122,7 @@ class TestChecks:
             build_model(
                 override_dict=override(param), scenario="simple_storage,one_day"
             )
-
+    @pytest.mark.filterwarnings("ignore:(?s).*Updated from coordinate system.*:calliope.exceptions.ModelWarning")
     def test_incorrect_location_coordinates(self):
         """
         Either all or no locations must have `coordinates` defined and, if all
@@ -1257,7 +1257,7 @@ class TestChecks:
                     heat: 1.0
             """
         )
-        with pytest.warns(None) as excinfo:
+        with pytest.warns() as excinfo:
             build_model(
                 override_dict=override, scenario="simple_conversion_plus,one_day"
             )
@@ -1266,6 +1266,7 @@ class TestChecks:
             str(i) for i in excinfo.list
         ]
 
+    @pytest.mark.filterwarnings("ignore:(?s).*Cost classes `{'monetary'}` are defined in the objective options but not defined elsewhere in the model:calliope.exceptions.ModelWarning")
     def test_carrier_ratio_from_file(self):
         """
         It is possible to load a timeseries carrier_ratio from file
@@ -1276,14 +1277,12 @@ class TestChecks:
                 carrier_out.heat: file=carrier_ratio.csv
             """
         )
-        with pytest.warns(None) as excinfo:
-            build_model(
-                override_dict=override, scenario="simple_conversion_plus,one_day"
-            )
 
-        assert "Cannot load data from file for configuration" not in [
-            str(i) for i in excinfo.list
-        ]
+        model = build_model(
+            override_dict=override, scenario="simple_conversion_plus,one_day"
+        )
+
+        assert "timesteps" in model._model_data.carrier_ratios.dims
 
     @pytest.mark.filterwarnings("ignore:(?s).*Integer:calliope.exceptions.ModelWarning")
     def test_milp_constraints(self):

--- a/calliope/test/test_example_models.py
+++ b/calliope/test/test_example_models.py
@@ -154,6 +154,9 @@ class TestNationalScaleExampleModelOperate:
         self.example_tester()
 
 
+@pytest.mark.filterwarnings(
+    "ignore:(?s).*Monetary cost class with a weight of 1 is still included in the objective:calliope.exceptions.ModelWarning"
+)
 class TestNationalScaleExampleModelSpores:
     def example_tester(self, solver="cbc", solver_io=None, **override_dict_kwargs):
 

--- a/calliope/test/test_io.py
+++ b/calliope/test/test_io.py
@@ -86,6 +86,9 @@ class TestIO:
             model_from_disk = calliope.read_netcdf(out_path)
             # FIXME test for some data in model_from_disk
 
+    @pytest.mark.filterwarnings(
+        "ignore:(?s).*The results of rerunning the backend model:calliope.exceptions.ModelWarning"
+    )
     def test_rerun_save_read_netcdf_with_mixed_dtype(self, model):
         new_model = model.backend.rerun()
         assert model._model_data.force_resource.dtype.kind == "f"

--- a/calliope/test/test_io.py
+++ b/calliope/test/test_io.py
@@ -152,6 +152,9 @@ class TestIO:
             with open(out_path, "r") as f:
                 assert "\nmin \nobj:\n+1 cost(monetary__region1_1__csp_)" in f.read()
 
+    @pytest.mark.filterwarnings(
+        "ignore:(?s).*Monetary cost class with a weight of 1 is still included in the objective:calliope.exceptions.ModelWarning"
+    )
     def test_save_per_spore(self):
         with tempfile.TemporaryDirectory() as tempdir:
             os.mkdir(os.path.join(tempdir, "output"))

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,5 @@ filterwarnings =
     ignore:.*Deprecated, pass a TempConstr or use Model.addLConstr.*:DeprecationWarning:pyomo
     ignore:.*distutils Version classes are deprecated.*:DeprecationWarning:
     ignore:.*`np.float` is a deprecated alias.*:DeprecationWarning:
+markers =
+    serial


### PR DESCRIPTION
Some warnings are expected and ignored,
others are deprecation warnings from pytest itself.