### PR TITLE
Add upper bounds to all v0.7 dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 click ~= 8.1
-ipython >= 7
-ipdb >= 0.13
-natsort >= 5
-netcdf4 >= 1.2.2
+ipython >= 7, < 9
+ipdb >= 0.13, < 1.0
+natsort >= 5, < 9
+netcdf4 >= 1.2.2, < 1.6.2
 numpy ~= 1.23.5
 pandas ~= 1.5.2
 pyomo ~= 6.4.4

--- a/requirements.yml
+++ b/requirements.yml
@@ -6,12 +6,12 @@ channels:
 dependencies:
     - bottleneck < 2
     - coverage >= 4.4
-    - codecov
+    - codecov < 3
     - glpk = 5.0
     - hdf5 < 2
     - libnetcdf < 4.9
-    - pre-commit
-    - pytest-cov
-    - pytest-xdist  # pytest distributed testing plugin
-    - pytest
+    - pre-commit < 4
+    - pytest-cov < 5
+    - pytest-xdist < 4 # pytest distributed testing plugin
+    - pytest < 8
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,12 +4,12 @@ channels:
     - conda-forge
 
 dependencies:
-    - bottleneck
+    - bottleneck < 2
     - coverage >= 4.4
     - codecov
     - glpk = 5.0
-    - hdf5
-    - libnetcdf
+    - hdf5 < 2
+    - libnetcdf < 4.9
     - pre-commit
     - pytest-cov
     - pytest-xdist  # pytest distributed testing plugin


### PR DESCRIPTION
Hotfixes issue(s) #402 (keep issue open until we've dealt with not trying to compress string/object arrays)

Summary of changes in this pull request:

* Add strict minor version upper bound for libnetcdf
* Add strict minor version upper bound for netcdf4 so that it doesn't try to update libnetcdf in dev installs (where you install by updating with "requirement.yml" followed by "requirements.txt")
* Add the upcoming major releases for all required dependencies as an upper bound, in the hope of not being caught out by backward incompatible changes (although, in reality, they could crop up in minor releases).

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved