### PR TITLE
Feature: add math formulation documentation generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-.PHONY : doc-plots
+.PHONY : doc-plots, doc-math
 doc-plots :
 	python doc/helpers/generate_plots.py
+
+doc-math :
+	python doc/helpers/generate_math.py
 
 ###
 # Build package and upload to PyPI

--- a/calliope/backend/backends.py
+++ b/calliope/backend/backends.py
@@ -586,7 +586,7 @@ class BackendModel(ABC, Generic[T]):
 
 
 class PyomoBackendModel(BackendModel):
-    def __init__(self):
+    def __init__(self, **kwargs):
         BackendModel.__init__(self, instance=pmo.block())
 
         self._instance.parameters = pmo.parameter_dict()

--- a/calliope/backend/equation_parser.py
+++ b/calliope/backend/equation_parser.py
@@ -54,7 +54,7 @@ class EvalOperatorOperand(EvalString):
     LATEX_OPERATOR_LOOKUP: dict[str, str] = {
         "**": "{val}^{{{operand}}}",
         "*": r"{val} \times {operand}",
-        "/": r"\frac{{ {val} }} {{ {operand} }}",
+        "/": r"\frac{{ {val} }}{{ {operand} }}",
         "+": "{val} + {operand}",
         "-": "{val} - {operand}",
     }
@@ -101,9 +101,11 @@ class EvalOperatorOperand(EvalString):
         # We ignore zeros that do nothing
         if operand == "0" and operator_ in ["-", "+"]:
             return val
-
         if operand_type == type(self):
             operand = "(" + operand + ")"
