### PR TITLE
Fix: Remove obsolete _datetime_to_string context manager

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -25,8 +25,6 @@ Internal changes
 
 |new| Generation of subsets over the model dimensions is now automated and determined by hardcoded YAML configuration files (`model_data_lookup.yaml` and `subsets.yaml`). This reduces the need to update code when incorporating additional functionality in the future.
 
-|changed| Timestamps are converted to strings when generating sets in Pyomo. This reduces the time and memory footprint of variable/constraint generation.
-
 |changed| Costs are now Pyomo expressions rather than decision variables.
 
 |changed| When a model is loaded into an active session, configuration dictionaries are stored as dictionaries instead of seralised YAML strings in the model data attributes dictionary. Serialisation and de-serialisation only occur on saving and loading from NetCDF, respectively.


### PR DESCRIPTION
Fixes issue(s) #

Summary of changes in this pull request:

* Remove obsolete `Model._datetime_to_string` context manager

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [x] Changelog updated
- [ ] Coverage maintained or improved