+        if val == "0" and operator_ in ["-", "+"]:
+            return operand
+
         return self.LATEX_OPERATOR_LOOKUP[operator_].format(val=val, operand=operand)
 
     def _eval(
@@ -637,8 +639,7 @@ class StringListParser(EvalString):
 
     def as_latex(self, evaluated):
         """Stingify evaluated object for use in a LaTex math formula"""
-        escaped_strings = [self.escape(i) for i in evaluated]
-        return evaluated  # f"[{', '.join(escaped_strings)}]"
+        return evaluated
 
     def eval(self, **eval_kwargs) -> list[str]:
         "Return input as list of strings."
@@ -667,7 +668,7 @@ class GenericStringParser(EvalString):
 
     def as_latex(self, evaluated):
         """Stingify evaluated string for use in a LaTex math formula"""
-        return evaluated  # rf"\text{{{evaluated}}}"
+        return evaluated
 
     def eval(self, **eval_kwargs) -> str:
         "Return input as string."

--- a/calliope/backend/helper_functions.py
+++ b/calliope/backend/helper_functions.py
@@ -25,8 +25,8 @@ def imask_sum(model_data, as_latex: bool = False, **kwargs):
         if isinstance(over, str):
             overstring = _instr(over)
         else:
-            overstring = r"\substack{" + " \\ ".join(_instr(i) for i in over) + "}"
-        return rf"\sum\limit_{{{overstring}}} ({component})"
+            overstring = r"\substack{" + r" \\ ".join(_instr(i) for i in over) + "}"
+        return rf"\sum\limits_{{{overstring}}} ({component})"
 
     def _imask_sum(component, *, over):
         """
@@ -57,8 +57,8 @@ def expression_sum(as_latex: bool = False, **kwargs):
         if isinstance(over, str):
             overstring = _instr(over)
         else:
-            overstring = r"\substack{" + " \\ ".join(_instr(i) for i in over) + "}"
-        return rf"\sum\limit_{{{overstring}}} ({component})"
+            overstring = r"\substack{" + r" \\ ".join(_instr(i) for i in over) + "}"
+        return rf"\sum\limits_{{{overstring}}} ({component})"
 
     def _expression_sum(component, *, over):
         """
@@ -93,7 +93,7 @@ def expression_sum(as_latex: bool = False, **kwargs):
 
 def squeeze_carriers(model_data, as_latex: bool = False, **kwargs):
     def _as_latex(component, carrier_tier):
-        return rf"\sum_{{\text{{carrier}} \in \text{{carrier_tier({carrier_tier})}}}} ({component})"
+        return rf"\sum\limits_{{\text{{carrier}} \in \text{{carrier_tier({carrier_tier})}}}} ({component})"
 
     def _squeeze_carriers(component, carrier_tier):
         return expression_sum(**kwargs)(
@@ -112,7 +112,7 @@ def squeeze_carriers(model_data, as_latex: bool = False, **kwargs):
 def squeeze_primary_carriers(model_data, as_latex: bool = False, **kwargs):
     def _as_latex(component, carrier_tier):
         return (
-            rf"\sum_{{\text{{carrier=primary_carrier_{carrier_tier}}}}} ({component})"
+            rf"\sum\limits_{{\text{{carrier=primary_carrier_{carrier_tier}}}}} ({component})"
         )
 
     def _squeeze_primary_carriers(component, carrier_tier):
@@ -176,18 +176,14 @@ def get_val_at_index(model_data, as_latex: bool = False, **kwargs):
 
 def roll(as_latex: bool = False, **kwargs):
     def _as_latex(component, **roll_kwargs):
-        try:
-            component_sections = component.split(r"_\text{")
-            sub_section = component_sections[1]
-        except IndexError:
-            return component
-        else:
-            for k, v in roll_kwargs.items():
-                k_singular = k.removesuffix("s")
-                sub_section = re.sub(
-                    rf"\b{k_singular}\b", rf"{k_singular}-{v}", sub_section
-                )
-            return component_sections[0] + r"_\text{" + sub_section
+        for k, v in roll_kwargs.items():
+            k_singular = k.removesuffix("s")
+            component = re.sub(
+                rf"(_\\text{{)([\w,_]*?)(\b{k_singular}\b)([\w,_]*?)(}})",
+                rf"\1\2\3{-1 * int(v)}\4\5",
+                component,
+            )
+        return component
 
     def _roll(component, **roll_kwargs):
         roll_kwargs_int = {k: int(v) for k, v in roll_kwargs.items()}

--- a/calliope/backend/latex_backend.py
+++ b/calliope/backend/latex_backend.py
@@ -1,0 +1,204 @@
+from typing import Any, Callable, Optional, Literal, TypeVar, Generic, Union, Iterable
+
+import xarray as xr
+import numpy as np
+
+from calliope.backend import backends
+from calliope.backend import parsing, equation_parser
+from calliope.exceptions import BackendError
+
+
+class LatexBackendModel(backends.BackendModel):
+    def __init__(self):
+        """Abstract base class for interfaces to solvers.
+
+        Args:
+            instance (T): Interface model instance.
+        """
+        backends.BackendModel.__init__(self, instance=None)
+
+    def add_parameter(
+        self,
+        parameter_name: str,
+        parameter_values: xr.DataArray,
+        default: Any = np.nan,
+        use_inf_as_na: bool = False,
+    ) -> None:
+        self._add_to_dataset(parameter_name, parameter_values, "parameters")
+        self.valid_arithmetic_components.add(parameter_name)
+
+    def add_constraint(
+        self,
+        model_data: xr.Dataset,
+        name: str,
+        constraint_dict: parsing.UnparsedConstraintDict,
+    ) -> None:
+        self._add_constraint_or_expression(
+            model_data,
+            name,
+            constraint_dict,
+            lambda x: None,
+            "constraints",
+            equation_parser.generate_equation_parser,
+        )
+
+    def add_expression(
+        self,
+        model_data: xr.Dataset,
+        name: str,
+        expression_dict: parsing.UnparsedConstraintDict,
+    ) -> None:
+        self.valid_arithmetic_components.add(name)
+
+        self._add_constraint_or_expression(
+            model_data,
+            name,
+            expression_dict,
+            lambda x: None,
+            "expressions",
+            equation_parser.generate_arithmetic_parser,
+        )
+
+    def add_variable(
+        self,
+        model_data: xr.Dataset,
+        name: str,
+        variable_dict: parsing.UnparsedVariableDict,
+    ) -> None:
+        self.valid_arithmetic_components.add(name)
+        self._raise_error_on_preexistence(name, "variables")
+
+        parsed_variable = parsing.ParsedBackendComponent(name, variable_dict)
+        foreach_imask = parsed_variable.evaluate_foreach(model_data)
+
+        parsed_variable.parse_top_level_where()
+        imask = parsed_variable.evaluate_where(model_data, initial_imask=foreach_imask)
+        imask = parsed_variable.align_imask_with_sets(imask)
+        imask_latex = parsed_variable.evaluate_where(model_data, as_latex=True)
+        imask.attrs["latex_strings"] = {1: {"where": imask_latex}}
+        self._add_to_dataset(name, imask.where(imask), "variables")
+
+    def add_objective(
+        self,
+        model_data: xr.Dataset,
+        name: str,
+        objective_dict: parsing.UnparsedObjectiveDict,
+    ) -> None:
+        self._raise_error_on_preexistence(name, "objectives")
+        sense_dict = {"minimize": r"\min{}", "maximize": r"\max{}"}
+        parsed_objective = parsing.ParsedBackendComponent(name, objective_dict)
+        equations = parsed_objective.parse_equations(
+            equation_parser.generate_arithmetic_parser, self.valid_arithmetic_components
+        )
+        latex_strings = {}
+        valid_expressions = []
+        for element in equations:
+            imask = element.evaluate_where(model_data)
+            if imask.any():
+                valid_expressions.append(element.name)
+            imask_latex = element.evaluate_where(model_data, as_latex=True)
+            expr = element.evaluate_expression(model_data, self, as_latex=True)
+            latex_strings[element.name] = {
+                "expression": sense_dict[objective_dict["sense"]] + expr,
+                "where": imask_latex,
+            }
+
+        self._add_to_dataset(
+            name,
+            xr.DataArray(valid_expressions).assign_attrs(latex_strings=latex_strings),
+            "objectives",
+        )
+
+    def get_parameter(
+        self, parameter_name: str, as_backend_objs: bool = True
+    ) -> Optional[xr.DataArray]:
+        return self.parameters.get(parameter_name, None)
+
+    def create_obj_list(self, key: str, component_type: backends._COMPONENTS_T) -> None:
+        return None
+
+    def get_constraint(
+        self,
+        constraint_name: str,
+        as_backend_objs: bool = True,
+        eval_body: bool = False,
+    ) -> Optional[Union[xr.DataArray, xr.Dataset]]:
+        return self.constraints.get(constraint_name, None)
+
+    def get_variable(
+        self, variable_name: str, as_backend_objs: bool = True
+    ) -> Optional[xr.DataArray]:
+        return self.variables.get(variable_name, None)
+
+    def get_expression(
+        self, expression_name: str, as_backend_objs: bool = True, eval_body: bool = True
+    ) -> Optional[xr.DataArray]:
+        return self.expressions.get(expression_name, None)
+
+    def solve(
+        self,
+        solver: str,
+        solver_io: Optional[str] = None,
+        solver_options: Optional[dict] = None,
+        save_logs: Optional[str] = None,
+        warmstart: bool = False,
+        **solve_kwargs,
+    ):
+        raise BackendError(
+            "Cannot solve a LaTex backend model - this only exists to produce a string representation of the model math"
+        )
+
+    def _add_constraint_or_expression(
+        self,
+        model_data: xr.Dataset,
+        name: str,
+        component_dict: parsing.UnparsedConstraintDict,
+        component_setter: Callable,
+        component_type: Literal["constraints", "expressions"],
+        parser: Callable,
+    ) -> None:
+        references: set[str] = set()
+
+        parsed_component = parsing.ParsedBackendComponent(name, component_dict)
+        foreach_imask = parsed_component.evaluate_foreach(model_data)
+        parsed_component.parse_top_level_where()
+        top_level_imask = parsed_component.evaluate_where(
+            model_data, initial_imask=foreach_imask
+        )
+        top_level_imask_latex = parsed_component.evaluate_where(
+            model_data, as_latex=True
+        )
+        self._raise_error_on_preexistence(name, component_type)
+
+        component_da = (
+            xr.DataArray()
+            .where(parsed_component.align_imask_with_sets(top_level_imask))
+            .assign_attrs(latex_strings={"where": top_level_imask_latex})
+        )
+
+        equations = parsed_component.parse_equations(
+            parser, self.valid_arithmetic_components
+        )
+        for element in equations:
+            imask = element.evaluate_where(model_data, initial_imask=top_level_imask)
+            imask = parsed_component.align_imask_with_sets(imask)
+
+            if component_da.where(imask).notnull().any():
+                subset_overlap = component_da.where(imask).to_series().dropna().index
+
+                raise BackendError(
+                    "Trying to set two equations for the same index of "
+                    f"{component_type.removesuffix('s')} `{name}`:\n{subset_overlap}"
+                )
+
+            expr = element.evaluate_expression(
+                model_data, self, as_latex=True, references=references
+            )
+            imask_latex = element.evaluate_where(model_data, as_latex=True)
+            component_da = component_da.fillna(xr.DataArray(element.name).where(imask))
+            component_da.latex_strings[element.name] = {
+                "expression": expr,
+                "where": imask_latex,
+            }
+
+        self._add_to_dataset(name, component_da, component_type, references)

--- a/calliope/backend/subset_parser.py
+++ b/calliope/backend/subset_parser.py
@@ -205,8 +205,8 @@ class ComparisonParser(equation_parser.EvalComparisonOp):
         "<=": r"\mathord{\leq}",
         ">=": r"\mathord{\geq}",
         "=": "\mathord{=}",
-        "<": r"\mathord{\lt}",
-        ">": r"\mathord{\gt}",
+        "<": r"\mathord{<}",
+        ">": r"\mathord{>}",
     }
 
     def __repr__(self):
@@ -219,12 +219,15 @@ class ComparisonParser(equation_parser.EvalComparisonOp):
 
         Returns:
             BOOLEANTYPE: Same shape as LHS.
+            str: latex representation of the comparison.
         """
         kwargs["apply_imask"] = False
         lhs = self.lhs.eval(**kwargs)
         rhs = self.rhs.eval(**kwargs)
 
         if kwargs.get("as_latex", False):
+            if not r"\text" in rhs:
+                rhs = rf"\text{{{rhs}}}"
             comparison = self.as_latex(lhs, rhs)
         else:
             if self.op == "<=":
@@ -269,7 +272,7 @@ class SubsetParser(equation_parser.EvalString):
         """stringify subset for use in a LaTex math formula"""
         set_singular = self.set_name.removesuffix("s")
         subset_string = "[" + ",".join(str(i) for i in subset) + "]"
-        return rf"\\text{{{set_singular}}}\in{{ \\text{{{subset_string}}} }}"
+        return rf"\text{{{set_singular}}}\in \text{{{subset_string}}}"
 
     def eval(self, model_data: xr.Dataset, **kwargs) -> Union[str, xr.DataArray]:
         subset = [i.eval(**kwargs) for i in self.subset]

--- a/calliope/config/base_math.yaml
+++ b/calliope/config/base_math.yaml
@@ -1,5 +1,4 @@
 constraints:
-
   energy_capacity_per_storage_capacity_min:
     foreach: [nodes, techs]
     where: "energy_cap_per_storage_cap_min AND NOT energy_cap_per_storage_cap_equals AND NOT run.mode=operate"
@@ -48,7 +47,6 @@ constraints:
     foreach: [nodes, techs, timesteps]
     where: "inheritance(conversion_plus) AND carrier_ratios>0"
     equation: squeeze_carriers(carrier_prod / carrier_ratios[carrier_tiers=out], carrier_tier=out) == -1 * squeeze_carriers(carrier_con * carrier_ratios[carrier_tiers=in], carrier_tier=in) * energy_eff
-
 
   carrier_production_max_conversion_plus:
     foreach: [nodes, techs, timesteps]
@@ -240,7 +238,9 @@ constraints:
     foreach: [nodes, techs]
     where: "storage_initial AND include_storage=True AND run.cyclic_storage=True"
     equation: storage[timesteps=$final_step] * ((1 - storage_loss) ** timestep_resolution[timesteps=$final_step]) == storage_initial * storage_cap
-    index_slices: *storage_previous_step_idx_items
+    index_slices:
+      final_step:
+        - expression: get_val_at_index(dim=timesteps, idx=-1)
 
   balance_transmission:
     foreach: [nodes, techs, carriers, timesteps]
@@ -375,7 +375,7 @@ constraints:
   ramping_down:
     foreach: [nodes, techs, carriers, timesteps]
     where: "energy_ramping AND NOT timesteps=get_val_at_index(dim=timesteps, idx=0)"
-    equation:  -1 * energy_ramping * energy_cap <= $flow - roll($flow, timesteps=1)
+    equation: -1 * energy_ramping * energy_cap <= $flow - roll($flow, timesteps=1)
     components:
       flow: *ramping_flow
 
@@ -496,19 +496,18 @@ variables:
       max: 0
 
 objectives:
-    min_cost_optimisation:
-      equation: sum(sum(cost, over=[nodes, techs]) * objective_cost_class, over=costs) + $unmet_demand
-      components:
-        unmet_demand:
-          - where: "run.ensure_feasibility=True"
-            expression: sum(sum(unmet_demand - unused_supply, over=[carriers, nodes])  * timestep_weights, over=timesteps) * bigM
-          - where: "NOT run.ensure_feasibility=True"
-            expression: "0"
-      domain: Reals
-      sense: minimize
+  min_cost_optimisation:
+    equation: sum(sum(cost, over=[nodes, techs]) * objective_cost_class, over=costs) + $unmet_demand
+    components:
+      unmet_demand:
+        - where: "run.ensure_feasibility=True"
+          expression: sum(sum(unmet_demand - unused_supply, over=[carriers, nodes])  * timestep_weights, over=timesteps) * bigM
+        - where: "NOT run.ensure_feasibility=True"
+          expression: "0"
+    domain: Reals
+    sense: minimize
 
 expressions:
-
   cost_var:
     foreach: [nodes, techs, costs, timesteps]
     where: "cost_export OR cost_om_con OR cost_om_prod"
@@ -542,24 +541,24 @@ expressions:
     foreach: [nodes, techs, costs]
     where: "(cost_energy_cap OR cost_om_annual OR cost_om_annual_investment_fraction OR cost_purchase OR cost_resource_area OR cost_resource_cap OR cost_storage_cap) AND NOT run.mode=operate"
     equations:
-        - where: "NOT inheritance(transmission)"
-          expression: >
-            annualisation_weight * (
-              cost_depreciation_rate * (
+      - where: "NOT inheritance(transmission)"
+        expression: >
+          annualisation_weight * (
+            cost_depreciation_rate * (
+                $cost_energy_cap + $cost_storage_cap + $cost_resource_cap
+                + $cost_resource_area + $cost_of_purchase
+              ) * (1 + cost_om_annual_investment_fraction)
+              + cost_om_annual * energy_cap
+          )
+      - where: "inheritance(transmission)"
+        expression: >
+          annualisation_weight * (
+            cost_depreciation_rate * (
                   $cost_energy_cap + $cost_storage_cap + $cost_resource_cap
                   + $cost_resource_area + $cost_of_purchase
-                ) * (1 + cost_om_annual_investment_fraction)
+                ) * (0.5 + cost_om_annual_investment_fraction)
                 + cost_om_annual * energy_cap
-            )
-        - where: "inheritance(transmission)"
-          expression: >
-            annualisation_weight * (
-              cost_depreciation_rate * (
-                    $cost_energy_cap + $cost_storage_cap + $cost_resource_cap
-                    + $cost_resource_area + $cost_of_purchase
-                  ) * (0.5 + cost_om_annual_investment_fraction)
-                  + cost_om_annual * energy_cap
-            )
+          )
     components:
       cost_energy_cap:
         - where: "cost_energy_cap"
@@ -604,4 +603,3 @@ expressions:
           expression: sum(cost_var, over=timesteps)
         - where: "NOT (cost_export OR cost_om_con OR cost_om_prod)"
           expression: "0"
-

--- a/calliope/config/base_math.yaml
+++ b/calliope/config/base_math.yaml
@@ -70,13 +70,13 @@ constraints:
           expression: squeeze_carriers(carrier_prod / carrier_ratios[carrier_tiers=out], carrier_tier=out)
       c_2:
         - where: "[in_2] in carrier_tiers"
-          expression: squeeze_carriers(carrier_con / carrier_ratios[carrier_tiers=in_2], carrier_tier=[in_2])
+          expression: squeeze_carriers(carrier_con / carrier_ratios[carrier_tiers=in_2], carrier_tier=in_2)
         - where: "[in_3] in carrier_tiers"
-          expression: squeeze_carriers(carrier_con / carrier_ratios[carrier_tiers=in_3], carrier_tier=[in_3])
+          expression: squeeze_carriers(carrier_con / carrier_ratios[carrier_tiers=in_3], carrier_tier=in_3)
         - where: "[out_2] in carrier_tiers"
-          expression: squeeze_carriers(carrier_prod / carrier_ratios[carrier_tiers=out_2], carrier_tier=[out_2])
+          expression: squeeze_carriers(carrier_prod / carrier_ratios[carrier_tiers=out_2], carrier_tier=out_2)
         - where: "[out_3] in carrier_tiers"
-          expression: squeeze_carriers(carrier_prod / carrier_ratios[carrier_tiers=out_3], carrier_tier=[out_3])
+          expression: squeeze_carriers(carrier_prod / carrier_ratios[carrier_tiers=out_3], carrier_tier=out_3)
 
   conversion_plus_prod_con_to_zero:
     foreach: [nodes, techs, carriers, timesteps]

--- a/calliope/core/model.py
+++ b/calliope/core/model.py
@@ -481,12 +481,30 @@ class Model(object):
         include: Literal["all", "valid"] = "all",
         format: Optional[_ALLOWED_MATH_FILE_FORMATS] = None,
     ) -> Optional[str]:
+        """Generate a string representation of the mathematical formulation using LaTeX math notation to write to file or to return as a string.
+
+        Args:
+            filename (Optional[str], optional):
+                If given, will write the built mathematical formulation to a file with the given extension as the file format. Defaults to None.
+            include (Literal["all", "valid"], optional):
+                Defines whether to include all possible math equations ("all") or only those for which at least one index item in the "where" string is valid ("valid"). Defaults to "all".
+            format (Optional["tex", "rst", "md"], optional):
+                Not required if filename is given (as the format will be automatically inferred). Required if expecting a string return from calling this function. The LaTeX math will be embedded in a document of the given format (tex=LaTeX, rst=reStructuredText, md=Markdown). Defaults to None.
+
+        Raises:
+            ValueError: The file format (inferred automatically from `filename` or given by `format`) must be one of ["tex", "rst", "md"].
+
+        Returns:
+            Optional[str]:
+                If `filename` is None, the built mathematical formulation documentation will be returned as a string.
+        """
         if format is None and filename is not None:
             format = Path(filename).suffix.removeprefix(".")  # type: ignore
 
-        if format not in typing.get_args(_ALLOWED_MATH_FILE_FORMATS):
+        allowed_formats = typing.get_args(_ALLOWED_MATH_FILE_FORMATS)
+        if format not in allowed_formats:
             raise ValueError(
-                f"Math documentation style must be one of {_ALLOWED_MATH_FILE_FORMATS}, received `{format}`"
+                f"Math documentation style must be one of {allowed_formats}, received `{format}`"
             )
 
         self.build(backend_interface="latex", include=include, format=format)

--- a/calliope/preprocess/model_data.py
+++ b/calliope/preprocess/model_data.py
@@ -342,7 +342,6 @@ class ModelDataFactory:
 
     def _add_var_attrs(self):
         for var_data in self.model_data.data_vars.values():
-            var_data.attrs["parameters"] = 1
             var_data.attrs["is_result"] = 0
 
     @staticmethod

--- a/calliope/test/test_backend_latex_backend.py
+++ b/calliope/test/test_backend_latex_backend.py
@@ -1,0 +1,385 @@
+import pytest
+import textwrap
+
+import xarray as xr
+from calliope.backend import latex_backend
+from calliope import exceptions
+from calliope.test.common.util import check_error_or_warning
+
+
+class TestLatexBackendModel:
+    @pytest.fixture(scope="class")
+    def valid_latex_backend(self):
+        return latex_backend.LatexBackendModel(include="valid")
+
+    @pytest.mark.parametrize(
+        "backend_obj", ["valid_latex_backend", "dummy_latex_backend_model"]
+    )
+    def test_add_parameter(self, request, backend_obj):
+        latex_backend_model = request.getfixturevalue(backend_obj)
+        latex_backend_model.add_parameter("param", xr.DataArray(1))
+        assert latex_backend_model.parameters["param"] == xr.DataArray(1)
+        assert "param" in latex_backend_model.valid_arithmetic_components
+
+    @pytest.mark.parametrize(
+        "backend_obj", ["valid_latex_backend", "dummy_latex_backend_model"]
+    )
+    def test_add_variable(self, request, dummy_model_data, backend_obj):
+        latex_backend_model = request.getfixturevalue(backend_obj)
+        latex_backend_model.add_variable(
+            dummy_model_data,
+            "var",
+            {
+                "foreach": ["nodes", "techs"],
+                "where": "with_inf",
+                "bounds": {"min": 0, "max": 1},
+            },
+        )
+        # some null values might be introduced by the foreach array, so we just check the upper bound
+        assert (
+            latex_backend_model.variables["var"].sum()
+            <= dummy_model_data.with_inf_as_bool.sum()
+        )
+        assert "var" in latex_backend_model.valid_arithmetic_components
+        assert latex_backend_model._instance["variables"][-1]["name"] == "var"
+
+    def test_add_variable_not_valid(self, dummy_model_data, valid_latex_backend):
+        valid_latex_backend.add_variable(
+            dummy_model_data,
+            "invalid_var",
+            {
+                "foreach": ["nodes", "techs"],
+                "where": "False",
+                "bounds": {"min": 0, "max": 1},
+            },
+        )
+        # some null values might be introduced by the foreach array, so we just check the upper bound
+        assert not valid_latex_backend.variables["invalid_var"].sum()
+        assert "invalid_var" in valid_latex_backend.valid_arithmetic_components
+        assert valid_latex_backend._instance["variables"][-1]["name"] != "invalid_var"
+
+    @pytest.mark.parametrize(
+        "backend_obj", ["valid_latex_backend", "dummy_latex_backend_model"]
+    )
+    def test_add_expression(self, request, dummy_model_data, backend_obj):
+        latex_backend_model = request.getfixturevalue(backend_obj)
+        latex_backend_model.add_expression(
+            dummy_model_data,
+            "expr",
+            {
+                "foreach": ["nodes", "techs"],
+                "where": "with_inf",
+                "equation": "var + param",
+            },
+        )
+        # some null values might be introduced by the foreach array, so we just check the upper bound
+        assert (
+            latex_backend_model.expressions["expr"].sum()
+            <= dummy_model_data.with_inf_as_bool.sum()
+        )
+        assert "expr" in latex_backend_model.valid_arithmetic_components
+        assert latex_backend_model._instance["expressions"][-1]["name"] == "expr"
+
+    @pytest.mark.parametrize(
+        "backend_obj", ["valid_latex_backend", "dummy_latex_backend_model"]
+    )
+    def test_add_constraint(self, request, dummy_model_data, backend_obj):
+        latex_backend_model = request.getfixturevalue(backend_obj)
+        latex_backend_model.add_constraint(
+            dummy_model_data,
+            "constr",
+            {
+                "foreach": ["nodes", "techs"],
+                "where": "with_inf",
+                "equation": "var >= param",
+            },
+        )
+        # some null values might be introduced by the foreach array, so we just check the upper bound
+        assert (
+            latex_backend_model.constraints["constr"].sum()
+            <= dummy_model_data.with_inf_as_bool.sum()
+        )
+        assert "constr" not in latex_backend_model.valid_arithmetic_components
+        assert latex_backend_model._instance["constraints"][-1]["name"] == "constr"
+
+    def test_add_constraint_not_valid(self, dummy_model_data, valid_latex_backend):
+        valid_latex_backend.add_constraint(
+            dummy_model_data,
+            "invalid_constr",
+            {
+                "foreach": ["nodes", "techs"],
+                "where": "False",
+                "equations": [
+                    {"expression": "var >= param"},
+                    {"expression": "var >= expr"},
+                ],
+            },
+        )
+        assert not valid_latex_backend.constraints["invalid_constr"].any()
+        assert (
+            valid_latex_backend._instance["constraints"][-1]["name"] != "invalid_constr"
+        )
+
+    def test_add_constraint_one_not_valid(self, dummy_model_data, valid_latex_backend):
+        valid_latex_backend.add_constraint(
+            dummy_model_data,
+            "valid_constr",
+            {
+                "foreach": ["nodes", "techs"],
+                "where": "with_inf",
+                "equations": [
+                    {"expression": "var >= param"},
+                    {"expression": "var <= expr", "where": "False"},
+                ],
+            },
+        )
+        assert (
+            valid_latex_backend._instance["constraints"][-1]["name"] == "valid_constr"
+        )
+        assert (
+            "expr" not in valid_latex_backend._instance["constraints"][-1]["expression"]
+        )
+
+    def test_add_objective(self, dummy_model_data, dummy_latex_backend_model):
+        dummy_latex_backend_model.add_objective(
+            dummy_model_data,
+            "obj",
+            {"equation": "sum(var, over=[nodes, techs])", "sense": "minimize"},
+        )
+        assert dummy_latex_backend_model.objectives["obj"].isnull().all()
+        assert "obj" not in dummy_latex_backend_model.valid_arithmetic_components
+        assert len(dummy_latex_backend_model._instance["objectives"]) == 1
+
+    def test_get_parameter(self, dummy_latex_backend_model):
+        param = dummy_latex_backend_model.get_parameter("param")
+        assert param.equals(xr.DataArray(1))
+
+    def test_create_obj_list(self, dummy_latex_backend_model):
+        assert dummy_latex_backend_model.create_obj_list("var", "variables") is None
+
+    def test_get_constraint(self, dummy_latex_backend_model):
+        constr = dummy_latex_backend_model.get_constraint("constr")
+        assert constr.equals(dummy_latex_backend_model.constraints["constr"])
+
+    def test_get_variable(self, dummy_latex_backend_model):
+        var = dummy_latex_backend_model.get_variable("var")
+        assert var.equals(dummy_latex_backend_model.variables["var"])
+
+    def test_get_expression(self, dummy_latex_backend_model):
+        expr = dummy_latex_backend_model.get_expression("expr")
+        assert expr.equals(dummy_latex_backend_model.expressions["expr"])
+
+    def test_solve(self, dummy_latex_backend_model):
+        with pytest.raises(exceptions.BackendError) as excinfo:
+            dummy_latex_backend_model.solve("cbc")
+        assert check_error_or_warning(excinfo, "Cannot solve a LaTex backend model")
+
+    @pytest.mark.parametrize(
+        ["format", "expected"],
+        [
+            (
+                "tex",
+                textwrap.dedent(
+                    r"""
+                    \documentclass{article}
+
+                    \usepackage{amsmath}
+                    \usepackage[T1]{fontenc}
+                    \usepackage{graphicx}
+                    \usepackage[landscape, margin=2mm]{geometry}
+
+                    \AtBeginDocument{ % escape underscores that are not in math
+                        \catcode`_=12
+                        \begingroup\lccode`~=`_
+                        \lowercase{\endgroup\let~}\sb
+                        \mathcode`_="8000
+                    }
+
+                    \begin{document}
+                    \section{Objective}
+                    \section{Subject to}
+                    \section{Where}
+
+                    \paragraph{ expr }
+                    \begin{equation}
+                    \resizebox{\ifdim\width>\linewidth0.95\linewidth\else\width\fi}{!}{$
+                    \begin{array}{r}
+                    \end{array}
+                    \begin{cases}
+                        1 + 2&\quad
+                        \\
+                    \end{cases}
+                    $}
+                    \end{equation}
+                    \section{Decision Variables}
+                    \end{document}"""
+                ),
+            ),
+            (
+                "rst",
+                textwrap.dedent(
+                    r"""
+                    Objective
+                    #########
+
+                    Subject to
+                    ##########
+
+                    Where
+                    #####
+
+                    expr
+                    ====
+
+                    .. container:: scrolling-wrapper
+
+                        .. math::
+                            \begin{array}{r}
+                            \end{array}
+                            \begin{cases}
+                                1 + 2&\quad
+                                \\
+                            \end{cases}
+
+                    Decision Variables
+                    ##################
+                    """
+                ),
+            ),
+            (
+                "md",
+                textwrap.dedent(
+                    r"""
+                    # Objective
+
+                    # Subject to
+
+                    # Where
+
+                    ## expr
+                        ```math
+                        \begin{array}{r}
+                        \end{array}
+                        \begin{cases}
+                            1 + 2&\quad
+                            \\
+                        \end{cases}
+                        ```
+
+                    # Decision Variables
+                    """
+                ),
+            ),
+        ],
+    )
+    def test_generate_math_doc(self, dummy_model_data, format, expected):
+        latex_backend_model = latex_backend.LatexBackendModel(format=format)
+        latex_backend_model.add_expression(
+            dummy_model_data, "expr", {"equation": "1 + 2"}
+        )
+        doc = latex_backend_model.generate_math_doc()
+        assert doc == expected
+
+    @pytest.mark.parametrize(
+        ["kwargs", "expected"],
+        [
+            (
+                {"sets": ["nodes", "techs"]},
+                textwrap.dedent(
+                    r"""
+                \begin{array}{r}
+                    \forall{}
+                    \text{\,node\,} \in \text{\,nodes, \,}
+                    \text{\,tech\,} \in \text{\,techs\,}
+                    \\
+                \end{array}
+                \begin{cases}
+                \end{cases}"""
+                ),
+            ),
+            (
+                {"sense": r"\min{}"},
+                textwrap.dedent(
+                    r"""
+                \begin{array}{r}
+                    \min{}
+                \end{array}
+                \begin{cases}
+                \end{cases}"""
+                ),
+            ),
+            (
+                {"where": r"foo \land bar"},
+                textwrap.dedent(
+                    r"""
+                \begin{array}{r}
+                    if foo \land bar
+                \end{array}
+                \begin{cases}
+                \end{cases}"""
+                ),
+            ),
+            (
+                {"where": r""},
+                textwrap.dedent(
+                    r"""
+                \begin{array}{r}
+                \end{array}
+                \begin{cases}
+                \end{cases}"""
+                ),
+            ),
+            (
+                {
+                    "equations": [
+                        {"expression": "foo", "where": "bar"},
+                        {"expression": "foo + 1", "where": ""},
+                    ]
+                },
+                textwrap.dedent(
+                    r"""
+                \begin{array}{r}
+                \end{array}
+                \begin{cases}
+                    foo&\quad
+                    if bar
+                    \\
+                    foo + 1&\quad
+                    \\
+                \end{cases}"""
+                ),
+            ),
+        ],
+    )
+    def test_generate_math_string(self, dummy_latex_backend_model, kwargs, expected):
+        da = xr.DataArray()
+        dummy_latex_backend_model._generate_math_string(
+            "foo", da, "constraints", **kwargs
+        )
+        assert da.math_string == expected
+        assert dummy_latex_backend_model._instance["constraints"][-1] == {
+            "expression": expected,
+            "name": "foo",
+        }
+
+    @pytest.mark.parametrize(
+        ["instring", "kwargs", "expected"],
+        [
+            ("{{ foo }}", {"foo": 1}, "1"),
+            ("{{ foo|removesuffix('s') }}", {"foo": "bars"}, "bar"),
+            ("{{ foo }} + {{ bar }}", {"foo": "1", "bar": "2"}, "1 + 2"),
+        ],
+    )
+    def test_render(self, dummy_latex_backend_model, instring, kwargs, expected):
+        rendered = dummy_latex_backend_model._render(instring, **kwargs)
+        assert rendered == expected
+
+    def test_get_capacity_bounds(self, dummy_latex_backend_model, dummy_model_data):
+        bounds = {"min": 1, "max": 2e6}
+        lb, ub = dummy_latex_backend_model._get_capacity_bounds(
+            bounds, "var", dummy_model_data
+        )
+        assert lb == {"expression": r"1 \leq \textbf{var}_\text{node,tech}"}
+        assert ub == {
+            "expression": r"\textbf{var}_\text{node,tech} \leq 2\mathord{\times}10^{+06}"
+        }

--- a/calliope/test/test_backend_pyomo.py
+++ b/calliope/test/test_backend_pyomo.py
@@ -1899,7 +1899,7 @@ class TestNewBackend:
             var.to_series().dropna().apply(lambda x: isinstance(x, pmo.variable)).all()
         )
         assert var.attrs == {
-            "variables": 1,
+            "obj_type": "variables",
             "references": {
                 "carrier_consumption_max",
                 "carrier_production_max",
@@ -1928,7 +1928,7 @@ class TestNewBackend:
             .all()
         )
         assert param.attrs == {
-            "parameters": 1,
+            "obj_type": "parameters",
             "is_result": 0,
             "references": {"balance_demand", "balance_transmission"},
         }
@@ -1952,7 +1952,7 @@ class TestNewBackend:
             .apply(lambda x: isinstance(x, pmo.expression))
             .all()
         )
-        assert expr.attrs == {"expressions": 1, "references": {"cost"}}
+        assert expr.attrs == {"obj_type": "expressions", "references": {"cost"}}
 
     def test_new_build_get_expression_as_str(self, simple_supply_new_build):
         expr = simple_supply_new_build.backend.get_expression(
@@ -1976,7 +1976,7 @@ class TestNewBackend:
             .apply(lambda x: isinstance(x, pmo.constraint))
             .all()
         )
-        assert constr.attrs == {"constraints": 1, "references": set()}
+        assert constr.attrs == {"obj_type": "constraints", "references": set()}
 
     def test_new_build_get_constraint_as_str(self, simple_supply_new_build):
         constr = simple_supply_new_build.backend.get_constraint(

--- a/calliope/test/test_core_model.py
+++ b/calliope/test/test_core_model.py
@@ -1,8 +1,8 @@
 import os
+import typing
+from pathlib import Path
 
 import pytest
-import tempfile
-import pandas as pd
 import numpy as np
 
 import calliope
@@ -209,3 +209,42 @@ class TestOptimisationConfigOverrides:
                 assert new[i]["max"] == new[i]["max"]
             else:
                 assert base[i] == new[i]
+
+
+class TestWriteMathDocumentation:
+    @pytest.fixture
+    def simple_supply_no_build(self):
+        return build_model({}, "simple_supply,two_hours,investment_costs")
+
+    @pytest.mark.parametrize(
+        ["format", "startswith"],
+        [
+            ("tex", "\n\\documentclass{article}"),
+            ("rst", "\nObjective"),
+            ("md", "\n# Objective"),
+        ],
+    )
+    @pytest.mark.parametrize("include", ["all", "valid"])
+    def test_string_return(self, simple_supply_no_build, format, startswith, include):
+        string_math = simple_supply_no_build.write_math_documentation(
+            None, include, format
+        )
+        assert string_math.startswith(startswith)
+
+    def test_to_file(self, simple_supply_no_build, tmpdir_factory):
+        filepath = tmpdir_factory.mktemp("custom_math").join("custom-math.tex")
+        simple_supply_no_build.write_math_documentation(filepath, "all")
+        assert Path(filepath).exists()
+
+    @pytest.mark.parametrize(
+        ["filepath", "format"],
+        [(None, "foo"), ("myfile.foo", None), ("myfile.tex", "foo")],
+    )
+    def test_invalid_format(
+        self, simple_supply_no_build, tmpdir_factory, filepath, format
+    ):
+        if filepath is not None:
+            filepath = tmpdir_factory.mktemp("custom_math").join(filepath)
+        with pytest.raises(ValueError) as excinfo:
+            simple_supply_no_build.write_math_documentation(None, "all", "foo")
+        check_error_or_warning(excinfo, "Math documentation style must be one of")

--- a/calliope/test/test_equation_parser.py
+++ b/calliope/test/test_equation_parser.py
@@ -11,15 +11,48 @@ from calliope import exceptions
 
 
 COMPONENT_CLASSIFIER = equation_parser.COMPONENT_CLASSIFIER
-HELPER_FUNCS = {
-    "dummy_func_1": lambda **kwargs: lambda x: x * 10,
-    "dummy_func_2": lambda **kwargs: lambda x, y: x + y,
-}
+
+
+def dummy_func_1(as_latex=False, **kwargs):
+    def _dummy_func_1(x):
+        return x * 10
+
+    def _as_latex(x):
+        return f"{x} * 10"
+
+    if as_latex:
+        return _as_latex
+    else:
+        return _dummy_func_1
+
+
+def dummy_func_2(as_latex=False, **kwargs):
+    def _dummy_func_2(x, y):
+        return x + y
+
+    def _as_latex(x, y):
+        return f"{x} + {y}"
+
+    if as_latex:
+        return _as_latex
+    else:
+        return _dummy_func_2
+
+
+HELPER_FUNCS = {"dummy_func_1": dummy_func_1, "dummy_func_2": dummy_func_2}
 
 
 @pytest.fixture
 def valid_object_names():
-    return ["foo", "foo_bar", "bar"]
+    return [
+        "foo",
+        "foo_bar",
+        "with_inf",
+        "only_techs",
+        "no_dims",
+        "multi_dim_var",
+        "no_dim_var",
+    ]
 
 
 @pytest.fixture
@@ -122,10 +155,10 @@ def helper_function_no_nesting(
 
 @pytest.fixture(
     params=[
-        ("number", "1.0", ["$foo", "foo", "foo[bars=bar1]"]),
-        ("sliced_param", "foo[bars=bar1]", ["1.0", "foo", "$foo"]),
-        ("component", "$foo", ["1.0", "foo", "foo[bars=bar1]"]),
-        ("unsliced_param_with_obj_names", "foo", ["1.0", "$foo", "foo[bars=bar1]"]),
+        ("number", "1.0", ["$foo", "foo", "foo[bars=bar]"]),
+        ("sliced_param", "foo[bars=bar]", ["1.0", "foo", "$foo"]),
+        ("component", "$foo", ["1.0", "foo", "foo[bars=bar]"]),
+        ("unsliced_param_with_obj_names", "foo", ["1.0", "$foo", "foo[bars=bar]"]),
     ]
 )
 def helper_function_one_parser_in_args(identifier, request):
@@ -364,15 +397,15 @@ class TestEquationParserElements:
     @pytest.mark.parametrize(
         "string_val",
         [
-            "foobar[bars=bar1]",  # name not in allowed list
-            "foo [bars=bar1]",  # space between param name and slicing
-            "foo[techs=tech bars=bar1]",  # missing delimination
+            "foobar[bars=bar]",  # name not in allowed list
+            "foo [bars=bar]",  # space between param name and slicing
+            "foo[techs=tech bars=bar]",  # missing delimination
             "foo[]",  # missing set and index slice
             "foo[techs]",  # missing index slice/set
             "foo[techs=]",  # missing index slice
             "foo[=techs]",  # missing set
-            "[bars=bar1]",  # missing component name
-            "foo(bars=bar1)",  # incorrect brackets
+            "[bars=bar]",  # missing component name
+            "foo(bars=bar)",  # incorrect brackets
         ],
     )
     def test_fail_string_issues_sliced_param(self, sliced_param, string_val):
@@ -458,12 +491,12 @@ class TestEquationParserElements:
                 },
             ),
             (
-                "dummy_func_1(1, foo[bars=bar1])",
+                "dummy_func_1(1, foo[bars=bar])",
                 {
                     "function": "dummy_func_1",
                     "args": [
                         1,
-                        {"param_or_var_name": "foo", "dimensions": {"bars": "bar1"}},
+                        {"param_or_var_name": "foo", "dimensions": {"bars": "bar"}},
                     ],
                     "kwargs": {},
                 },
@@ -549,7 +582,7 @@ class TestEquationParserElements:
                 },
             ),
             (
-                "dummy_func_1(1, dummy_func_2(1, foo[bars=$bar]), foo[foos=foo1, bars=bar1], $foo, 1, bar)",
+                "dummy_func_1(1, dummy_func_2(1, foo[bars=$bar]), foo[foos=foo1, bars=bar1], $foo, 1, foo)",
                 {
                     "function": "dummy_func_1",
                     "args": [
@@ -573,7 +606,7 @@ class TestEquationParserElements:
                         },
                         {"component": "foo"},
                         1,
-                        {"param_or_var_name": "bar"},
+                        {"param_or_var_name": "foo"},
                     ],
                     "kwargs": {},
                 },
@@ -729,12 +762,12 @@ class TestEquationParserArithmetic:
 
     @pytest.mark.parametrize("number_", numbers)
     @pytest.mark.parametrize("component_", ["$foo", "$bar1"])
-    @pytest.mark.parametrize("unsliced_param_", ["foo", "bar"])
+    @pytest.mark.parametrize("unsliced_param_", ["foo", "foo_bar"])
     @pytest.mark.parametrize(
-        "sliced_param_", ["foo[bars=bar1]", "bar[foos=foo1, bars=$bar]"]
+        "sliced_param_", ["foo[bars=bar1]", "foo_bar[foos=foo1, bars=$bar]"]
     )
     @pytest.mark.parametrize(
-        "helper_function_", ["foo(1)", "bar1(foo, $foo, bar[foos=foo1], x=1)"]
+        "helper_function_", ["foo(1)", "bar1(foo, $foo, foo_bar[foos=foo1], x=1)"]
     )
     @pytest.mark.parametrize(
         "func_string", ["arithmetic", "helper_function_allow_arithmetic"]
@@ -865,7 +898,7 @@ class TestEquationParserComparison:
         },
         "foo[bars=bar1]": {"param_or_var_name": "foo", "dimensions": {"bars": "bar1"}},
         "$foo": {"component": "foo"},
-        "dummy_func_1(1, foo[bars=$bar], $foo, x=dummy_func_2(1, y=2), foo=bar)": {
+        "dummy_func_1(1, foo[bars=$bar], $foo, x=dummy_func_2(1, y=2), foo=foo_bar)": {
             "function": "dummy_func_1",
             "args": [
                 1,
@@ -877,7 +910,7 @@ class TestEquationParserComparison:
             ],
             "kwargs": {
                 "x": {"function": "dummy_func_2", "args": [1], "kwargs": {"y": 2}},
-                "foo": {"param_or_var_name": "bar"},
+                "foo": {"param_or_var_name": "foo_bar"},
             },
         },
     }
@@ -986,3 +1019,125 @@ class TestEquationParserComparison:
         )
         parsed_ = equation_comparison.parse_string(parse_string, parse_all=True)
         assert str(parsed_[0]) == expected
+
+
+class TestAsLatex:
+    @pytest.fixture
+    def latex_eval_kwargs(self, dummy_latex_backend_model, dummy_model_data):
+        return {
+            "helper_func_dict": HELPER_FUNCS,
+            "as_dict": False,
+            "as_latex": True,
+            "index_slice_dict": {},
+            "component_dict": {},
+            "equation_name": "foobar",
+            "apply_imask": False,
+            "references": set(),
+            "backend_interface": dummy_latex_backend_model,
+            "backend_dataset": dummy_latex_backend_model._dataset,
+            "model_data": dummy_model_data,
+        }
+
+    @pytest.mark.parametrize(
+        ["parser", "instring", "expected"],
+        [
+            ("number", "1", "1"),
+            ("number", "1.0", "1"),
+            ("number", "0.01", "0.01"),
+            ("number", "inf", "inf"),
+            ("number", "-1", "-1"),
+            ("number", "2000000", "2\\mathord{\\times}10^{+06}"),
+            ("evaluatable_identifier", "hello_there", "hello_there"),
+            ("id_list", "[hello, hello_there]", ["hello", "hello_there"]),
+            ("unsliced_param_with_obj_names", "no_dims", r"\textit{no_dims}"),
+            (
+                "unsliced_param_with_obj_names",
+                "with_inf",
+                r"\textit{with_inf}_\text{node,tech}",
+            ),
+            ("unsliced_param_with_obj_names", "no_dim_var", r"\textbf{no_dim_var}"),
+            (
+                "unsliced_param_with_obj_names",
+                "multi_dim_var",
+                r"\textbf{multi_dim_var}_\text{node,tech}",
+            ),
+            (
+                "sliced_param",
+                "with_inf[node=bar]",
+                r"\textit{with_inf}_\text{node=bar,tech}",
+            ),
+            (
+                "sliced_param",
+                "only_techs[tech=foobar]",
+                r"\textit{only_techs}_\text{tech=foobar}",
+            ),
+            (
+                "sliced_param",
+                "multi_dim_var[node=bar]",
+                r"\textbf{multi_dim_var}_\text{node=bar,tech}",
+            ),
+            (
+                "sliced_param",
+                "with_inf[node=bar, tech=foobar]",
+                r"\textit{with_inf}_\text{node=bar,tech=foobar}",
+            ),
+            (
+                "sliced_param",
+                "multi_dim_var[node=bar, tech=foobar]",
+                r"\textbf{multi_dim_var}_\text{node=bar,tech=foobar}",
+            ),
+            ("helper_function", "dummy_func_1(1)", r"1 * 10"),
+            (
+                "helper_function",
+                "dummy_func_2(1, with_inf)",
+                r"1 + \textit{with_inf}_\text{node,tech}",
+            ),
+            (
+                "helper_function",
+                "dummy_func_2(dummy_func_1(1), with_inf)",
+                r"1 * 10 + \textit{with_inf}_\text{node,tech}",
+            ),
+            ("arithmetic", "1 + with_inf", r"1 + \textit{with_inf}_\text{node,tech}"),
+            (
+                "arithmetic",
+                "multi_dim_var[node=bar] + with_inf",
+                r"\textbf{multi_dim_var}_\text{node=bar,tech} + \textit{with_inf}_\text{node,tech}",
+            ),
+            # We ignore zeros that make no difference
+            ("arithmetic", "0 + with_inf", r"\textit{with_inf}_\text{node,tech}"),
+            ("arithmetic", "0 - with_inf", r"\textit{with_inf}_\text{node,tech}"),
+            ("arithmetic", "with_inf - 0", r"\textit{with_inf}_\text{node,tech}"),
+            # We DO NOT ignore zeros that make a difference
+            ("arithmetic", "with_inf**0", r"\textit{with_inf}_\text{node,tech}^{0}"),
+            (
+                "arithmetic",
+                "0 * with_inf",
+                r"0 \times \textit{with_inf}_\text{node,tech}",
+            ),
+            (
+                "arithmetic",
+                "0 / with_inf",
+                r"\frac{ 0 }{ \textit{with_inf}_\text{node,tech} }",
+            ),
+            (
+                "arithmetic",
+                "(no_dims * no_dim_var) + (with_inf + 2)",
+                r"(\textit{no_dims} \times \textbf{no_dim_var}) + (\textit{with_inf}_\text{node,tech} + 2)",
+            ),
+            (
+                "equation_comparison",
+                "no_dim_var >= with_inf",
+                r"\textbf{no_dim_var} \geq \textit{with_inf}_\text{node,tech}",
+            ),
+            (
+                "equation_comparison",
+                "no_dim_var == with_inf",
+                r"\textbf{no_dim_var} = \textit{with_inf}_\text{node,tech}",
+            ),
+        ],
+    )
+    def test_latex_eval(self, request, latex_eval_kwargs, parser, instring, expected):
+        parser_func = request.getfixturevalue(parser)
+        parsed_ = parser_func.parse_string(instring, parse_all=True)
+        evaluated_ = parsed_[0].eval(**latex_eval_kwargs)
+        assert evaluated_ == expected

--- a/calliope/test/test_model_data.py
+++ b/calliope/test/test_model_data.py
@@ -390,7 +390,7 @@ class TestModelData:
 
         model_data._clean_model_data()
         for var in model_data.model_data.data_vars.values():
-            assert var.attrs == {"parameters": 1, "is_result": 0}
+            assert var.attrs == {"is_result": 0}
 
     @pytest.mark.parametrize("subdict", ["tech", "node"])
     def test_check_data(self, model_data, subdict):

--- a/calliope/test/test_subset_parser.py
+++ b/calliope/test/test_subset_parser.py
@@ -540,3 +540,49 @@ class TestParserMasking:
         with pytest.raises(pyparsing.ParseException) as excinfo:
             imasking.parse_string(instring, parse_all=True)
         assert check_error_or_warning(excinfo, "Expected")
+
+
+class TestAsLatex:
+    @pytest.fixture
+    def latex_eval_kwargs(self, eval_kwargs):
+        eval_kwargs["as_latex"] = True
+        return eval_kwargs
+
+    @pytest.mark.parametrize(
+        ["parser", "instring", "expected"],
+        [
+            ("data_var", "with_inf", r"\exists (\textit{with_inf}_\text{node,tech})"),
+            ("data_var", "foo", r"\exists (\textit{foo})"),
+            ("data_var", "no_dims", r"\exists (\textit{no_dims})"),
+            ("config_option", "run.foo", r"\text{run_config.foo}"),
+            ("bool_operand", "True", "true"),
+            ("comparison", "run.foo>1", r"\text{run_config.foo}\mathord{>}\text{1}"),
+            (
+                "comparison",
+                "with_inf=True",
+                r"\textit{with_inf}_\text{node,tech}\mathord{=}\text{true}",
+            ),
+            ("subset", "[foo, bar] in foos", r"\text{foo} \in \text{[foo,bar]}"),
+            ("imasking", "NOT no_dims", r"\neg (\exists (\textit{no_dims}))"),
+            (
+                "imasking",
+                "true AND with_inf",
+                r"\exists (\textit{with_inf}_\text{node,tech})",
+            ),
+            (
+                "imasking",
+                "with_inf AND true",
+                r"\exists (\textit{with_inf}_\text{node,tech})",
+            ),
+            (
+                "imasking",
+                "no_dims AND (with_inf OR run.foo>1)",
+                r"\exists (\textit{no_dims}) \land (\exists (\textit{with_inf}_\text{node,tech}) \lor \text{run_config.foo}\mathord{>}\text{1})",
+            ),
+        ],
+    )
+    def test_latex_eval(self, request, latex_eval_kwargs, parser, instring, expected):
+        parser_func = request.getfixturevalue(parser)
+        parsed_ = parser_func.parse_string(instring, parse_all=True)
+        evaluated_ = parsed_[0].eval(**latex_eval_kwargs)
+        assert evaluated_ == expected

--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ import xarray as xr
 import numpy as np
 
 from calliope.test.common.util import build_test_model as build_model
+from calliope.backend import latex_backend, backends
 from calliope import AttrDict
 
 
@@ -135,6 +136,7 @@ def dummy_model_data():
                 [[1.0, np.nan, 1.0, 3], [np.inf, 2.0, True, np.nan]],
             ),
             "only_techs": (["techs"], [np.nan, 1, 2, 3]),
+            "no_dims": (2),
             "all_inf": (["nodes", "techs"], np.ones((2, 4)) * np.inf, {"is_result": 1}),
             "all_nan": (["nodes", "techs"], np.ones((2, 4)) * np.nan),
             "all_false": (["nodes", "techs"], np.zeros((2, 4)).astype(bool)),
@@ -196,6 +198,9 @@ def dummy_model_data():
     for k in ["link_remote_nodes", "link_remote_techs"]:
         model_data[k] = model_data[k].where(model_data[k] != "nan")
 
+    for param in model_data.data_vars.values():
+        param.attrs["is_result"] = 0
+
     model_data.attrs["run_config"] = AttrDict(
         {"foo": True, "bar": {"foobar": "baz"}, "foobar": {"baz": {"foo": np.inf}}}
     )
@@ -205,3 +210,32 @@ def dummy_model_data():
         {"all_inf": np.inf, "all_nan": np.nan, "with_inf": 100, "only_techs": 5}
     )
     return model_data
+
+
+def populate_backend_model(backend, model_data):
+    backend.add_all_parameters(model_data, model_data.run_config)
+    backend.add_variable(
+        model_data,
+        "multi_dim_var",
+        {
+            "foreach": ["nodes", "techs"],
+            "where": "with_inf",
+            "bounds": {"min": "0", "max": ".inf"},
+        },
+    )
+    backend.add_variable(
+        model_data, "no_dim_var", {"bounds": {"min": "-1", "max": "1"}}
+    )
+    return backend
+
+
+@pytest.fixture(scope="module")
+def dummy_pyomo_backend_model(dummy_model_data):
+    backend = backends.PyomoBackendModel()
+    return populate_backend_model(backend, dummy_model_data)
+
+
+@pytest.fixture(scope="module")
+def dummy_latex_backend_model(dummy_model_data):
+    backend = latex_backend.LatexBackendModel()
+    return populate_backend_model(backend, dummy_model_data)

--- a/doc/_static/math.rst
+++ b/doc/_static/math.rst
@@ -1,0 +1,1964 @@
+
+Objective
+#########
+
+min_cost_optimisation
+=====================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \min{}
+        \end{array}
+        \begin{cases}
+            \sum\limits_{\text{cost} \in \text{costs}} (\sum\limits_{\substack{\text{node} \in \text{nodes} \\ \text{tech} \in \text{techs}}} (\textbf{cost}_\text{tech,node,cost}) \times \textit{objective_cost_class}_\text{cost}) + \sum\limits_{\text{timestep} \in \text{timesteps}} (\sum\limits_{\substack{\text{carrier} \in \text{carriers} \\ \text{node} \in \text{nodes}}} (\textbf{unmet_demand}_\text{carrier,node,timestep} - \textbf{unused_supply}_\text{carrier,node,timestep}) \times \textit{timestep_weights}_\text{timestep}) \times \textit{bigM}&\quad
+            if (\text{run_config.ensure_feasibility}\mathord{=}\text{true})
+            \\
+            \sum\limits_{\text{cost} \in \text{costs}} (\sum\limits_{\substack{\text{node} \in \text{nodes} \\ \text{tech} \in \text{techs}}} (\textbf{cost}_\text{tech,node,cost}) \times \textit{objective_cost_class}_\text{cost})&\quad
+            if (\neg (\text{run_config.ensure_feasibility}\mathord{=}\text{true}))
+            \\
+        \end{cases}
+
+Subject to
+##########
+
+energy_capacity_per_storage_capacity_min
+========================================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\exists (\textit{energy_cap_per_storage_cap_min}) \land \neg (\exists (\textit{energy_cap_per_storage_cap_equals})) \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
+        \end{array}
+        \begin{cases}
+            \textbf{energy_cap}_\text{tech,node}\geq{}\textbf{storage_cap}_\text{tech,node} \times \textit{energy_cap_per_storage_cap_min}_\text{node,tech}&\quad
+            \\
+        \end{cases}
+
+energy_capacity_per_storage_capacity_max
+========================================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\exists (\textit{energy_cap_per_storage_cap_max}) \land \neg (\exists (\textit{energy_cap_per_storage_cap_equals})) \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
+        \end{array}
+        \begin{cases}
+            \textbf{energy_cap}_\text{tech,node}\leq{}\textbf{storage_cap}_\text{tech,node} \times \textit{energy_cap_per_storage_cap_max}_\text{node,tech}&\quad
+            \\
+        \end{cases}
+
+energy_capacity_per_storage_capacity_equals
+===========================================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\exists (\textit{energy_cap_per_storage_cap_equals}) \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
+        \end{array}
+        \begin{cases}
+            \textbf{energy_cap}_\text{tech,node} = \textbf{storage_cap}_\text{tech,node} \times \textit{energy_cap_per_storage_cap_equals}_\text{node,tech}&\quad
+            \\
+        \end{cases}
+
+resource_capacity_equals_energy_capacity
+========================================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\textit{resource_cap_equals_energy_cap}\mathord{=}\text{true} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
+        \end{array}
+        \begin{cases}
+            \textbf{resource_cap}_\text{tech,node} = \textbf{energy_cap}_\text{tech,node}&\quad
+            \\
+        \end{cases}
+
+force_zero_resource_area
+========================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}) \land \textit{energy_cap_max}\mathord{=}\text{0})
+        \end{array}
+        \begin{cases}
+            \textbf{resource_area}_\text{tech,node} = 0&\quad
+            \\
+        \end{cases}
+
+resource_area_per_energy_capacity
+=================================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\exists (\textit{resource_area_per_energy_cap}) \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
+        \end{array}
+        \begin{cases}
+            \textbf{resource_area}_\text{tech,node} = \textbf{energy_cap}_\text{tech,node} \times \textit{resource_area_per_energy_cap}_\text{node,tech}&\quad
+            \\
+        \end{cases}
+
+resource_area_capacity_per_loc
+==============================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes
+            \\
+            if (\exists (\textit{available_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}) \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
+        \end{array}
+        \begin{cases}
+            \sum\limits_{\text{tech} \in \text{techs}} (\textbf{resource_area}_\text{tech,node})\leq{}\textit{available_area}_\text{node}&\quad
+            \\
+        \end{cases}
+
+energy_capacity_systemwide
+==========================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            tech \in techs
+            \\
+            if (\exists (\textit{energy_cap_equals_systemwide}) \lor \exists (\textit{energy_cap_max_systemwide}) \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
+        \end{array}
+        \begin{cases}
+            \sum\limits_{\text{node} \in \text{nodes}} (\textbf{energy_cap}_\text{tech,node}) = \textit{energy_cap_equals_systemwide}_\text{tech}&\quad
+            if (\exists (\textit{energy_cap_equals_systemwide}))
+            \\
+            \sum\limits_{\text{node} \in \text{nodes}} (\textbf{energy_cap}_\text{tech,node})\leq{}\textit{energy_cap_max_systemwide}_\text{tech}&\quad
+            if (\neg (\exists (\textit{energy_cap_equals_systemwide})))
+            \\
+        \end{cases}
+
+balance_conversion_plus_primary
+===============================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            timestep \in timesteps
+            \\
+            if (\text{tech_group=conversion_plus} \land \textit{carrier_ratios}\mathord{>}\text{0})
+        \end{array}
+        \begin{cases}
+            \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{carrier_ratios}_\text{carrier_tier,carrier,node,tech,timestep} }) = -1 \times \sum\limits_{\text{carrier} \in \text{carrier_tier(in)}} (\textbf{carrier_con}_\text{carrier,tech,node,timestep} \times \textit{carrier_ratios}_\text{carrier_tier,carrier,node,tech,timestep}) \times \textit{energy_eff}_\text{node,tech,timestep}&\quad
+            \\
+        \end{cases}
+
+carrier_production_max_conversion_plus
+======================================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            timestep \in timesteps
+            \\
+            if (\text{tech_group=conversion_plus} \land \neg (\textit{cap_method}\mathord{=}\text{integer}))
+        \end{array}
+        \begin{cases}
+            \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep})\leq{}\textit{timestep_resolution}_\text{timestep} \times \textbf{energy_cap}_\text{tech,node}&\quad
+            \\
+        \end{cases}
+
+carrier_production_min_conversion_plus
+======================================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            timestep \in timesteps
+            \\
+            if (\exists (\textit{energy_cap_min_use}) \land \text{tech_group=conversion_plus} \land \neg (\textit{cap_method}\mathord{=}\text{integer}))
+        \end{array}
+        \begin{cases}
+            \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep})\geq{}\textit{timestep_resolution}_\text{timestep} \times \textbf{energy_cap}_\text{tech,node} \times \textit{energy_cap_min_use}_\text{node,tech}&\quad
+            \\
+        \end{cases}
+
+balance_conversion_plus_non_primary
+===================================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier_tier \in carrier_tiers, 
+            timestep \in timesteps
+            \\
+            if (\text{tech_group=conversion_plus} \land \text{carrier_tier}\in \text{[in_2,out_2,in_3,out_3]} \land \textit{carrier_ratios}\mathord{>}\text{0})
+        \end{array}
+        \begin{cases}
+            \sum\limits_{\text{carrier} \in \text{carrier_tier(in)}} (\frac{ \textbf{carrier_con}_\text{carrier,tech,node,timestep} }{ \textit{carrier_ratios}_\text{carrier_tier,carrier,node,tech,timestep} }) = \sum\limits_{\text{carrier} \in \text{carrier_tier(in_2)}} (\frac{ \textbf{carrier_con}_\text{carrier,tech,node,timestep} }{ \textit{carrier_ratios}_\text{carrier_tier,carrier,node,tech,timestep} })&\quad
+            if (\text{carrier_tier}\in \text{[in_2,in_3]})\land{}(\text{carrier_tier}\in \text{[in_2]})
+            \\
+            \sum\limits_{\text{carrier} \in \text{carrier_tier(in)}} (\frac{ \textbf{carrier_con}_\text{carrier,tech,node,timestep} }{ \textit{carrier_ratios}_\text{carrier_tier,carrier,node,tech,timestep} }) = \sum\limits_{\text{carrier} \in \text{carrier_tier(in_3)}} (\frac{ \textbf{carrier_con}_\text{carrier,tech,node,timestep} }{ \textit{carrier_ratios}_\text{carrier_tier,carrier,node,tech,timestep} })&\quad
+            if (\text{carrier_tier}\in \text{[in_2,in_3]})\land{}(\text{carrier_tier}\in \text{[in_3]})
+            \\
+            \sum\limits_{\text{carrier} \in \text{carrier_tier(in)}} (\frac{ \textbf{carrier_con}_\text{carrier,tech,node,timestep} }{ \textit{carrier_ratios}_\text{carrier_tier,carrier,node,tech,timestep} }) = \sum\limits_{\text{carrier} \in \text{carrier_tier(out_2)}} (\frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{carrier_ratios}_\text{carrier_tier,carrier,node,tech,timestep} })&\quad
+            if (\text{carrier_tier}\in \text{[in_2,in_3]})\land{}(\text{carrier_tier}\in \text{[out_2]})
+            \\
+            \sum\limits_{\text{carrier} \in \text{carrier_tier(in)}} (\frac{ \textbf{carrier_con}_\text{carrier,tech,node,timestep} }{ \textit{carrier_ratios}_\text{carrier_tier,carrier,node,tech,timestep} }) = \sum\limits_{\text{carrier} \in \text{carrier_tier(out_3)}} (\frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{carrier_ratios}_\text{carrier_tier,carrier,node,tech,timestep} })&\quad
+            if (\text{carrier_tier}\in \text{[in_2,in_3]})\land{}(\text{carrier_tier}\in \text{[out_3]})
+            \\
+            \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{carrier_ratios}_\text{carrier_tier,carrier,node,tech,timestep} }) = \sum\limits_{\text{carrier} \in \text{carrier_tier(in_2)}} (\frac{ \textbf{carrier_con}_\text{carrier,tech,node,timestep} }{ \textit{carrier_ratios}_\text{carrier_tier,carrier,node,tech,timestep} })&\quad
+            if (\text{carrier_tier}\in \text{[out_2,out_3]})\land{}(\text{carrier_tier}\in \text{[in_2]})
+            \\
+            \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{carrier_ratios}_\text{carrier_tier,carrier,node,tech,timestep} }) = \sum\limits_{\text{carrier} \in \text{carrier_tier(in_3)}} (\frac{ \textbf{carrier_con}_\text{carrier,tech,node,timestep} }{ \textit{carrier_ratios}_\text{carrier_tier,carrier,node,tech,timestep} })&\quad
+            if (\text{carrier_tier}\in \text{[out_2,out_3]})\land{}(\text{carrier_tier}\in \text{[in_3]})
+            \\
+            \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{carrier_ratios}_\text{carrier_tier,carrier,node,tech,timestep} }) = \sum\limits_{\text{carrier} \in \text{carrier_tier(out_2)}} (\frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{carrier_ratios}_\text{carrier_tier,carrier,node,tech,timestep} })&\quad
+            if (\text{carrier_tier}\in \text{[out_2,out_3]})\land{}(\text{carrier_tier}\in \text{[out_2]})
+            \\
+            \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{carrier_ratios}_\text{carrier_tier,carrier,node,tech,timestep} }) = \sum\limits_{\text{carrier} \in \text{carrier_tier(out_3)}} (\frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{carrier_ratios}_\text{carrier_tier,carrier,node,tech,timestep} })&\quad
+            if (\text{carrier_tier}\in \text{[out_2,out_3]})\land{}(\text{carrier_tier}\in \text{[out_3]})
+            \\
+        \end{cases}
+
+conversion_plus_prod_con_to_zero
+================================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\textit{carrier_ratios}\mathord{=}\text{0} \land \text{tech_group=conversion_plus})
+        \end{array}
+        \begin{cases}
+            \textbf{carrier_con}_\text{carrier,tech,node,timestep} = 0&\quad
+            if (\text{carrier_tier}\in \text{[in,in_2,in_3]})
+            \\
+            \textbf{carrier_prod}_\text{carrier,tech,node,timestep} = 0&\quad
+            if (\text{carrier_tier}\in \text{[out,out_2,out_3]})
+            \\
+        \end{cases}
+
+balance_conversion
+==================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            timestep \in timesteps
+            \\
+            if (\text{tech_group=conversion})
+        \end{array}
+        \begin{cases}
+            \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) = -1 \times \sum\limits_{\text{carrier} \in \text{carrier_tier(in)}} (\textbf{carrier_con}_\text{carrier,tech,node,timestep}) \times \textit{energy_eff}_\text{node,tech,timestep}&\quad
+            \\
+        \end{cases}
+
+carrier_production_max
+======================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\exists (\textit{carrier}) \land \neg (\text{tech_group=conversion_plus}) \land \neg (\textit{cap_method}\mathord{=}\text{integer}) \land \textit{allowed_carrier_prod}\mathord{=}\text{true} \land \text{carrier_tier}\in \text{[out]})
+        \end{array}
+        \begin{cases}
+            \textbf{carrier_prod}_\text{carrier,tech,node,timestep}\leq{}\textbf{energy_cap}_\text{tech,node} \times \textit{timestep_resolution}_\text{timestep} \times \textit{parasitic_eff}_\text{node,tech,timestep}&\quad
+            \\
+        \end{cases}
+
+carrier_production_min
+======================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\exists (\textit{carrier}) \land \exists (\textit{energy_cap_min_use}) \land \neg (\text{tech_group=conversion_plus}) \land \neg (\textit{cap_method}\mathord{=}\text{integer}) \land \textit{allowed_carrier_prod}\mathord{=}\text{true} \land \text{carrier_tier}\in \text{[out]})
+        \end{array}
+        \begin{cases}
+            \textbf{carrier_prod}_\text{carrier,tech,node,timestep}\geq{}\textbf{energy_cap}_\text{tech,node} \times \textit{timestep_resolution}_\text{timestep} \times \textit{energy_cap_min_use}_\text{node,tech}&\quad
+            \\
+        \end{cases}
+
+carrier_consumption_max
+=======================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\exists (\textit{carrier}) \land (\text{tech_group=transmission} \lor \text{tech_group=demand} \lor \text{tech_group=storage}) \land (\neg (\textit{cap_method}\mathord{=}\text{integer}) \lor \text{tech_group=demand}) \land \textit{allowed_carrier_con}\mathord{=}\text{true} \land \text{carrier_tier}\in \text{[in]})
+        \end{array}
+        \begin{cases}
+            \textbf{carrier_con}_\text{carrier,tech,node,timestep}\geq{}-1 \times \textbf{energy_cap}_\text{tech,node} \times \textit{timestep_resolution}_\text{timestep}&\quad
+            \\
+        \end{cases}
+
+resource_max
+============
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            timestep \in timesteps
+            \\
+            if (\text{tech_group=supply_plus})
+        \end{array}
+        \begin{cases}
+            \textbf{resource_con}_\text{tech,node,timestep}\leq{}\textit{timestep_resolution}_\text{timestep} \times \textbf{resource_cap}_\text{tech,node}&\quad
+            \\
+        \end{cases}
+
+storage_max
+===========
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            timestep \in timesteps
+            \\
+            if (\textit{include_storage}\mathord{=}\text{true})
+        \end{array}
+        \begin{cases}
+            \textbf{storage}_\text{tech,node,timestep} - \textbf{storage_cap}_\text{tech,node}\leq{}0&\quad
+            \\
+        \end{cases}
+
+storage_discharge_depth_limit
+=============================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            timestep \in timesteps
+            \\
+            if (\textit{include_storage}\mathord{=}\text{true} \land \exists (\textit{storage_discharge_depth}))
+        \end{array}
+        \begin{cases}
+            \textbf{storage}_\text{tech,node,timestep} - (\textit{storage_discharge_depth}_\text{node,tech} \times \textbf{storage_cap}_\text{tech,node})\geq{}0&\quad
+            \\
+        \end{cases}
+
+system_balance
+==============
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+        \end{array}
+        \begin{cases}
+            \sum\limits_{\text{tech} \in \text{techs}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \sum\limits_{\text{tech} \in \text{techs}} (\textbf{carrier_con}_\text{carrier,tech,node,timestep}) - \sum\limits_{\text{tech} \in \text{techs}} (\textbf{carrier_export}_\text{carrier,tech,node,timestep}) + \textbf{unmet_demand}_\text{carrier,node,timestep} + \textbf{unused_supply}_\text{carrier,node,timestep} = 0&\quad
+            if (\sum\limits_{\text{tech} \in \text{techs}} (export_carrier))\land{}(\text{run_config.ensure_feasibility}\mathord{=}\text{true})
+            \\
+            \sum\limits_{\text{tech} \in \text{techs}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \sum\limits_{\text{tech} \in \text{techs}} (\textbf{carrier_con}_\text{carrier,tech,node,timestep}) - \sum\limits_{\text{tech} \in \text{techs}} (\textbf{carrier_export}_\text{carrier,tech,node,timestep}) = 0&\quad
+            if (\sum\limits_{\text{tech} \in \text{techs}} (export_carrier))\land{}(\neg (\text{run_config.ensure_feasibility}\mathord{=}\text{true}))
+            \\
+            \sum\limits_{\text{tech} \in \text{techs}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \sum\limits_{\text{tech} \in \text{techs}} (\textbf{carrier_con}_\text{carrier,tech,node,timestep}) + \textbf{unmet_demand}_\text{carrier,node,timestep} + \textbf{unused_supply}_\text{carrier,node,timestep} = 0&\quad
+            if (\neg (\sum\limits_{\text{tech} \in \text{techs}} (export_carrier)))\land{}(\text{run_config.ensure_feasibility}\mathord{=}\text{true})
+            \\
+            \sum\limits_{\text{tech} \in \text{techs}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \sum\limits_{\text{tech} \in \text{techs}} (\textbf{carrier_con}_\text{carrier,tech,node,timestep}) = 0&\quad
+            if (\neg (\sum\limits_{\text{tech} \in \text{techs}} (export_carrier)))\land{}(\neg (\text{run_config.ensure_feasibility}\mathord{=}\text{true}))
+            \\
+        \end{cases}
+
+balance_supply
+==============
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\exists (\textit{resource}) \land \text{tech_group=supply})
+        \end{array}
+        \begin{cases}
+            \frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{energy_eff}_\text{node,tech,timestep} } = \textit{resource}_\text{node,tech,timestep} \times \textit{resource_scale}_\text{node,tech} \times \textbf{resource_area}_\text{tech,node}&\quad
+            if (\textit{force_resource}\mathord{=}\text{true} \land \textit{energy_eff}\mathord{>}\text{0})\land{}(\textit{resource_unit}\mathord{=}\text{energy_per_area})
+            \\
+            \frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{energy_eff}_\text{node,tech,timestep} } = \textit{resource}_\text{node,tech,timestep} \times \textit{resource_scale}_\text{node,tech} \times \textbf{energy_cap}_\text{tech,node}&\quad
+            if (\textit{force_resource}\mathord{=}\text{true} \land \textit{energy_eff}\mathord{>}\text{0})\land{}(\textit{resource_unit}\mathord{=}\text{energy_per_cap})
+            \\
+            \frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{energy_eff}_\text{node,tech,timestep} } = \textit{resource}_\text{node,tech,timestep} \times \textit{resource_scale}_\text{node,tech}&\quad
+            if (\textit{force_resource}\mathord{=}\text{true} \land \textit{energy_eff}\mathord{>}\text{0})\land{}(\textit{resource_unit}\mathord{=}\text{energy})
+            \\
+            \frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{energy_eff}_\text{node,tech,timestep} }\leq{}\textit{resource}_\text{node,tech,timestep} \times \textit{resource_scale}_\text{node,tech} \times \textbf{resource_area}_\text{tech,node}&\quad
+            if (\neg (\textit{force_resource}\mathord{=}\text{true}) \land \textit{energy_eff}\mathord{>}\text{0})\land{}(\textit{resource_unit}\mathord{=}\text{energy_per_area})
+            \\
+            \frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{energy_eff}_\text{node,tech,timestep} }\leq{}\textit{resource}_\text{node,tech,timestep} \times \textit{resource_scale}_\text{node,tech} \times \textbf{energy_cap}_\text{tech,node}&\quad
+            if (\neg (\textit{force_resource}\mathord{=}\text{true}) \land \textit{energy_eff}\mathord{>}\text{0})\land{}(\textit{resource_unit}\mathord{=}\text{energy_per_cap})
+            \\
+            \frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{energy_eff}_\text{node,tech,timestep} }\leq{}\textit{resource}_\text{node,tech,timestep} \times \textit{resource_scale}_\text{node,tech}&\quad
+            if (\neg (\textit{force_resource}\mathord{=}\text{true}) \land \textit{energy_eff}\mathord{>}\text{0})\land{}(\textit{resource_unit}\mathord{=}\text{energy})
+            \\
+            \textbf{carrier_prod}_\text{carrier,tech,node,timestep} = 0&\quad
+            if (\textit{energy_eff}\mathord{=}\text{0})
+            \\
+        \end{cases}
+
+balance_supply_min_use
+======================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\exists (\textit{resource}) \land \text{tech_group=supply} \land \exists (\textit{resource_min_use}) \land \textit{energy_eff}\mathord{>}\text{0} \land \neg (\textit{force_resource}\mathord{=}\text{true}))
+        \end{array}
+        \begin{cases}
+            \textit{resource_min_use}_\text{node,tech}\leq{}\frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{energy_eff}_\text{node,tech,timestep} }&\quad
+            \\
+        \end{cases}
+
+balance_demand
+==============
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\text{tech_group=demand})
+        \end{array}
+        \begin{cases}
+            \textbf{carrier_con}_\text{carrier,tech,node,timestep} \times \textit{energy_eff}_\text{node,tech,timestep} = \textit{resource}_\text{node,tech,timestep} \times \textit{resource_scale}_\text{node,tech} \times \textbf{resource_area}_\text{tech,node}&\quad
+            if (\textit{force_resource}\mathord{=}\text{true})\land{}(\textit{resource_unit}\mathord{=}\text{energy_per_area})
+            \\
+            \textbf{carrier_con}_\text{carrier,tech,node,timestep} \times \textit{energy_eff}_\text{node,tech,timestep} = \textit{resource}_\text{node,tech,timestep} \times \textit{resource_scale}_\text{node,tech} \times \textbf{energy_cap}_\text{tech,node}&\quad
+            if (\textit{force_resource}\mathord{=}\text{true})\land{}(\textit{resource_unit}\mathord{=}\text{energy_per_cap})
+            \\
+            \textbf{carrier_con}_\text{carrier,tech,node,timestep} \times \textit{energy_eff}_\text{node,tech,timestep} = \textit{resource}_\text{node,tech,timestep} \times \textit{resource_scale}_\text{node,tech}&\quad
+            if (\textit{force_resource}\mathord{=}\text{true})\land{}(\textit{resource_unit}\mathord{=}\text{energy})
+            \\
+            \textbf{carrier_con}_\text{carrier,tech,node,timestep} \times \textit{energy_eff}_\text{node,tech,timestep}\geq{}\textit{resource}_\text{node,tech,timestep} \times \textit{resource_scale}_\text{node,tech} \times \textbf{resource_area}_\text{tech,node}&\quad
+            if (\neg (\textit{force_resource}\mathord{=}\text{true}))\land{}(\textit{resource_unit}\mathord{=}\text{energy_per_area})
+            \\
+            \textbf{carrier_con}_\text{carrier,tech,node,timestep} \times \textit{energy_eff}_\text{node,tech,timestep}\geq{}\textit{resource}_\text{node,tech,timestep} \times \textit{resource_scale}_\text{node,tech} \times \textbf{energy_cap}_\text{tech,node}&\quad
+            if (\neg (\textit{force_resource}\mathord{=}\text{true}))\land{}(\textit{resource_unit}\mathord{=}\text{energy_per_cap})
+            \\
+            \textbf{carrier_con}_\text{carrier,tech,node,timestep} \times \textit{energy_eff}_\text{node,tech,timestep}\geq{}\textit{resource}_\text{node,tech,timestep} \times \textit{resource_scale}_\text{node,tech}&\quad
+            if (\neg (\textit{force_resource}\mathord{=}\text{true}))\land{}(\textit{resource_unit}\mathord{=}\text{energy})
+            \\
+        \end{cases}
+
+balance_supply_plus_no_storage
+==============================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\text{tech_group=supply_plus} \land \neg (\textit{include_storage}\mathord{=}\text{true}))
+        \end{array}
+        \begin{cases}
+            \textbf{resource_con}_\text{tech,node,timestep} \times \textit{resource_eff}_\text{node,tech,timestep} = 0&\quad
+            if (\textit{energy_eff}\mathord{=}\text{0} \lor \textit{parasitic_eff}\mathord{=}\text{0})
+            \\
+            \textbf{resource_con}_\text{tech,node,timestep} \times \textit{resource_eff}_\text{node,tech,timestep} = \frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ (\textit{energy_eff}_\text{node,tech,timestep} \times \textit{parasitic_eff}_\text{node,tech,timestep}) }&\quad
+            if (\neg (\textit{energy_eff}\mathord{=}\text{0} \lor \textit{parasitic_eff}\mathord{=}\text{0}))
+            \\
+        \end{cases}
+
+balance_supply_plus_with_storage
+================================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\text{tech_group=supply_plus} \land \textit{include_storage}\mathord{=}\text{true})
+        \end{array}
+        \begin{cases}
+            \textbf{storage}_\text{tech,node,timestep} = \textit{storage_initial}_\text{node,tech} \times \textbf{storage_cap}_\text{tech,node} + (\textbf{resource_con}_\text{tech,node,timestep} \times \textit{resource_eff}_\text{node,tech,timestep})&\quad
+            if (\textit{energy_eff}\mathord{=}\text{0} \lor \textit{parasitic_eff}\mathord{=}\text{0})\land{}(\textit{timesteps}\mathord{=}\text{timesteps[0]} \land \neg (\text{run_config.cyclic_storage}\mathord{=}\text{true}))
+            \\
+            \textbf{storage}_\text{tech,node,timestep} = 1 - \textit{storage_loss}_\text{node,tech,timestep}^{\textit{timestep_resolution}_\text{timestep-1}} \times \textbf{storage}_\text{tech,node,timestep-1} + (\textbf{resource_con}_\text{tech,node,timestep} \times \textit{resource_eff}_\text{node,tech,timestep})&\quad
+            if (\textit{energy_eff}\mathord{=}\text{0} \lor \textit{parasitic_eff}\mathord{=}\text{0})\land{}(\textit{timesteps}\mathord{=}\text{timesteps[0]} \land \text{run_config.cyclic_storage}\mathord{=}\text{true} \lor \neg (\textit{timesteps}\mathord{=}\text{timesteps[0]}) \land \neg (\exists (\textit{lookup_cluster_last_timestep})))
+            \\
+            \textbf{storage}_\text{tech,node,timestep} = 1 - \textit{storage_loss}_\text{node,tech,timestep}^{\textit{timestep_resolution}_\text{timestep=lookup_cluster_last_timestep}} \times \textbf{storage}_\text{tech,node,timestep=lookup_cluster_last_timestep} + (\textbf{resource_con}_\text{tech,node,timestep} \times \textit{resource_eff}_\text{node,tech,timestep})&\quad
+            if (\textit{energy_eff}\mathord{=}\text{0} \lor \textit{parasitic_eff}\mathord{=}\text{0})\land{}(\exists (\textit{lookup_cluster_last_timestep}))
+            \\
+            \textbf{storage}_\text{tech,node,timestep} = \textit{storage_initial}_\text{node,tech} \times \textbf{storage_cap}_\text{tech,node} + (\textbf{resource_con}_\text{tech,node,timestep} \times \textit{resource_eff}_\text{node,tech,timestep}) - \frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ (\textit{energy_eff}_\text{node,tech,timestep} \times \textit{parasitic_eff}_\text{node,tech,timestep}) }&\quad
+            if (\neg (\textit{energy_eff}\mathord{=}\text{0} \lor \textit{parasitic_eff}\mathord{=}\text{0}))\land{}(\textit{timesteps}\mathord{=}\text{timesteps[0]} \land \neg (\text{run_config.cyclic_storage}\mathord{=}\text{true}))
+            \\
+            \textbf{storage}_\text{tech,node,timestep} = 1 - \textit{storage_loss}_\text{node,tech,timestep}^{\textit{timestep_resolution}_\text{timestep-1}} \times \textbf{storage}_\text{tech,node,timestep-1} + (\textbf{resource_con}_\text{tech,node,timestep} \times \textit{resource_eff}_\text{node,tech,timestep}) - \frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ (\textit{energy_eff}_\text{node,tech,timestep} \times \textit{parasitic_eff}_\text{node,tech,timestep}) }&\quad
+            if (\neg (\textit{energy_eff}\mathord{=}\text{0} \lor \textit{parasitic_eff}\mathord{=}\text{0}))\land{}(\textit{timesteps}\mathord{=}\text{timesteps[0]} \land \text{run_config.cyclic_storage}\mathord{=}\text{true} \lor \neg (\textit{timesteps}\mathord{=}\text{timesteps[0]}) \land \neg (\exists (\textit{lookup_cluster_last_timestep})))
+            \\
+            \textbf{storage}_\text{tech,node,timestep} = 1 - \textit{storage_loss}_\text{node,tech,timestep}^{\textit{timestep_resolution}_\text{timestep=lookup_cluster_last_timestep}} \times \textbf{storage}_\text{tech,node,timestep=lookup_cluster_last_timestep} + (\textbf{resource_con}_\text{tech,node,timestep} \times \textit{resource_eff}_\text{node,tech,timestep}) - \frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ (\textit{energy_eff}_\text{node,tech,timestep} \times \textit{parasitic_eff}_\text{node,tech,timestep}) }&\quad
+            if (\neg (\textit{energy_eff}\mathord{=}\text{0} \lor \textit{parasitic_eff}\mathord{=}\text{0}))\land{}(\exists (\textit{lookup_cluster_last_timestep}))
+            \\
+        \end{cases}
+
+resource_availability_supply_plus
+=================================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            timestep \in timesteps
+            \\
+            if (\exists (\textit{resource}) \land \text{tech_group=supply_plus})
+        \end{array}
+        \begin{cases}
+            \textbf{resource_con}_\text{tech,node,timestep} = \textit{resource}_\text{node,tech,timestep} \times \textit{resource_scale}_\text{node,tech} \times \textbf{resource_area}_\text{tech,node}&\quad
+            if (\textit{force_resource}\mathord{=}\text{true})\land{}(\textit{resource_unit}\mathord{=}\text{energy_per_area})
+            \\
+            \textbf{resource_con}_\text{tech,node,timestep} = \textit{resource}_\text{node,tech,timestep} \times \textit{resource_scale}_\text{node,tech} \times \textbf{energy_cap}_\text{tech,node}&\quad
+            if (\textit{force_resource}\mathord{=}\text{true})\land{}(\textit{resource_unit}\mathord{=}\text{energy_per_cap})
+            \\
+            \textbf{resource_con}_\text{tech,node,timestep} = \textit{resource}_\text{node,tech,timestep} \times \textit{resource_scale}_\text{node,tech}&\quad
+            if (\textit{force_resource}\mathord{=}\text{true})\land{}(\textit{resource_unit}\mathord{=}\text{energy})
+            \\
+            \textbf{resource_con}_\text{tech,node,timestep}\leq{}\textit{resource}_\text{node,tech,timestep} \times \textit{resource_scale}_\text{node,tech} \times \textbf{resource_area}_\text{tech,node}&\quad
+            if (\neg (\textit{force_resource}\mathord{=}\text{true}))\land{}(\textit{resource_unit}\mathord{=}\text{energy_per_area})
+            \\
+            \textbf{resource_con}_\text{tech,node,timestep}\leq{}\textit{resource}_\text{node,tech,timestep} \times \textit{resource_scale}_\text{node,tech} \times \textbf{energy_cap}_\text{tech,node}&\quad
+            if (\neg (\textit{force_resource}\mathord{=}\text{true}))\land{}(\textit{resource_unit}\mathord{=}\text{energy_per_cap})
+            \\
+            \textbf{resource_con}_\text{tech,node,timestep}\leq{}\textit{resource}_\text{node,tech,timestep} \times \textit{resource_scale}_\text{node,tech}&\quad
+            if (\neg (\textit{force_resource}\mathord{=}\text{true}))\land{}(\textit{resource_unit}\mathord{=}\text{energy})
+            \\
+        \end{cases}
+
+balance_storage
+===============
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\text{tech_group=storage})
+        \end{array}
+        \begin{cases}
+            \textbf{storage}_\text{tech,node,timestep} = \textit{storage_initial}_\text{node,tech} \times \textbf{storage_cap}_\text{tech,node} - \frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{energy_eff}_\text{node,tech,timestep} } - (\textbf{carrier_con}_\text{carrier,tech,node,timestep} \times \textit{energy_eff}_\text{node,tech,timestep})&\quad
+            if (\textit{energy_eff}\mathord{>}\text{0})\land{}(\textit{timesteps}\mathord{=}\text{timesteps[0]} \land \neg (\text{run_config.cyclic_storage}\mathord{=}\text{true}))
+            \\
+            \textbf{storage}_\text{tech,node,timestep} = 1 - \textit{storage_loss}_\text{node,tech,timestep}^{\textit{timestep_resolution}_\text{timestep-1}} \times \textbf{storage}_\text{tech,node,timestep-1} - \frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{energy_eff}_\text{node,tech,timestep} } - (\textbf{carrier_con}_\text{carrier,tech,node,timestep} \times \textit{energy_eff}_\text{node,tech,timestep})&\quad
+            if (\textit{energy_eff}\mathord{>}\text{0})\land{}(\textit{timesteps}\mathord{=}\text{timesteps[0]} \land \text{run_config.cyclic_storage}\mathord{=}\text{true} \lor \neg (\textit{timesteps}\mathord{=}\text{timesteps[0]}) \land \neg (\exists (\textit{lookup_cluster_last_timestep})))
+            \\
+            \textbf{storage}_\text{tech,node,timestep} = 1 - \textit{storage_loss}_\text{node,tech,timestep}^{\textit{timestep_resolution}_\text{timestep=lookup_cluster_last_timestep}} \times \textbf{storage}_\text{tech,node,timestep=lookup_cluster_last_timestep} - \frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{energy_eff}_\text{node,tech,timestep} } - (\textbf{carrier_con}_\text{carrier,tech,node,timestep} \times \textit{energy_eff}_\text{node,tech,timestep})&\quad
+            if (\textit{energy_eff}\mathord{>}\text{0})\land{}(\exists (\textit{lookup_cluster_last_timestep}))
+            \\
+            \textbf{storage}_\text{tech,node,timestep} = \textit{storage_initial}_\text{node,tech} \times \textbf{storage_cap}_\text{tech,node} - (\textbf{carrier_con}_\text{carrier,tech,node,timestep} \times \textit{energy_eff}_\text{node,tech,timestep})&\quad
+            if (\textit{energy_eff}\mathord{=}\text{0})\land{}(\textit{timesteps}\mathord{=}\text{timesteps[0]} \land \neg (\text{run_config.cyclic_storage}\mathord{=}\text{true}))
+            \\
+            \textbf{storage}_\text{tech,node,timestep} = 1 - \textit{storage_loss}_\text{node,tech,timestep}^{\textit{timestep_resolution}_\text{timestep-1}} \times \textbf{storage}_\text{tech,node,timestep-1} - (\textbf{carrier_con}_\text{carrier,tech,node,timestep} \times \textit{energy_eff}_\text{node,tech,timestep})&\quad
+            if (\textit{energy_eff}\mathord{=}\text{0})\land{}(\textit{timesteps}\mathord{=}\text{timesteps[0]} \land \text{run_config.cyclic_storage}\mathord{=}\text{true} \lor \neg (\textit{timesteps}\mathord{=}\text{timesteps[0]}) \land \neg (\exists (\textit{lookup_cluster_last_timestep})))
+            \\
+            \textbf{storage}_\text{tech,node,timestep} = 1 - \textit{storage_loss}_\text{node,tech,timestep}^{\textit{timestep_resolution}_\text{timestep=lookup_cluster_last_timestep}} \times \textbf{storage}_\text{tech,node,timestep=lookup_cluster_last_timestep} - (\textbf{carrier_con}_\text{carrier,tech,node,timestep} \times \textit{energy_eff}_\text{node,tech,timestep})&\quad
+            if (\textit{energy_eff}\mathord{=}\text{0})\land{}(\exists (\textit{lookup_cluster_last_timestep}))
+            \\
+        \end{cases}
+
+set_storage_initial
+===================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\exists (\textit{storage_initial}) \land \textit{include_storage}\mathord{=}\text{true} \land \text{run_config.cyclic_storage}\mathord{=}\text{true})
+        \end{array}
+        \begin{cases}
+            \textbf{storage}_\text{tech,node,timestep=timesteps[-1]} \times (1 - \textit{storage_loss}_\text{node,tech,timestep}^{\textit{timestep_resolution}_\text{timestep=timesteps[-1]}}) = \textit{storage_initial}_\text{node,tech} \times \textbf{storage_cap}_\text{tech,node}&\quad
+            \\
+        \end{cases}
+
+balance_transmission
+====================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\text{tech_group=transmission} \land \textit{allowed_carrier_prod}\mathord{=}\text{true})
+        \end{array}
+        \begin{cases}
+            \textbf{carrier_prod}_\text{carrier,tech,node,timestep} = -1 \times \textbf{carrier_con}_\text{carrier,tech=remote\_tech,node=remote\_node,timestep} \times \textit{energy_eff}_\text{node,tech,timestep}&\quad
+            \\
+        \end{cases}
+
+symmetric_transmission
+======================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\text{tech_group=transmission} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
+        \end{array}
+        \begin{cases}
+            \textbf{energy_cap}_\text{tech,node} = \textbf{energy_cap}_\text{tech=remote\_tech,node=remote\_node}&\quad
+            \\
+        \end{cases}
+
+export_balance
+==============
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\exists (\textit{export_carrier}) \land \textit{export}\mathord{=}\text{true})
+        \end{array}
+        \begin{cases}
+            \textbf{carrier_prod}_\text{carrier,tech,node,timestep}\geq{}\textbf{carrier_export}_\text{carrier,tech,node,timestep}&\quad
+            \\
+        \end{cases}
+
+carrier_export_max
+==================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\exists (\textit{export_max}) \land \exists (\textit{export_carrier}) \land \textit{export}\mathord{=}\text{true})
+        \end{array}
+        \begin{cases}
+            \textbf{carrier_export}_\text{carrier,tech,node,timestep}\leq{}\textit{export_max}_\text{node,tech} \times \textbf{operating_units}_\text{tech,node,timestep}&\quad
+            if (\textit{cap_method}\mathord{=}\text{integer})
+            \\
+            \textbf{carrier_export}_\text{carrier,tech,node,timestep}\leq{}\textit{export_max}_\text{node,tech}&\quad
+            if (\neg (\textit{cap_method}\mathord{=}\text{integer}))
+            \\
+        \end{cases}
+
+unit_commitment_milp
+====================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            timestep \in timesteps
+            \\
+            if (\textit{cap_method}\mathord{=}\text{integer})
+        \end{array}
+        \begin{cases}
+            \textbf{operating_units}_\text{tech,node,timestep}\leq{}\textbf{units}_\text{tech,node}&\quad
+            \\
+        \end{cases}
+
+carrier_production_max_milp
+===========================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\exists (\textit{carrier}) \land \neg (\text{tech_group=conversion_plus}) \land \textit{cap_method}\mathord{=}\text{integer} \land \textit{allowed_carrier_prod}\mathord{=}\text{true})
+        \end{array}
+        \begin{cases}
+            \textbf{carrier_prod}_\text{carrier,tech,node,timestep}\leq{}\textbf{operating_units}_\text{tech,node,timestep} \times \textit{timestep_resolution}_\text{timestep} \times \textit{energy_cap_per_unit}_\text{node,tech} \times \textit{parasitic_eff}_\text{node,tech,timestep}&\quad
+            \\
+        \end{cases}
+
+carrier_production_max_conversion_plus_milp
+===========================================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            timestep \in timesteps
+            \\
+            if (\text{tech_group=conversion_plus} \land \textit{cap_method}\mathord{=}\text{integer} \land \textit{allowed_carrier_prod}\mathord{=}\text{true})
+        \end{array}
+        \begin{cases}
+            \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep})\leq{}\textbf{operating_units}_\text{tech,node,timestep} \times \textit{timestep_resolution}_\text{timestep} \times \textit{energy_cap_per_unit}_\text{node,tech}&\quad
+            \\
+        \end{cases}
+
+carrier_consumption_max_milp
+============================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\neg (\text{tech_group=conversion_plus}) \land \textit{cap_method}\mathord{=}\text{integer} \land \textit{allowed_carrier_con}\mathord{=}\text{true})
+        \end{array}
+        \begin{cases}
+            \textbf{carrier_con}_\text{carrier,tech,node,timestep}\geq{}-1 \times \textbf{operating_units}_\text{tech,node,timestep} \times \textit{timestep_resolution}_\text{timestep} \times \textit{energy_cap_per_unit}_\text{node,tech}&\quad
+            \\
+        \end{cases}
+
+carrier_production_min_milp
+===========================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\exists (\textit{carrier}) \land \exists (\textit{energy_cap_min_use}) \land \neg (\text{tech_group=conversion_plus}) \land \textit{cap_method}\mathord{=}\text{integer} \land \textit{allowed_carrier_prod}\mathord{=}\text{true})
+        \end{array}
+        \begin{cases}
+            \textbf{carrier_prod}_\text{carrier,tech,node,timestep}\geq{}\textbf{operating_units}_\text{tech,node,timestep} \times \textit{timestep_resolution}_\text{timestep} \times \textit{energy_cap_per_unit}_\text{node,tech} \times \textit{energy_cap_min_use}_\text{node,tech}&\quad
+            \\
+        \end{cases}
+
+carrier_production_min_conversion_plus_milp
+===========================================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            timestep \in timesteps
+            \\
+            if (\exists (\textit{energy_cap_min_use}) \land \text{tech_group=conversion_plus} \land \textit{cap_method}\mathord{=}\text{integer} \land \textit{allowed_carrier_prod}\mathord{=}\text{true})
+        \end{array}
+        \begin{cases}
+            \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep})\geq{}\textbf{operating_units}_\text{tech,node,timestep} \times \textit{timestep_resolution}_\text{timestep} \times \textit{energy_cap_per_unit}_\text{node,tech} \times \textit{energy_cap_min_use}_\text{node,tech}&\quad
+            \\
+        \end{cases}
+
+storage_capacity_units_milp
+===========================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\text{tech_group=storage} \lor \text{tech_group=supply_plus} \land \textit{cap_method}\mathord{=}\text{integer} \land \textit{include_storage}\mathord{=}\text{true} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
+        \end{array}
+        \begin{cases}
+            \textbf{storage_cap}_\text{tech,node} = \textbf{units}_\text{tech,node} \times \textit{storage_cap_per_unit}_\text{node,tech}&\quad
+            \\
+        \end{cases}
+
+energy_capacity_units_milp
+==========================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\exists (\textit{energy_cap_per_unit}) \land \textit{cap_method}\mathord{=}\text{integer} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
+        \end{array}
+        \begin{cases}
+            \textbf{energy_cap}_\text{tech,node} = \textbf{units}_\text{tech,node} \times \textit{energy_cap_per_unit}_\text{node,tech}&\quad
+            \\
+        \end{cases}
+
+energy_capacity_max_purchase_milp
+=================================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\exists (\textit{cost_purchase}) \land (\exists (\textit{energy_cap_max}) \lor \exists (\textit{energy_cap_equals})) \land \textit{cap_method}\mathord{=}\text{binary})
+        \end{array}
+        \begin{cases}
+            \textbf{energy_cap}_\text{tech,node} = \textit{energy_cap_equals}_\text{node,tech} \times \textit{energy_cap_scale}_\text{node,tech} \times \textbf{purchased}_\text{tech,node}&\quad
+            if (\exists (\textit{energy_cap_equals}))
+            \\
+            \textbf{energy_cap}_\text{tech,node}\leq{}\textit{energy_cap_max}_\text{node,tech} \times \textit{energy_cap_scale}_\text{node,tech} \times \textbf{purchased}_\text{tech,node}&\quad
+            if (\neg (\exists (\textit{energy_cap_equals})))
+            \\
+        \end{cases}
+
+energy_capacity_min_purchase_milp
+=================================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\exists (\textit{cost_purchase}) \land \exists (\textit{energy_cap_min}) \land \neg (\exists (\textit{energy_cap_equals})) \land \textit{cap_method}\mathord{=}\text{binary})
+        \end{array}
+        \begin{cases}
+            \textbf{energy_cap}_\text{tech,node}\geq{}\textit{energy_cap_min}_\text{node,tech} \times \textit{energy_cap_scale}_\text{node,tech} \times \textbf{purchased}_\text{tech,node}&\quad
+            \\
+        \end{cases}
+
+storage_capacity_max_purchase_milp
+==================================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\exists (\textit{cost_purchase}) \land (\exists (\textit{storage_cap_max}) \lor \exists (\textit{storage_cap_equals})) \land \textit{cap_method}\mathord{=}\text{binary})
+        \end{array}
+        \begin{cases}
+            \textbf{storage_cap}_\text{tech,node} = \textit{storage_cap_equals}_\text{node,tech} \times \textbf{purchased}_\text{tech,node}&\quad
+            if (\exists (\textit{storage_cap_equals}))
+            \\
+            \textbf{storage_cap}_\text{tech,node}\leq{}\textit{storage_cap_max}_\text{node,tech} \times \textbf{purchased}_\text{tech,node}&\quad
+            if (\neg (\exists (\textit{storage_cap_equals})))
+            \\
+        \end{cases}
+
+storage_capacity_min_purchase_milp
+==================================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\exists (\textit{cost_purchase}) \land \exists (\textit{storage_cap_min}) \land \neg (\exists (\textit{storage_cap_equals})) \land \textit{cap_method}\mathord{=}\text{binary})
+        \end{array}
+        \begin{cases}
+            \textbf{storage_cap}_\text{tech,node}\geq{}\textit{storage_cap_min}_\text{node,tech} \times \textbf{purchased}_\text{tech,node}&\quad
+            \\
+        \end{cases}
+
+unit_capacity_systemwide_milp
+=============================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            tech \in techs
+            \\
+            if (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer} \land (\exists (\textit{units_max_systemwide}) \lor \exists (\textit{units_equals_systemwide})) \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
+        \end{array}
+        \begin{cases}
+            \sum\limits_{\text{node} \in \text{nodes}} (\textbf{purchased}_\text{tech,node}) = \textit{units_equals_systemwide}_\text{tech}&\quad
+            if (\exists (\textit{units_equals_systemwide}))\land{}(\textit{cap_method}\mathord{=}\text{binary})
+            \\
+            \sum\limits_{\text{node} \in \text{nodes}} (\textbf{units}_\text{tech,node}) = \textit{units_equals_systemwide}_\text{tech}&\quad
+            if (\exists (\textit{units_equals_systemwide}))\land{}(\textit{cap_method}\mathord{=}\text{integer})
+            \\
+            \sum\limits_{\text{node} \in \text{nodes}} (\textbf{purchased}_\text{tech,node})\leq{}\textit{units_max_systemwide}_\text{tech}&\quad
+            if (\neg (\exists (\textit{units_equals_systemwide})))\land{}(\textit{cap_method}\mathord{=}\text{binary})
+            \\
+            \sum\limits_{\text{node} \in \text{nodes}} (\textbf{units}_\text{tech,node})\leq{}\textit{units_max_systemwide}_\text{tech}&\quad
+            if (\neg (\exists (\textit{units_equals_systemwide})))\land{}(\textit{cap_method}\mathord{=}\text{integer})
+            \\
+        \end{cases}
+
+asynchronous_con_milp
+=====================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            timestep \in timesteps
+            \\
+            if (\textit{force_asynchronous_prod_con}\mathord{=}\text{true})
+        \end{array}
+        \begin{cases}
+            -1 \times \sum\limits_{\text{carrier} \in \text{carrier_tier(in)}} (\textbf{carrier_con}_\text{carrier,tech,node,timestep})\leq{}1 - \textbf{prod_con_switch}_\text{tech,node,timestep} \times \textit{bigM}&\quad
+            \\
+        \end{cases}
+
+asynchronous_prod_milp
+======================
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            timestep \in timesteps
+            \\
+            if (\textit{force_asynchronous_prod_con}\mathord{=}\text{true})
+        \end{array}
+        \begin{cases}
+            \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep})\leq{}\textbf{prod_con_switch}_\text{tech,node,timestep} \times \textit{bigM}&\quad
+            \\
+        \end{cases}
+
+ramping_up
+==========
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\exists (\textit{energy_ramping}) \land \neg (\textit{timesteps}\mathord{=}\text{timesteps[0]}))
+        \end{array}
+        \begin{cases}
+            \frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{timestep_resolution}_\text{timestep} } - \frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep-1} }{ \textit{timestep_resolution}_\text{timestep-1} }\leq{}\textit{energy_ramping}_\text{node,tech,timestep} \times \textbf{energy_cap}_\text{tech,node}&\quad
+            if (\exists (\textit{carrier}) \land \textit{allowed_carrier_prod}\mathord{=}\text{true} \land \neg (\textit{allowed_carrier_con}\mathord{=}\text{true}))
+            \\
+            \frac{ \textbf{carrier_con}_\text{carrier,tech,node,timestep} }{ \textit{timestep_resolution}_\text{timestep} } - \frac{ \textbf{carrier_con}_\text{carrier,tech,node,timestep-1} }{ \textit{timestep_resolution}_\text{timestep-1} }\leq{}\textit{energy_ramping}_\text{node,tech,timestep} \times \textbf{energy_cap}_\text{tech,node}&\quad
+            if (\exists (\textit{carrier}) \land \textit{allowed_carrier_con}\mathord{=}\text{true} \land \neg (\textit{allowed_carrier_prod}\mathord{=}\text{true}))
+            \\
+            \frac{ \textbf{carrier_con}_\text{carrier,tech,node,timestep} + \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{timestep_resolution}_\text{timestep} } - \frac{ \textbf{carrier_con}_\text{carrier,tech,node,timestep-1} + \textbf{carrier_prod}_\text{carrier,tech,node,timestep-1} }{ \textit{timestep_resolution}_\text{timestep-1} }\leq{}\textit{energy_ramping}_\text{node,tech,timestep} \times \textbf{energy_cap}_\text{tech,node}&\quad
+            if (\exists (\textit{carrier}) \land \textit{allowed_carrier_con}\mathord{=}\text{true} \land \textit{allowed_carrier_prod}\mathord{=}\text{true})
+            \\
+        \end{cases}
+
+ramping_down
+============
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\exists (\textit{energy_ramping}) \land \neg (\textit{timesteps}\mathord{=}\text{timesteps[0]}))
+        \end{array}
+        \begin{cases}
+            -1 \times \textit{energy_ramping}_\text{node,tech,timestep} \times \textbf{energy_cap}_\text{tech,node}\leq{}\frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{timestep_resolution}_\text{timestep} } - \frac{ \textbf{carrier_prod}_\text{carrier,tech,node,timestep-1} }{ \textit{timestep_resolution}_\text{timestep-1} }&\quad
+            if (\exists (\textit{carrier}) \land \textit{allowed_carrier_prod}\mathord{=}\text{true} \land \neg (\textit{allowed_carrier_con}\mathord{=}\text{true}))
+            \\
+            -1 \times \textit{energy_ramping}_\text{node,tech,timestep} \times \textbf{energy_cap}_\text{tech,node}\leq{}\frac{ \textbf{carrier_con}_\text{carrier,tech,node,timestep} }{ \textit{timestep_resolution}_\text{timestep} } - \frac{ \textbf{carrier_con}_\text{carrier,tech,node,timestep-1} }{ \textit{timestep_resolution}_\text{timestep-1} }&\quad
+            if (\exists (\textit{carrier}) \land \textit{allowed_carrier_con}\mathord{=}\text{true} \land \neg (\textit{allowed_carrier_prod}\mathord{=}\text{true}))
+            \\
+            -1 \times \textit{energy_ramping}_\text{node,tech,timestep} \times \textbf{energy_cap}_\text{tech,node}\leq{}\frac{ \textbf{carrier_con}_\text{carrier,tech,node,timestep} + \textbf{carrier_prod}_\text{carrier,tech,node,timestep} }{ \textit{timestep_resolution}_\text{timestep} } - \frac{ \textbf{carrier_con}_\text{carrier,tech,node,timestep-1} + \textbf{carrier_prod}_\text{carrier,tech,node,timestep-1} }{ \textit{timestep_resolution}_\text{timestep-1} }&\quad
+            if (\exists (\textit{carrier}) \land \textit{allowed_carrier_con}\mathord{=}\text{true} \land \textit{allowed_carrier_prod}\mathord{=}\text{true})
+            \\
+        \end{cases}
+
+Where
+#####
+
+cost_var
+========
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            cost \in costs, 
+            timestep \in timesteps
+            \\
+            if (\exists (\textit{cost_export}) \lor \exists (\textit{cost_om_con}) \lor \exists (\textit{cost_om_prod}))
+        \end{array}
+        \begin{cases}
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_export}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carriers}} (\textbf{carrier_export}_\text{carrier,tech,node,timestep}) + \textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier=primary_carrier_out}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \textit{cost_om_con}_\text{cost,node,tech,timestep} \times \textbf{resource_con}_\text{tech,node,timestep})&\quad
+            if (\exists (\textit{export_carrier}) \land \exists (\textit{cost_export}))\land{}(\exists (\textit{cost_om_prod}) \land \text{tech_group=conversion_plus})\land{}(\exists (\textit{cost_om_con}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_export}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carriers}} (\textbf{carrier_export}_\text{carrier,tech,node,timestep}) + \textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier=primary_carrier_out}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \frac{ \textit{cost_om_con}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) }{ \textit{energy_eff}_\text{node,tech,timestep} })&\quad
+            if (\exists (\textit{export_carrier}) \land \exists (\textit{cost_export}))\land{}(\exists (\textit{cost_om_prod}) \land \text{tech_group=conversion_plus})\land{}(\exists (\textit{cost_om_con}) \land \text{tech_group=supply} \land \textit{energy_eff}\mathord{>}\text{0} \land \text{carrier_tier}\in \text{[out]})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_export}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carriers}} (\textbf{carrier_export}_\text{carrier,tech,node,timestep}) + \textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier=primary_carrier_out}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \textit{cost_om_con}_\text{cost,node,tech,timestep} \times -1 \times \sum\limits_{\text{carrier=primary_carrier_in}} (\textbf{carrier_con}_\text{carrier,tech,node,timestep}))&\quad
+            if (\exists (\textit{export_carrier}) \land \exists (\textit{cost_export}))\land{}(\exists (\textit{cost_om_prod}) \land \text{tech_group=conversion_plus})\land{}(\exists (\textit{cost_om_con}) \land \text{tech_group=conversion_plus})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_export}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carriers}} (\textbf{carrier_export}_\text{carrier,tech,node,timestep}) + \textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier=primary_carrier_out}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \textit{cost_om_con}_\text{cost,node,tech,timestep} \times -1 \times \sum\limits_{\text{carrier} \in \text{carrier_tier(in)}} (\textbf{carrier_con}_\text{carrier,tech,node,timestep}))&\quad
+            if (\exists (\textit{export_carrier}) \land \exists (\textit{cost_export}))\land{}(\exists (\textit{cost_om_prod}) \land \text{tech_group=conversion_plus})\land{}(\exists (\textit{cost_om_con}) \land \neg (\text{tech_group=conversion_plus} \lor \text{tech_group=supply_plus} \lor \text{tech_group=supply}) \land \text{carrier_tier}\in \text{[in]})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_export}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carriers}} (\textbf{carrier_export}_\text{carrier,tech,node,timestep}) + \textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier=primary_carrier_out}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}))&\quad
+            if (\exists (\textit{export_carrier}) \land \exists (\textit{cost_export}))\land{}(\exists (\textit{cost_om_prod}) \land \text{tech_group=conversion_plus})\land{}(\neg (\exists (\textit{cost_om_con})))
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_export}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carriers}} (\textbf{carrier_export}_\text{carrier,tech,node,timestep}) + \textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \textit{cost_om_con}_\text{cost,node,tech,timestep} \times \textbf{resource_con}_\text{tech,node,timestep})&\quad
+            if (\exists (\textit{export_carrier}) \land \exists (\textit{cost_export}))\land{}(\exists (\textit{cost_om_prod}) \land \neg (\text{tech_group=conversion_plus}))\land{}(\exists (\textit{cost_om_con}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_export}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carriers}} (\textbf{carrier_export}_\text{carrier,tech,node,timestep}) + \textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \frac{ \textit{cost_om_con}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) }{ \textit{energy_eff}_\text{node,tech,timestep} })&\quad
+            if (\exists (\textit{export_carrier}) \land \exists (\textit{cost_export}))\land{}(\exists (\textit{cost_om_prod}) \land \neg (\text{tech_group=conversion_plus}))\land{}(\exists (\textit{cost_om_con}) \land \text{tech_group=supply} \land \textit{energy_eff}\mathord{>}\text{0} \land \text{carrier_tier}\in \text{[out]})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_export}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carriers}} (\textbf{carrier_export}_\text{carrier,tech,node,timestep}) + \textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \textit{cost_om_con}_\text{cost,node,tech,timestep} \times -1 \times \sum\limits_{\text{carrier=primary_carrier_in}} (\textbf{carrier_con}_\text{carrier,tech,node,timestep}))&\quad
+            if (\exists (\textit{export_carrier}) \land \exists (\textit{cost_export}))\land{}(\exists (\textit{cost_om_prod}) \land \neg (\text{tech_group=conversion_plus}))\land{}(\exists (\textit{cost_om_con}) \land \text{tech_group=conversion_plus})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_export}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carriers}} (\textbf{carrier_export}_\text{carrier,tech,node,timestep}) + \textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \textit{cost_om_con}_\text{cost,node,tech,timestep} \times -1 \times \sum\limits_{\text{carrier} \in \text{carrier_tier(in)}} (\textbf{carrier_con}_\text{carrier,tech,node,timestep}))&\quad
+            if (\exists (\textit{export_carrier}) \land \exists (\textit{cost_export}))\land{}(\exists (\textit{cost_om_prod}) \land \neg (\text{tech_group=conversion_plus}))\land{}(\exists (\textit{cost_om_con}) \land \neg (\text{tech_group=conversion_plus} \lor \text{tech_group=supply_plus} \lor \text{tech_group=supply}) \land \text{carrier_tier}\in \text{[in]})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_export}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carriers}} (\textbf{carrier_export}_\text{carrier,tech,node,timestep}) + \textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}))&\quad
+            if (\exists (\textit{export_carrier}) \land \exists (\textit{cost_export}))\land{}(\exists (\textit{cost_om_prod}) \land \neg (\text{tech_group=conversion_plus}))\land{}(\neg (\exists (\textit{cost_om_con})))
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_export}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carriers}} (\textbf{carrier_export}_\text{carrier,tech,node,timestep}) + \textit{cost_om_con}_\text{cost,node,tech,timestep} \times \textbf{resource_con}_\text{tech,node,timestep})&\quad
+            if (\exists (\textit{export_carrier}) \land \exists (\textit{cost_export}))\land{}(\neg (\exists (\textit{cost_om_prod})))\land{}(\exists (\textit{cost_om_con}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_export}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carriers}} (\textbf{carrier_export}_\text{carrier,tech,node,timestep}) + \frac{ \textit{cost_om_con}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) }{ \textit{energy_eff}_\text{node,tech,timestep} })&\quad
+            if (\exists (\textit{export_carrier}) \land \exists (\textit{cost_export}))\land{}(\neg (\exists (\textit{cost_om_prod})))\land{}(\exists (\textit{cost_om_con}) \land \text{tech_group=supply} \land \textit{energy_eff}\mathord{>}\text{0} \land \text{carrier_tier}\in \text{[out]})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_export}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carriers}} (\textbf{carrier_export}_\text{carrier,tech,node,timestep}) + \textit{cost_om_con}_\text{cost,node,tech,timestep} \times -1 \times \sum\limits_{\text{carrier=primary_carrier_in}} (\textbf{carrier_con}_\text{carrier,tech,node,timestep}))&\quad
+            if (\exists (\textit{export_carrier}) \land \exists (\textit{cost_export}))\land{}(\neg (\exists (\textit{cost_om_prod})))\land{}(\exists (\textit{cost_om_con}) \land \text{tech_group=conversion_plus})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_export}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carriers}} (\textbf{carrier_export}_\text{carrier,tech,node,timestep}) + \textit{cost_om_con}_\text{cost,node,tech,timestep} \times -1 \times \sum\limits_{\text{carrier} \in \text{carrier_tier(in)}} (\textbf{carrier_con}_\text{carrier,tech,node,timestep}))&\quad
+            if (\exists (\textit{export_carrier}) \land \exists (\textit{cost_export}))\land{}(\neg (\exists (\textit{cost_om_prod})))\land{}(\exists (\textit{cost_om_con}) \land \neg (\text{tech_group=conversion_plus} \lor \text{tech_group=supply_plus} \lor \text{tech_group=supply}) \land \text{carrier_tier}\in \text{[in]})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_export}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carriers}} (\textbf{carrier_export}_\text{carrier,tech,node,timestep}))&\quad
+            if (\exists (\textit{export_carrier}) \land \exists (\textit{cost_export}))\land{}(\neg (\exists (\textit{cost_om_prod})))\land{}(\neg (\exists (\textit{cost_om_con})))
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier=primary_carrier_out}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \textit{cost_om_con}_\text{cost,node,tech,timestep} \times \textbf{resource_con}_\text{tech,node,timestep})&\quad
+            if (\neg (\exists (\textit{cost_export})))\land{}(\exists (\textit{cost_om_prod}) \land \text{tech_group=conversion_plus})\land{}(\exists (\textit{cost_om_con}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier=primary_carrier_out}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \frac{ \textit{cost_om_con}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) }{ \textit{energy_eff}_\text{node,tech,timestep} })&\quad
+            if (\neg (\exists (\textit{cost_export})))\land{}(\exists (\textit{cost_om_prod}) \land \text{tech_group=conversion_plus})\land{}(\exists (\textit{cost_om_con}) \land \text{tech_group=supply} \land \textit{energy_eff}\mathord{>}\text{0} \land \text{carrier_tier}\in \text{[out]})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier=primary_carrier_out}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \textit{cost_om_con}_\text{cost,node,tech,timestep} \times -1 \times \sum\limits_{\text{carrier=primary_carrier_in}} (\textbf{carrier_con}_\text{carrier,tech,node,timestep}))&\quad
+            if (\neg (\exists (\textit{cost_export})))\land{}(\exists (\textit{cost_om_prod}) \land \text{tech_group=conversion_plus})\land{}(\exists (\textit{cost_om_con}) \land \text{tech_group=conversion_plus})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier=primary_carrier_out}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \textit{cost_om_con}_\text{cost,node,tech,timestep} \times -1 \times \sum\limits_{\text{carrier} \in \text{carrier_tier(in)}} (\textbf{carrier_con}_\text{carrier,tech,node,timestep}))&\quad
+            if (\neg (\exists (\textit{cost_export})))\land{}(\exists (\textit{cost_om_prod}) \land \text{tech_group=conversion_plus})\land{}(\exists (\textit{cost_om_con}) \land \neg (\text{tech_group=conversion_plus} \lor \text{tech_group=supply_plus} \lor \text{tech_group=supply}) \land \text{carrier_tier}\in \text{[in]})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier=primary_carrier_out}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}))&\quad
+            if (\neg (\exists (\textit{cost_export})))\land{}(\exists (\textit{cost_om_prod}) \land \text{tech_group=conversion_plus})\land{}(\neg (\exists (\textit{cost_om_con})))
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \textit{cost_om_con}_\text{cost,node,tech,timestep} \times \textbf{resource_con}_\text{tech,node,timestep})&\quad
+            if (\neg (\exists (\textit{cost_export})))\land{}(\exists (\textit{cost_om_prod}) \land \neg (\text{tech_group=conversion_plus}))\land{}(\exists (\textit{cost_om_con}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \frac{ \textit{cost_om_con}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) }{ \textit{energy_eff}_\text{node,tech,timestep} })&\quad
+            if (\neg (\exists (\textit{cost_export})))\land{}(\exists (\textit{cost_om_prod}) \land \neg (\text{tech_group=conversion_plus}))\land{}(\exists (\textit{cost_om_con}) \land \text{tech_group=supply} \land \textit{energy_eff}\mathord{>}\text{0} \land \text{carrier_tier}\in \text{[out]})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \textit{cost_om_con}_\text{cost,node,tech,timestep} \times -1 \times \sum\limits_{\text{carrier=primary_carrier_in}} (\textbf{carrier_con}_\text{carrier,tech,node,timestep}))&\quad
+            if (\neg (\exists (\textit{cost_export})))\land{}(\exists (\textit{cost_om_prod}) \land \neg (\text{tech_group=conversion_plus}))\land{}(\exists (\textit{cost_om_con}) \land \text{tech_group=conversion_plus})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) + \textit{cost_om_con}_\text{cost,node,tech,timestep} \times -1 \times \sum\limits_{\text{carrier} \in \text{carrier_tier(in)}} (\textbf{carrier_con}_\text{carrier,tech,node,timestep}))&\quad
+            if (\neg (\exists (\textit{cost_export})))\land{}(\exists (\textit{cost_om_prod}) \land \neg (\text{tech_group=conversion_plus}))\land{}(\exists (\textit{cost_om_con}) \land \neg (\text{tech_group=conversion_plus} \lor \text{tech_group=supply_plus} \lor \text{tech_group=supply}) \land \text{carrier_tier}\in \text{[in]})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_om_prod}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}))&\quad
+            if (\neg (\exists (\textit{cost_export})))\land{}(\exists (\textit{cost_om_prod}) \land \neg (\text{tech_group=conversion_plus}))\land{}(\neg (\exists (\textit{cost_om_con})))
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_om_con}_\text{cost,node,tech,timestep} \times \textbf{resource_con}_\text{tech,node,timestep})&\quad
+            if (\neg (\exists (\textit{cost_export})))\land{}(\neg (\exists (\textit{cost_om_prod})))\land{}(\exists (\textit{cost_om_con}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\frac{ \textit{cost_om_con}_\text{cost,node,tech,timestep} \times \sum\limits_{\text{carrier} \in \text{carrier_tier(out)}} (\textbf{carrier_prod}_\text{carrier,tech,node,timestep}) }{ \textit{energy_eff}_\text{node,tech,timestep} })&\quad
+            if (\neg (\exists (\textit{cost_export})))\land{}(\neg (\exists (\textit{cost_om_prod})))\land{}(\exists (\textit{cost_om_con}) \land \text{tech_group=supply} \land \textit{energy_eff}\mathord{>}\text{0} \land \text{carrier_tier}\in \text{[out]})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_om_con}_\text{cost,node,tech,timestep} \times -1 \times \sum\limits_{\text{carrier=primary_carrier_in}} (\textbf{carrier_con}_\text{carrier,tech,node,timestep}))&\quad
+            if (\neg (\exists (\textit{cost_export})))\land{}(\neg (\exists (\textit{cost_om_prod})))\land{}(\exists (\textit{cost_om_con}) \land \text{tech_group=conversion_plus})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (\textit{cost_om_con}_\text{cost,node,tech,timestep} \times -1 \times \sum\limits_{\text{carrier} \in \text{carrier_tier(in)}} (\textbf{carrier_con}_\text{carrier,tech,node,timestep}))&\quad
+            if (\neg (\exists (\textit{cost_export})))\land{}(\neg (\exists (\textit{cost_om_prod})))\land{}(\exists (\textit{cost_om_con}) \land \neg (\text{tech_group=conversion_plus} \lor \text{tech_group=supply_plus} \lor \text{tech_group=supply}) \land \text{carrier_tier}\in \text{[in]})
+            \\
+            \textit{timestep_weights}_\text{timestep} \times (0)&\quad
+            if (\neg (\exists (\textit{cost_export})))\land{}(\neg (\exists (\textit{cost_om_prod})))\land{}(\neg (\exists (\textit{cost_om_con})))
+            \\
+        \end{cases}
+
+cost_investment
+===============
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            cost \in costs
+            \\
+            if (\exists (\textit{cost_energy_cap}) \lor \exists (\textit{cost_om_annual}) \lor \exists (\textit{cost_om_annual_investment_fraction}) \lor \exists (\textit{cost_purchase}) \lor \exists (\textit{cost_resource_area}) \lor \exists (\textit{cost_resource_cap}) \lor \exists (\textit{cost_storage_cap}) \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
+        \end{array}
+        \begin{cases}
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node}) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (0) \times (1 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\neg (\text{tech_group=transmission}))\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_resource_area}_\text{cost,node,tech} \times \textbf{resource_area}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area}))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_storage_cap}_\text{cost,node,tech} \times \textbf{storage_cap}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage}))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_purchase}_\text{cost,node,tech} \times \textbf{purchased}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{binary})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node} + \textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_purchase}_\text{cost,node,tech} \times \textbf{units}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\exists (\textit{cost_purchase}) \land \textit{cap_method}\mathord{=}\text{integer})\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node} + \textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\exists (\textit{cost_energy_cap}))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_energy_cap}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\exists (\textit{cost_energy_cap}))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (\textit{cost_resource_cap}_\text{cost,node,tech} \times \textbf{resource_cap}_\text{tech,node}) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus})
+            \\
+            \textit{annualisation_weight} \times (\textit{cost_depreciation_rate}_\text{cost,node,tech} \times (0) \times (0.5 + \textit{cost_om_annual_investment_fraction}_\text{cost,node,tech}) + (\textit{cost_om_annual}_\text{cost,node,tech} \times \textbf{energy_cap}_\text{tech,node}))&\quad
+            if (\text{tech_group=transmission})\land{}(\neg (\exists (\textit{cost_resource_area}) \land (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area})))\land{}(\neg (\exists (\textit{cost_storage_cap}) \land (\text{tech_group=supply_plus} \lor \text{tech_group=storage})))\land{}(\neg (\exists (\textit{cost_purchase}) \land (\textit{cap_method}\mathord{=}\text{binary} \lor \textit{cap_method}\mathord{=}\text{integer})))\land{}(\neg (\exists (\textit{cost_energy_cap})))\land{}(\neg (\exists (\textit{cost_resource_cap}) \land \text{tech_group=supply_plus}))
+            \\
+        \end{cases}
+
+cost
+====
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            cost \in costs
+            \\
+            if (\exists (\textit{cost_energy_cap}) \lor \exists (\textit{cost_om_annual}) \lor \exists (\textit{cost_om_annual_investment_fraction}) \lor \exists (\textit{cost_purchase}) \lor \exists (\textit{cost_resource_area}) \lor \exists (\textit{cost_resource_cap}) \lor \exists (\textit{cost_storage_cap}) \lor \exists (\textit{cost_export}) \lor \exists (\textit{cost_om_con}) \lor \exists (\textit{cost_om_prod}))
+        \end{array}
+        \begin{cases}
+            \textbf{cost_investment}_\text{tech,node,cost} + \sum\limits_{\text{timestep} \in \text{timesteps}} (\textbf{cost_var}_\text{tech,node,timestep,cost})&\quad
+            if (\exists (\textit{cost_export}) \lor \exists (\textit{cost_om_con}) \lor \exists (\textit{cost_om_prod}))\land{}(\exists (\textit{cost_energy_cap}) \lor \exists (\textit{cost_om_annual}) \lor \exists (\textit{cost_om_annual_investment_fraction}) \lor \exists (\textit{cost_purchase}) \lor \exists (\textit{cost_resource_area}) \lor \exists (\textit{cost_resource_cap}) \lor \exists (\textit{cost_storage_cap}) \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
+            \\
+            \sum\limits_{\text{timestep} \in \text{timesteps}} (\textbf{cost_var}_\text{tech,node,timestep,cost})&\quad
+            if (\exists (\textit{cost_export}) \lor \exists (\textit{cost_om_con}) \lor \exists (\textit{cost_om_prod}))\land{}(\neg (\exists (\textit{cost_energy_cap}) \lor \exists (\textit{cost_om_annual}) \lor \exists (\textit{cost_om_annual_investment_fraction}) \lor \exists (\textit{cost_purchase}) \lor \exists (\textit{cost_resource_area}) \lor \exists (\textit{cost_resource_cap}) \lor \exists (\textit{cost_storage_cap}) \land \neg (\text{run_config.mode}\mathord{=}\text{operate})))
+            \\
+            \textbf{cost_investment}_\text{tech,node,cost}&\quad
+            if (\neg (\exists (\textit{cost_export}) \lor \exists (\textit{cost_om_con}) \lor \exists (\textit{cost_om_prod})))\land{}(\exists (\textit{cost_energy_cap}) \lor \exists (\textit{cost_om_annual}) \lor \exists (\textit{cost_om_annual_investment_fraction}) \lor \exists (\textit{cost_purchase}) \lor \exists (\textit{cost_resource_area}) \lor \exists (\textit{cost_resource_cap}) \lor \exists (\textit{cost_storage_cap}) \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
+            \\
+            0&\quad
+            if (\neg (\exists (\textit{cost_export}) \lor \exists (\textit{cost_om_con}) \lor \exists (\textit{cost_om_prod})))\land{}(\neg (\exists (\textit{cost_energy_cap}) \lor \exists (\textit{cost_om_annual}) \lor \exists (\textit{cost_om_annual_investment_fraction}) \lor \exists (\textit{cost_purchase}) \lor \exists (\textit{cost_resource_area}) \lor \exists (\textit{cost_resource_cap}) \lor \exists (\textit{cost_storage_cap}) \land \neg (\text{run_config.mode}\mathord{=}\text{operate})))
+            \\
+        \end{cases}
+
+Decision Variables
+##################
+
+energy_cap
+==========
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\neg (\text{run_config.mode}\mathord{=}\text{operate}))
+        \end{array}
+        \begin{cases}
+            \textit{energy_cap_min}_\text{node,tech}\leq{}\textbf{energy_cap}_\text{tech,node}&\quad
+            \\
+            \textbf{energy_cap}_\text{tech,node}\leq{}\textit{energy_cap_max}_\text{node,tech}&\quad
+            \\
+        \end{cases}
+
+carrier_prod
+============
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\exists (\textit{carrier}) \land \textit{allowed_carrier_prod}\mathord{=}\text{true} \land \text{carrier_tier}\in \text{[out,out_2,out_3]})
+        \end{array}
+        \begin{cases}
+            0\leq{}\textbf{carrier_prod}_\text{carrier,tech,node,timestep}&\quad
+            \\
+            \textbf{carrier_prod}_\text{carrier,tech,node,timestep}\leq{}inf&\quad
+            \\
+        \end{cases}
+
+carrier_con
+===========
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\exists (\textit{carrier}) \land \textit{allowed_carrier_con}\mathord{=}\text{true} \land \text{carrier_tier}\in \text{[in,in_2,in_3]})
+        \end{array}
+        \begin{cases}
+            -inf\leq{}\textbf{carrier_con}_\text{carrier,tech,node,timestep}&\quad
+            \\
+            \textbf{carrier_con}_\text{carrier,tech,node,timestep}\leq{}0&\quad
+            \\
+        \end{cases}
+
+carrier_export
+==============
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\exists (\textit{export_carrier}) \land \textit{export}\mathord{=}\text{true})
+        \end{array}
+        \begin{cases}
+            0\leq{}\textbf{carrier_export}_\text{carrier,tech,node,timestep}&\quad
+            \\
+            \textbf{carrier_export}_\text{carrier,tech,node,timestep}\leq{}inf&\quad
+            \\
+        \end{cases}
+
+resource_area
+=============
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
+        \end{array}
+        \begin{cases}
+            \textit{resource_area_min}_\text{node,tech}\leq{}\textbf{resource_area}_\text{tech,node}&\quad
+            \\
+            \textbf{resource_area}_\text{tech,node}\leq{}\textit{resource_area_max}_\text{node,tech}&\quad
+            \\
+        \end{cases}
+
+resource_con
+============
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            timestep \in timesteps
+            \\
+            if (\text{tech_group=supply_plus})
+        \end{array}
+        \begin{cases}
+            0\leq{}\textbf{resource_con}_\text{tech,node,timestep}&\quad
+            \\
+            \textbf{resource_con}_\text{tech,node,timestep}\leq{}inf&\quad
+            \\
+        \end{cases}
+
+resource_cap
+============
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\text{tech_group=supply_plus} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
+        \end{array}
+        \begin{cases}
+            \textit{resource_cap_min}_\text{node,tech}\leq{}\textbf{resource_cap}_\text{tech,node}&\quad
+            \\
+            \textbf{resource_cap}_\text{tech,node}\leq{}\textit{resource_cap_max}_\text{node,tech}&\quad
+            \\
+        \end{cases}
+
+storage_cap
+===========
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\text{tech_group=storage} \lor \text{tech_group=supply_plus} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}) \land \textit{include_storage}\mathord{=}\text{true})
+        \end{array}
+        \begin{cases}
+            \textit{storage_cap_min}_\text{node,tech}\leq{}\textbf{storage_cap}_\text{tech,node}&\quad
+            \\
+            \textbf{storage_cap}_\text{tech,node}\leq{}\textit{storage_cap_max}_\text{node,tech}&\quad
+            \\
+        \end{cases}
+
+storage
+=======
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            timestep \in timesteps
+            \\
+            if (\text{tech_group=storage} \lor \text{tech_group=supply_plus} \land \textit{include_storage}\mathord{=}\text{true})
+        \end{array}
+        \begin{cases}
+            0\leq{}\textbf{storage}_\text{tech,node,timestep}&\quad
+            \\
+            \textbf{storage}_\text{tech,node,timestep}\leq{}inf&\quad
+            \\
+        \end{cases}
+
+purchased
+=========
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\textit{cap_method}\mathord{=}\text{binary} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
+        \end{array}
+        \begin{cases}
+            0\leq{}\textbf{purchased}_\text{tech,node}&\quad
+            \\
+            \textbf{purchased}_\text{tech,node}\leq{}1&\quad
+            \\
+        \end{cases}
+
+units
+=====
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs
+            \\
+            if (\textit{cap_method}\mathord{=}\text{integer} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
+        \end{array}
+        \begin{cases}
+            \textit{units_min}_\text{node,tech}\leq{}\textbf{units}_\text{tech,node}&\quad
+            \\
+            \textbf{units}_\text{tech,node}\leq{}\textit{units_max}_\text{node,tech}&\quad
+            \\
+        \end{cases}
+
+operating_units
+===============
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            timestep \in timesteps
+            \\
+            if (\textit{cap_method}\mathord{=}\text{integer})
+        \end{array}
+        \begin{cases}
+            0\leq{}\textbf{operating_units}_\text{tech,node,timestep}&\quad
+            \\
+            \textbf{operating_units}_\text{tech,node,timestep}\leq{}inf&\quad
+            \\
+        \end{cases}
+
+prod_con_switch
+===============
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            tech \in techs, 
+            timestep \in timesteps
+            \\
+            if (\textit{force_asynchronous_prod_con}\mathord{=}\text{true})
+        \end{array}
+        \begin{cases}
+            0\leq{}\textbf{prod_con_switch}_\text{tech,node,timestep}&\quad
+            \\
+            \textbf{prod_con_switch}_\text{tech,node,timestep}\leq{}1&\quad
+            \\
+        \end{cases}
+
+unmet_demand
+============
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\text{run_config.ensure_feasibility}\mathord{=}\text{true})
+        \end{array}
+        \begin{cases}
+            0\leq{}\textbf{unmet_demand}_\text{carrier,node,timestep}&\quad
+            \\
+            \textbf{unmet_demand}_\text{carrier,node,timestep}\leq{}inf&\quad
+            \\
+        \end{cases}
+
+unused_supply
+=============
+
+.. container:: scrolling-wrapper
+
+    .. math::
+        
+        \begin{array}{r}
+            \forall{}
+            node \in nodes, 
+            carrier \in carriers, 
+            timestep \in timesteps
+            \\
+            if (\text{run_config.ensure_feasibility}\mathord{=}\text{true})
+        \end{array}
+        \begin{cases}
+            -inf\leq{}\textbf{unused_supply}_\text{carrier,node,timestep}&\quad
+            \\
+            \textbf{unused_supply}_\text{carrier,node,timestep}\leq{}0&\quad
+            \\
+        \end{cases}

--- a/doc/_static/math.rst
+++ b/doc/_static/math.rst
@@ -8,7 +8,7 @@ min_cost_optimisation
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \min{}
         \end{array}
@@ -30,10 +30,10 @@ energy_capacity_per_storage_capacity_min
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\exists (\textit{energy_cap_per_storage_cap_min}) \land \neg (\exists (\textit{energy_cap_per_storage_cap_equals})) \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
@@ -49,10 +49,10 @@ energy_capacity_per_storage_capacity_max
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\exists (\textit{energy_cap_per_storage_cap_max}) \land \neg (\exists (\textit{energy_cap_per_storage_cap_equals})) \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
@@ -68,10 +68,10 @@ energy_capacity_per_storage_capacity_equals
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\exists (\textit{energy_cap_per_storage_cap_equals}) \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
@@ -87,10 +87,10 @@ resource_capacity_equals_energy_capacity
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\textit{resource_cap_equals_energy_cap}\mathord{=}\text{true} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
@@ -106,10 +106,10 @@ force_zero_resource_area
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}) \land \textit{energy_cap_max}\mathord{=}\text{0})
@@ -125,10 +125,10 @@ resource_area_per_energy_capacity
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\exists (\textit{resource_area_per_energy_cap}) \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
@@ -144,7 +144,7 @@ resource_area_capacity_per_loc
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
             node \in nodes
@@ -162,7 +162,7 @@ energy_capacity_systemwide
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
             tech \in techs
@@ -184,11 +184,11 @@ balance_conversion_plus_primary
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
+            node \in nodes,
+            tech \in techs,
             timestep \in timesteps
             \\
             if (\text{tech_group=conversion_plus} \land \textit{carrier_ratios}\mathord{>}\text{0})
@@ -204,11 +204,11 @@ carrier_production_max_conversion_plus
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
+            node \in nodes,
+            tech \in techs,
             timestep \in timesteps
             \\
             if (\text{tech_group=conversion_plus} \land \neg (\textit{cap_method}\mathord{=}\text{integer}))
@@ -224,11 +224,11 @@ carrier_production_min_conversion_plus
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
+            node \in nodes,
+            tech \in techs,
             timestep \in timesteps
             \\
             if (\exists (\textit{energy_cap_min_use}) \land \text{tech_group=conversion_plus} \land \neg (\textit{cap_method}\mathord{=}\text{integer}))
@@ -244,12 +244,12 @@ balance_conversion_plus_non_primary
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier_tier \in carrier_tiers, 
+            node \in nodes,
+            tech \in techs,
+            carrier_tier \in carrier_tiers,
             timestep \in timesteps
             \\
             if (\text{tech_group=conversion_plus} \land \text{carrier_tier}\in \text{[in_2,out_2,in_3,out_3]} \land \textit{carrier_ratios}\mathord{>}\text{0})
@@ -287,12 +287,12 @@ conversion_plus_prod_con_to_zero
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\textit{carrier_ratios}\mathord{=}\text{0} \land \text{tech_group=conversion_plus})
@@ -312,11 +312,11 @@ balance_conversion
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
+            node \in nodes,
+            tech \in techs,
             timestep \in timesteps
             \\
             if (\text{tech_group=conversion})
@@ -332,12 +332,12 @@ carrier_production_max
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\exists (\textit{carrier}) \land \neg (\text{tech_group=conversion_plus}) \land \neg (\textit{cap_method}\mathord{=}\text{integer}) \land \textit{allowed_carrier_prod}\mathord{=}\text{true} \land \text{carrier_tier}\in \text{[out]})
@@ -353,12 +353,12 @@ carrier_production_min
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\exists (\textit{carrier}) \land \exists (\textit{energy_cap_min_use}) \land \neg (\text{tech_group=conversion_plus}) \land \neg (\textit{cap_method}\mathord{=}\text{integer}) \land \textit{allowed_carrier_prod}\mathord{=}\text{true} \land \text{carrier_tier}\in \text{[out]})
@@ -374,12 +374,12 @@ carrier_consumption_max
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\exists (\textit{carrier}) \land (\text{tech_group=transmission} \lor \text{tech_group=demand} \lor \text{tech_group=storage}) \land (\neg (\textit{cap_method}\mathord{=}\text{integer}) \lor \text{tech_group=demand}) \land \textit{allowed_carrier_con}\mathord{=}\text{true} \land \text{carrier_tier}\in \text{[in]})
@@ -395,11 +395,11 @@ resource_max
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
+            node \in nodes,
+            tech \in techs,
             timestep \in timesteps
             \\
             if (\text{tech_group=supply_plus})
@@ -415,11 +415,11 @@ storage_max
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
+            node \in nodes,
+            tech \in techs,
             timestep \in timesteps
             \\
             if (\textit{include_storage}\mathord{=}\text{true})
@@ -435,11 +435,11 @@ storage_discharge_depth_limit
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
+            node \in nodes,
+            tech \in techs,
             timestep \in timesteps
             \\
             if (\textit{include_storage}\mathord{=}\text{true} \land \exists (\textit{storage_discharge_depth}))
@@ -455,11 +455,11 @@ system_balance
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            carrier \in carriers, 
+            node \in nodes,
+            carrier \in carriers,
             timestep \in timesteps
             \\
         \end{array}
@@ -484,12 +484,12 @@ balance_supply
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\exists (\textit{resource}) \land \text{tech_group=supply})
@@ -524,12 +524,12 @@ balance_supply_min_use
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\exists (\textit{resource}) \land \text{tech_group=supply} \land \exists (\textit{resource_min_use}) \land \textit{energy_eff}\mathord{>}\text{0} \land \neg (\textit{force_resource}\mathord{=}\text{true}))
@@ -545,12 +545,12 @@ balance_demand
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\text{tech_group=demand})
@@ -582,12 +582,12 @@ balance_supply_plus_no_storage
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\text{tech_group=supply_plus} \land \neg (\textit{include_storage}\mathord{=}\text{true}))
@@ -607,12 +607,12 @@ balance_supply_plus_with_storage
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\text{tech_group=supply_plus} \land \textit{include_storage}\mathord{=}\text{true})
@@ -644,11 +644,11 @@ resource_availability_supply_plus
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
+            node \in nodes,
+            tech \in techs,
             timestep \in timesteps
             \\
             if (\exists (\textit{resource}) \land \text{tech_group=supply_plus})
@@ -680,12 +680,12 @@ balance_storage
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\text{tech_group=storage})
@@ -717,10 +717,10 @@ set_storage_initial
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\exists (\textit{storage_initial}) \land \textit{include_storage}\mathord{=}\text{true} \land \text{run_config.cyclic_storage}\mathord{=}\text{true})
@@ -736,12 +736,12 @@ balance_transmission
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\text{tech_group=transmission} \land \textit{allowed_carrier_prod}\mathord{=}\text{true})
@@ -757,10 +757,10 @@ symmetric_transmission
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\text{tech_group=transmission} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
@@ -776,12 +776,12 @@ export_balance
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\exists (\textit{export_carrier}) \land \textit{export}\mathord{=}\text{true})
@@ -797,12 +797,12 @@ carrier_export_max
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\exists (\textit{export_max}) \land \exists (\textit{export_carrier}) \land \textit{export}\mathord{=}\text{true})
@@ -822,11 +822,11 @@ unit_commitment_milp
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
+            node \in nodes,
+            tech \in techs,
             timestep \in timesteps
             \\
             if (\textit{cap_method}\mathord{=}\text{integer})
@@ -842,12 +842,12 @@ carrier_production_max_milp
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\exists (\textit{carrier}) \land \neg (\text{tech_group=conversion_plus}) \land \textit{cap_method}\mathord{=}\text{integer} \land \textit{allowed_carrier_prod}\mathord{=}\text{true})
@@ -863,11 +863,11 @@ carrier_production_max_conversion_plus_milp
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
+            node \in nodes,
+            tech \in techs,
             timestep \in timesteps
             \\
             if (\text{tech_group=conversion_plus} \land \textit{cap_method}\mathord{=}\text{integer} \land \textit{allowed_carrier_prod}\mathord{=}\text{true})
@@ -883,12 +883,12 @@ carrier_consumption_max_milp
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\neg (\text{tech_group=conversion_plus}) \land \textit{cap_method}\mathord{=}\text{integer} \land \textit{allowed_carrier_con}\mathord{=}\text{true})
@@ -904,12 +904,12 @@ carrier_production_min_milp
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\exists (\textit{carrier}) \land \exists (\textit{energy_cap_min_use}) \land \neg (\text{tech_group=conversion_plus}) \land \textit{cap_method}\mathord{=}\text{integer} \land \textit{allowed_carrier_prod}\mathord{=}\text{true})
@@ -925,11 +925,11 @@ carrier_production_min_conversion_plus_milp
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
+            node \in nodes,
+            tech \in techs,
             timestep \in timesteps
             \\
             if (\exists (\textit{energy_cap_min_use}) \land \text{tech_group=conversion_plus} \land \textit{cap_method}\mathord{=}\text{integer} \land \textit{allowed_carrier_prod}\mathord{=}\text{true})
@@ -945,10 +945,10 @@ storage_capacity_units_milp
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\text{tech_group=storage} \lor \text{tech_group=supply_plus} \land \textit{cap_method}\mathord{=}\text{integer} \land \textit{include_storage}\mathord{=}\text{true} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
@@ -964,10 +964,10 @@ energy_capacity_units_milp
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\exists (\textit{energy_cap_per_unit}) \land \textit{cap_method}\mathord{=}\text{integer} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
@@ -983,10 +983,10 @@ energy_capacity_max_purchase_milp
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\exists (\textit{cost_purchase}) \land (\exists (\textit{energy_cap_max}) \lor \exists (\textit{energy_cap_equals})) \land \textit{cap_method}\mathord{=}\text{binary})
@@ -1006,10 +1006,10 @@ energy_capacity_min_purchase_milp
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\exists (\textit{cost_purchase}) \land \exists (\textit{energy_cap_min}) \land \neg (\exists (\textit{energy_cap_equals})) \land \textit{cap_method}\mathord{=}\text{binary})
@@ -1025,10 +1025,10 @@ storage_capacity_max_purchase_milp
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\exists (\textit{cost_purchase}) \land (\exists (\textit{storage_cap_max}) \lor \exists (\textit{storage_cap_equals})) \land \textit{cap_method}\mathord{=}\text{binary})
@@ -1048,10 +1048,10 @@ storage_capacity_min_purchase_milp
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\exists (\textit{cost_purchase}) \land \exists (\textit{storage_cap_min}) \land \neg (\exists (\textit{storage_cap_equals})) \land \textit{cap_method}\mathord{=}\text{binary})
@@ -1067,7 +1067,7 @@ unit_capacity_systemwide_milp
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
             tech \in techs
@@ -1095,11 +1095,11 @@ asynchronous_con_milp
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
+            node \in nodes,
+            tech \in techs,
             timestep \in timesteps
             \\
             if (\textit{force_asynchronous_prod_con}\mathord{=}\text{true})
@@ -1115,11 +1115,11 @@ asynchronous_prod_milp
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
+            node \in nodes,
+            tech \in techs,
             timestep \in timesteps
             \\
             if (\textit{force_asynchronous_prod_con}\mathord{=}\text{true})
@@ -1135,12 +1135,12 @@ ramping_up
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\exists (\textit{energy_ramping}) \land \neg (\textit{timesteps}\mathord{=}\text{timesteps[0]}))
@@ -1163,12 +1163,12 @@ ramping_down
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\exists (\textit{energy_ramping}) \land \neg (\textit{timesteps}\mathord{=}\text{timesteps[0]}))
@@ -1194,12 +1194,12 @@ cost_var
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            cost \in costs, 
+            node \in nodes,
+            tech \in techs,
+            cost \in costs,
             timestep \in timesteps
             \\
             if (\exists (\textit{cost_export}) \lor \exists (\textit{cost_om_con}) \lor \exists (\textit{cost_om_prod}))
@@ -1303,11 +1303,11 @@ cost_investment
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
+            node \in nodes,
+            tech \in techs,
             cost \in costs
             \\
             if (\exists (\textit{cost_energy_cap}) \lor \exists (\textit{cost_om_annual}) \lor \exists (\textit{cost_om_annual_investment_fraction}) \lor \exists (\textit{cost_purchase}) \lor \exists (\textit{cost_resource_area}) \lor \exists (\textit{cost_resource_cap}) \lor \exists (\textit{cost_storage_cap}) \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
@@ -1609,11 +1609,11 @@ cost
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
+            node \in nodes,
+            tech \in techs,
             cost \in costs
             \\
             if (\exists (\textit{cost_energy_cap}) \lor \exists (\textit{cost_om_annual}) \lor \exists (\textit{cost_om_annual_investment_fraction}) \lor \exists (\textit{cost_purchase}) \lor \exists (\textit{cost_resource_area}) \lor \exists (\textit{cost_resource_cap}) \lor \exists (\textit{cost_storage_cap}) \lor \exists (\textit{cost_export}) \lor \exists (\textit{cost_om_con}) \lor \exists (\textit{cost_om_prod}))
@@ -1642,10 +1642,10 @@ energy_cap
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\neg (\text{run_config.mode}\mathord{=}\text{operate}))
@@ -1663,12 +1663,12 @@ carrier_prod
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\exists (\textit{carrier}) \land \textit{allowed_carrier_prod}\mathord{=}\text{true} \land \text{carrier_tier}\in \text{[out,out_2,out_3]})
@@ -1686,12 +1686,12 @@ carrier_con
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\exists (\textit{carrier}) \land \textit{allowed_carrier_con}\mathord{=}\text{true} \land \text{carrier_tier}\in \text{[in,in_2,in_3]})
@@ -1709,12 +1709,12 @@ carrier_export
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
-            carrier \in carriers, 
+            node \in nodes,
+            tech \in techs,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\exists (\textit{export_carrier}) \land \textit{export}\mathord{=}\text{true})
@@ -1732,10 +1732,10 @@ resource_area
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\exists (\textit{resource_area_min}) \lor \exists (\textit{resource_area_max}) \lor \exists (\textit{resource_area_equals}) \lor \exists (\textit{resource_area_per_energy_cap}) \lor \textit{resource_unit}\mathord{=}\text{energy_per_area} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
@@ -1753,11 +1753,11 @@ resource_con
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
+            node \in nodes,
+            tech \in techs,
             timestep \in timesteps
             \\
             if (\text{tech_group=supply_plus})
@@ -1775,10 +1775,10 @@ resource_cap
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\text{tech_group=supply_plus} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
@@ -1796,10 +1796,10 @@ storage_cap
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\text{tech_group=storage} \lor \text{tech_group=supply_plus} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}) \land \textit{include_storage}\mathord{=}\text{true})
@@ -1817,11 +1817,11 @@ storage
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
+            node \in nodes,
+            tech \in techs,
             timestep \in timesteps
             \\
             if (\text{tech_group=storage} \lor \text{tech_group=supply_plus} \land \textit{include_storage}\mathord{=}\text{true})
@@ -1839,10 +1839,10 @@ purchased
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\textit{cap_method}\mathord{=}\text{binary} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
@@ -1860,10 +1860,10 @@ units
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
+            node \in nodes,
             tech \in techs
             \\
             if (\textit{cap_method}\mathord{=}\text{integer} \land \neg (\text{run_config.mode}\mathord{=}\text{operate}))
@@ -1881,11 +1881,11 @@ operating_units
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
+            node \in nodes,
+            tech \in techs,
             timestep \in timesteps
             \\
             if (\textit{cap_method}\mathord{=}\text{integer})
@@ -1903,11 +1903,11 @@ prod_con_switch
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            tech \in techs, 
+            node \in nodes,
+            tech \in techs,
             timestep \in timesteps
             \\
             if (\textit{force_asynchronous_prod_con}\mathord{=}\text{true})
@@ -1925,11 +1925,11 @@ unmet_demand
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            carrier \in carriers, 
+            node \in nodes,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\text{run_config.ensure_feasibility}\mathord{=}\text{true})
@@ -1947,11 +1947,11 @@ unused_supply
 .. container:: scrolling-wrapper
 
     .. math::
-        
+
         \begin{array}{r}
             \forall{}
-            node \in nodes, 
-            carrier \in carriers, 
+            node \in nodes,
+            carrier \in carriers,
             timestep \in timesteps
             \\
             if (\text{run_config.ensure_feasibility}\mathord{=}\text{true})

--- a/doc/api/api.rst
+++ b/doc/api/api.rst
@@ -25,14 +25,6 @@ Time series
 .. automodule:: calliope.time.funcs
     :members: resample
 
-.. _api_analysis:
-
-Analyzing models
-================
-
-.. autoclass:: calliope.postprocess.plotting.plotting.ModelPlotMethods
-    :members: timeseries, capacity, transmission, summary
-
 .. _api_backend_interface:
 
 Pyomo backend interface

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -33,28 +33,6 @@ generate_tables.process()
 # Mock modules for Read The Docs autodoc generation
 ##
 
-
-class Mock(object):
-    __all__ = []
-
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def __call__(self, *args, **kwargs):
-        return Mock()
-
-    @classmethod
-    def __getattr__(cls, name):
-        if name in ("__file__", "__path__"):
-            return "/dev/null"
-        elif name[0] == name[0].upper():
-            mockType = type(name, (), {})
-            mockType.__module__ = __name__
-            return mockType
-        else:
-            return Mock()
-
-
 MOCK_MODULES = [
     "numpy",
     "matplotlib",
@@ -75,9 +53,10 @@ MOCK_MODULES = [
     "pandas.api",
     "pandas.api.types",
     "click",
-    "xarray",
     "dask",
+    "xarray",
     "xarray.ufuncs",
+    "xarray.DataArray",
     "numpy.random",
     "numpy.fft",
     "numpy.lib",
@@ -100,8 +79,7 @@ MOCK_MODULES = [
     "IPython",
 ]
 
-for m in MOCK_MODULES:
-    sys.modules[m] = Mock()
+autodoc_mock_imports = MOCK_MODULES
 
 
 # Redefine supported_image_types for the HTML builder to prefer PNG over SVG
@@ -138,10 +116,11 @@ extensions = [
     "sphinx_search.extension",
 ]
 
-# Ensure that cdnjs is used rather than the discontinued mathjax cdn
-mathjax_path = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
+# Ensure that mathjax will render large equations
+mathjax3_config = {"tex": {"MAXBUFFER": 25 * 1024}}
 
-numpydoc_show_class_members = False  # numpydoc: don't do autosummary
+# numpydoc: don't do autosummary
+numpydoc_show_class_members = False
 
 nbviewer_url = "https://nbviewer.org/url/calliope.readthedocs.io/"
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -68,6 +68,8 @@ MOCK_MODULES = [
     "pyomo.common",
     "pyomo.common.tempfiles",
     "pyomo.common.tempfiles.TempfileManager",
+    "pyomo.kernel",
+    "pyparsing",
     "yaml",
     "pandas",
     "pandas.api",
@@ -337,7 +339,7 @@ latex_documents = [
         "manual",
     ),
 ]
-
+imgmath_latex_preamble = r"\usepackage{breqn}"
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
 # latex_logo = None

--- a/doc/helpers/generate_math.py
+++ b/doc/helpers/generate_math.py
@@ -1,0 +1,121 @@
+"""
+Copyright (C) since 2013 Calliope contributors listed in AUTHORS.
+Licensed under the Apache 2.0 License (see LICENSE file).
+
+generate_math.py
+~~~~~~~~~~~~~~~~~
+
+Generate LaTeX math to include in the documentation.
+
+"""
+from pathlib import Path
+
+import pandas as pd
+import calliope
+
+BASEPATH = Path(__file__).resolve().parent
+NONDEMAND_TECHGROUPS = [
+    "supply",
+    "storage",
+    "conversion",
+    "transmission",
+    "conversion_plus",
+    "supply_plus",
+]
+
+
+def generate_math():
+    """
+    To generate the written mathematical formulation of all possible base constraints, we first create a dummy model that has all the relevant technology groups defining all their allowed parameters defined.
+
+    Parameters that can be defined over a timeseries are forced to be defined over a timeseries. Accordingly, the parameters will have "timesteps" in their dimensions in the formulation.
+    """
+    defaults = calliope.AttrDict.from_yaml(
+        BASEPATH / ".." / ".." / "calliope" / "config" / "defaults.yaml"
+    )
+
+    ts = pd.DataFrame(
+        [1, 1, 1],
+        index=pd.date_range("2005-01-01 00:00", "2005-01-01 02:00", freq="H"),
+        columns=["A"],
+    )
+
+    allowed_ = {i: {"all": set()} for i in ["costs", "constraints"]}
+
+    dummy_techs = {
+        "demand_tech": {
+            "essentials": {"parent": "demand", "carrier": "electricity"},
+            "constraints": {"resource": "df=ts_neg"},
+        }
+    }
+
+    for tech_group in NONDEMAND_TECHGROUPS:
+        for config_ in ["costs", "constraints"]:
+            tech_allowed_ = defaults.tech_groups[tech_group][f"allowed_{config_}"]
+            # We keep parameter definitions to a bare minimum, so any that have been
+            # defined for a previous tech group in the loop will not be defined for
+            # later tech groups.
+            allowed_[config_][tech_group] = set(tech_allowed_).difference(
+                allowed_[config_]["all"]
+            )
+            # We keep lifetime and interest rate since all techs that define costs will
+            # need them.
+            allowed_[config_][tech_group].update(["lifetime", "interest_rate"])
+
+            allowed_[config_]["all"].update(tech_allowed_)
+
+        if "conversion" in tech_group:
+            carriers = {"carrier_in": "electricity", "carrier_out": "heat"}
+        else:
+            carriers = {"carrier": "electricity"}
+
+        dummy_techs[f"{tech_group}_tech"] = {
+            "essentials": {"parent": tech_group, **carriers},
+            "constraints": {
+                k: _add_data(k, v, defaults)
+                for k, v in defaults.techs.default_tech.constraints.items()
+                if k in allowed_["constraints"][tech_group]
+            },
+            "costs": {
+                "monetary": {
+                    k: _add_data(k, v, defaults)
+                    for k, v in defaults.techs.default_tech.costs.default_cost.items()
+                    if k in allowed_["costs"][tech_group]
+                }
+            },
+        }
+
+    model_config = {
+        "model": {},
+        "run": {"objective_options": {"cost_class": {"monetary": 1}}},
+        # Hardcoding just one expected per-node parameter: available area
+        "nodes": {
+            "A": {"techs": {k: None for k in dummy_techs.keys()}, "available_area": 1}
+        },
+        "techs": dummy_techs,
+    }
+    m = calliope.Model(
+        config=model_config, timeseries_dataframes={"ts": ts, "ts_neg": -1 * ts}
+    )
+    m.write_math_documentation(
+        filename=BASEPATH / ".." / "user" / "includes" / "math.rst"
+    )
+
+
+def _add_data(name, default_val, defaults):
+    "If timeseries is allowed, we reference timeseries data. Some parameters need hardcoded values to be returned"
+    if name in defaults["model"]["file_allowed"]:
+        if name == "carrier_ratios":
+            return {"carrier_in.electricity": "df=ts"}
+        else:
+            return "df=ts"
+    elif name == "export_carrier":
+        return "electricity"
+    elif default_val is None or name == "interest_rate":
+        return 1
+    else:
+        return default_val
+
+
+if __name__ == "__main__":
+    generate_math()

--- a/doc/user/develop.rst
+++ b/doc/user/develop.rst
@@ -245,6 +245,7 @@ Pre-release
 
 * Make sure all unit tests pass
 * Build up-to-date Plotly plots for the documentation with (``make doc-plots``)
+* Build up-to-date mathematical formulation for the documentation with (``make doc-math``)
 * Re-run tutorial Jupyter notebooks, found in `doc/_static/notebooks`
 * Make sure documentation builds without errors
 * Make sure the release notes are up-to-date, especially that new features and backward incompatible changes are clearly marked
@@ -265,6 +266,7 @@ Create release
         * Reset ``build: number: 0`` if it is not already at zero (should be automatically updated)
         * Range of python versions supported
         * Requirement version pinning, to match any changes in ``requirements.txt`` and ``requirements.yml``
+
     ^ Any necessary updates can be made direclty on the PR by pushing directly to the bot's branch or by using the GIthub interactive editing interface.
 
 Post-release

--- a/doc/user/ref_formulation.rst
+++ b/doc/user/ref_formulation.rst
@@ -2,94 +2,19 @@
 Mathematical formulation
 ------------------------
 
-This section details the mathematical formulation of the different components. For each component, a link to the actual implementing function in the Calliope code is given.
+This section details the base mathematical formulation that is loaded when creating a Calliope model.
+If a math component's initial conditions are met (those to the left of the curly brace), it will be applied to a model.
+For each objective, constraint and global expression, a number of subconditions then apply (those to the right of the curly brace) to decide on the specific expression to apply at a given iteration of the component dimensions.
 
-.. note::
-    Make sure to also refer to the detailed :doc:`listing of constraints and costs along with their units and default values <config_defaults>`.
+In the following expressions, terms in **bold** font are decision variables and terms in *italic* font are parameters. A list of the decision variables is given at the end of this page. A detailed listing of parameters along with their units and default values is given  :doc:`here <config_defaults>`.
+Those parameters which are defined over time (`timesteps`) in the expressions can be defined by a user as a single, time invariant value, or as a timeseries that is :ref:`loaded from file or dataframe <_configuration_timeseries>`.
 
-Decision variables
-------------------
+To view only the mathematical formulation valid for your own model, you can write a LaTeX or reStructuredText file as follows:
 
-.. automodule:: calliope.backend.pyomo.variables
-    :members:
+.. code-block:: python
 
-Objective functions
--------------------
+    model = calliope.Model("path/to/model.yaml")
+    model.write_math_documentation(filename="path/to/output/file.[tex|rst]", include="valid")
 
-.. automodule:: calliope.backend.pyomo.objective
-    :members:
+.. include:: ../_static/math.rst
 
-.. _api_constraints:
-
-Constraints
-===========
-
-Energy Balance
---------------
-
-.. automodule:: calliope.backend.pyomo.constraints.energy_balance
-    :members:
-
-.. _constraint_capacity:
-
-Capacity
---------
-
-.. automodule:: calliope.backend.pyomo.constraints.capacity
-    :members:
-
-Dispatch
---------
-
-.. automodule:: calliope.backend.pyomo.constraints.dispatch
-    :members:
-
-Costs
------
-
-.. automodule:: calliope.backend.pyomo.constraints.costs
-    :members:
-
-Export
-------
-
-.. automodule:: calliope.backend.pyomo.constraints.export
-    :members:
-
-MILP
-----
-
-.. automodule:: calliope.backend.pyomo.constraints.milp
-    :members:
-
-Conversion
-----------
-
-.. automodule:: calliope.backend.pyomo.constraints.conversion
-    :members:
-
-Conversion_plus
----------------
-
-.. automodule:: calliope.backend.pyomo.constraints.conversion_plus
-    :members:
-
-Network
--------
-
-.. automodule:: calliope.backend.pyomo.constraints.network
-    :members:
-
-Policy
-------
-
-.. automodule:: calliope.backend.pyomo.constraints.policy
-    :members:
-
-.. _constraint_group:
-
-Group constraints
-----------------------
-
-.. automodule:: calliope.backend.pyomo.constraints.group
-    :members:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 click ~= 8.1
 ipython >= 7, < 9
 ipdb >= 0.13, < 1.0
+jinja2 ~= 3.1.2
 natsort >= 5, < 9
 netcdf4 >= 1.2.2, < 1.7
 numpy ~= 1.23.5

--- a/requirements_docs.yml
+++ b/requirements_docs.yml
@@ -1,14 +1,14 @@
 name: calliope-docs
 
 channels:
-    - conda-forge
+  - conda-forge
 
 dependencies:
-    - python=3.7  # https://docs.readthedocs.io/en/stable/config-file/v2.html#python-version
-    - sphinx=4.2
-    - numpydoc
-    - ruamel.yaml
-    - nbconvert  # To generate HTML files from example notebooks
-    - pip
-    - pip:
-        - "git+https://github.com/readthedocs/readthedocs-sphinx-search@main"
+  - python=3.9 # https://docs.readthedocs.io/en/stable/config-file/v2.html#python-version
+  - sphinx~=6.1.3
+  - numpydoc
+  - ruamel.yaml
+  - nbconvert # To generate HTML files from example notebooks
+  - pip
+  - pip:
+      - readthedocs-sphinx-search


### PR DESCRIPTION
Fixes issue(s) #361 #426 

Summary of changes in this pull request:

* New method on the model object `write_math_documentation` to return a string or write to file.
* New subclass of the backend model abstract class which handles creating string representations of the math formulation elements. 
* New helper function to generate all the in-built math and write it to an RST file that can be included in the docs. NOTE: does not handle custom in-built math at the moment (e.g., storage_inter_cluster). Where should the custom math go in the docs? Do we just generate the parts of the math that are different or generate the whole thing for the specific custom math file after it has overridden the base math file?


Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved