### PR TITLE
[work-in-progress] delete 'equals' bounds in variables' definitions

### DIFF
--- a/calliope/backend/parsing.py
+++ b/calliope/backend/parsing.py
@@ -46,7 +46,6 @@ class ParsedEquationDict(TypedDict):
 class UnparsedVariableBoundDict(TypedDict):
     min: str
     max: str
-    equals: str
     scale: NotRequired[str]
 
 
@@ -665,7 +664,6 @@ class ParsedVariable(ParsedBackendComponent):
                 bounds: UnparsedBoundsDict <- link to parameters with which to apply explicit numeric bounds on each item in the variable
                     min: str
                     max: str
-                    equals: str
                     scale: str
             variable_name (str): Name of variable.
         """

--- a/calliope/backend/pyomo/constraints/capacity.py
+++ b/calliope/backend/pyomo/constraints/capacity.py
@@ -23,20 +23,14 @@ def get_capacity_bounds(bounds):
                 return None
 
         scale = _get_bound("scale")
-        _equals = _get_bound("equals")
         _min = _get_bound("min")
         _max = _get_bound("max")
-
-        if not invalid(_equals):
-            if not invalid(scale):
-                _equals *= scale
-            bound_tuple = (_equals, _equals)
-        else:
-            if invalid(_min):
-                _min = None
-            if invalid(_max):
-                _max = None
-            bound_tuple = (_min, _max)
+        
+        if invalid(_min):
+            _min = None
+        if invalid(_max):
+            _max = None
+        bound_tuple = (_min, _max)
 
         if not invalid(scale):
             bound_tuple = tuple(i * scale for i in bound_tuple)

--- a/calliope/backend/pyomo/constraints/capacity.py
+++ b/calliope/backend/pyomo/constraints/capacity.py
@@ -25,7 +25,7 @@ def get_capacity_bounds(bounds):
         scale = _get_bound("scale")
         _min = _get_bound("min")
         _max = _get_bound("max")
-        
+
         if invalid(_min):
             _min = None
         if invalid(_max):

--- a/calliope/backend/pyomo/constraints/milp.py
+++ b/calliope/backend/pyomo/constraints/milp.py
@@ -248,8 +248,8 @@ def energy_capacity_max_purchase_milp_constraint_rule(backend_model, node, tech)
 
             \\frac{\\boldsymbol{energy_{cap}}(loc::tech)}{energy_{cap, scale}(loc::tech)}
             \\begin{cases}
-                = energy_{cap, equals}(loc::tech) \\times \\boldsymbol{purchased}(loc::tech),&
-                    \\text{if } energy_{cap, equals}(loc::tech)\\\\
+                \\geq energy_{cap, min}(loc::tech) \\times \\boldsymbol{purchased}(loc::tech),&
+                    \\text{if } energy_{cap, min}(loc::tech)\\\\
                 \\leq energy_{cap, max}(loc::tech) \\times \\boldsymbol{purchased}(loc::tech),&
                     \\text{if } energy_{cap, max}(loc::tech)\\\\
                 \\text{unconstrained},& \\text{otherwise}
@@ -258,12 +258,12 @@ def energy_capacity_max_purchase_milp_constraint_rule(backend_model, node, tech)
 
     """
     energy_cap_max = get_param(backend_model, "energy_cap_max", (node, tech))
-    energy_cap_equals = get_param(backend_model, "energy_cap_equals", (node, tech))
+    energy_cap_min = get_param(backend_model, "energy_cap_min", (node, tech))
     energy_cap_scale = get_param(backend_model, "energy_cap_scale", (node, tech))
 
-    if po.value(energy_cap_equals):
+    if po.value(energy_cap_max) == po.value(energy_cap_min):
         return backend_model.energy_cap[node, tech] == (
-            energy_cap_equals * energy_cap_scale * backend_model.purchased[node, tech]
+            energy_cap_max * energy_cap_scale * backend_model.purchased[node, tech]
         )
 
     else:
@@ -307,8 +307,8 @@ def storage_capacity_max_purchase_milp_constraint_rule(backend_model, node, tech
 
             \\boldsymbol{storage_{cap}}(loc::tech)
             \\begin{cases}
-                = storage_{cap, equals}(loc::tech) \\times \\boldsymbol{purchased},&
-                    \\text{if } storage_{cap, equals} \\\\
+                \\geq storage_{cap, min}(loc::tech) \\times \\boldsymbol{purchased},&
+                    \\text{if } storage_{cap, min}(loc::tech)\\\\
                 \\leq storage_{cap, max}(loc::tech) \\times \\boldsymbol{purchased},&
                     \\text{if } storage_{cap, max}(loc::tech)\\\\
                 \\text{unconstrained},& \\text{otherwise}
@@ -317,11 +317,11 @@ def storage_capacity_max_purchase_milp_constraint_rule(backend_model, node, tech
 
     """
     storage_cap_max = get_param(backend_model, "storage_cap_max", (node, tech))
-    storage_cap_equals = get_param(backend_model, "storage_cap_equals", (node, tech))
+    storage_cap_min = get_param(backend_model, "storage_cap_min", (node, tech))
 
-    if po.value(storage_cap_equals):
+    if po.value(storage_cap_max) == po.value(storage_cap_min):
         return backend_model.storage_cap[node, tech] == (
-            storage_cap_equals * backend_model.purchased[node, tech]
+            storage_cap_max * backend_model.purchased[node, tech]
         )
 
     elif po.value(storage_cap_max):

--- a/calliope/config/defaults.yaml
+++ b/calliope/config/defaults.yaml
@@ -54,7 +54,7 @@ model:
 tech_groups:
     conversion:
         required_constraints: []
-        allowed_constraints: ['energy_cap_equals', 'energy_cap_equals_systemwide', 'energy_cap_max', 'energy_cap_max_systemwide', 'energy_cap_min', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_cap_scale', 'energy_eff', 'energy_ramping', 'export_max', 'export_carrier', 'lifetime', 'units_equals', 'units_equals_systemwide', 'units_max', 'units_max_systemwide', 'units_min']
+        allowed_constraints: ['energy_cap_equals_systemwide', 'energy_cap_max', 'energy_cap_max_systemwide', 'energy_cap_min', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_cap_scale', 'energy_eff', 'energy_ramping', 'export_max', 'export_carrier', 'lifetime', 'units_equals_systemwide', 'units_max', 'units_max_systemwide', 'units_min']
         allowed_costs: ['depreciation_rate', 'energy_cap', 'export', 'interest_rate', 'om_annual', 'om_annual_investment_fraction', 'om_con', 'om_prod', 'purchase']
         allowed_switches: [cap_method, export, allowed_carrier_con, allowed_carrier_prod]
         essentials:
@@ -67,7 +67,7 @@ tech_groups:
 
     conversion_plus:
         required_constraints: []
-        allowed_constraints: ['carrier_ratios', 'energy_cap_equals', 'energy_cap_equals_systemwide', 'energy_cap_max', 'energy_cap_max_systemwide', 'energy_cap_min', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_cap_scale', 'energy_eff', 'energy_ramping', 'export_max', 'export_carrier', 'lifetime', 'units_equals', 'units_equals_systemwide', 'units_max', 'units_max_systemwide', 'units_min']
+        allowed_constraints: ['carrier_ratios', 'energy_cap_equals_systemwide', 'energy_cap_max', 'energy_cap_max_systemwide', 'energy_cap_min', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_cap_scale', 'energy_eff', 'energy_ramping', 'export_max', 'export_carrier', 'lifetime', 'units_equals_systemwide', 'units_max', 'units_max_systemwide', 'units_min']
         allowed_costs: ['depreciation_rate', 'energy_cap', 'export', 'interest_rate', 'om_annual', 'om_annual_investment_fraction', 'om_con', 'om_prod', 'purchase']
         allowed_switches: [cap_method, export, allowed_carrier_con, allowed_carrier_prod]
         essentials:
@@ -79,7 +79,7 @@ tech_groups:
             allowed_carrier_prod: true
     demand:
         required_constraints: ['resource']
-        allowed_constraints: ['resource', 'resource_area_equals', 'resource_scale', 'resource_unit']
+        allowed_constraints: ['resource', 'resource_scale', 'resource_unit']
         allowed_costs: [om_con]
         allowed_switches: [resource_unit, force_resource, allowed_carrier_con, allowed_carrier_prod]
         essentials:
@@ -91,7 +91,7 @@ tech_groups:
             allowed_carrier_prod: false
     storage:
         required_constraints: []
-        allowed_constraints: ['energy_cap_per_storage_cap_min', 'energy_cap_per_storage_cap_equals', 'energy_cap_per_storage_cap_max', 'energy_cap_equals', 'energy_cap_equals_systemwide', 'energy_cap_max', 'energy_cap_max_systemwide', 'energy_cap_min', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_cap_scale', 'energy_eff', 'energy_ramping', 'export_max', 'export_carrier', 'force_asynchronous_prod_con', 'lifetime', 'storage_cap_equals', 'storage_cap_max', 'storage_cap_min', 'storage_cap_per_unit', 'storage_initial', 'storage_loss', 'storage_time_max', 'storage_discharge_depth', 'units_equals', 'units_equals_systemwide', 'units_max', 'units_max_systemwide', 'units_min']
+        allowed_constraints: ['energy_cap_per_storage_cap_min', 'energy_cap_per_storage_cap_equals', 'energy_cap_per_storage_cap_max', 'energy_cap_equals_systemwide', 'energy_cap_max', 'energy_cap_max_systemwide', 'energy_cap_min', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_cap_scale', 'energy_eff', 'energy_ramping', 'export_max', 'export_carrier', 'force_asynchronous_prod_con', 'lifetime', 'storage_cap_max', 'storage_cap_min', 'storage_cap_per_unit', 'storage_initial', 'storage_loss', 'storage_time_max', 'storage_discharge_depth', 'units_equals_systemwide', 'units_max', 'units_max_systemwide', 'units_min']
         allowed_costs: ['depreciation_rate', 'energy_cap', 'export', 'interest_rate', 'om_annual', 'om_annual_investment_fraction', 'om_prod', 'purchase', 'storage_cap']
         allowed_switches: [cap_method, include_storage, export, allowed_carrier_con, allowed_carrier_prod]
         essentials:
@@ -104,7 +104,7 @@ tech_groups:
             allowed_carrier_prod: true
     supply:
         required_constraints: []
-        allowed_constraints: ['energy_cap_equals', 'energy_cap_equals_systemwide', 'energy_cap_max', 'energy_cap_max_systemwide', 'energy_cap_min', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_cap_scale', 'energy_eff', 'energy_ramping', 'export_max', 'export_carrier', 'lifetime', 'resource', 'resource_area_equals', 'resource_area_max', 'resource_area_min', 'resource_area_per_energy_cap', 'resource_min_use', 'resource_scale', 'units_equals', 'units_equals_systemwide', 'units_max', 'units_max_systemwide', 'units_min']
+        allowed_constraints: ['energy_cap_equals_systemwide', 'energy_cap_max', 'energy_cap_max_systemwide', 'energy_cap_min', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_cap_scale', 'energy_eff', 'energy_ramping', 'export_max', 'export_carrier', 'lifetime', 'resource', 'resource_area_max', 'resource_area_min', 'resource_area_per_energy_cap', 'resource_min_use', 'resource_scale', 'units_equals_systemwide', 'units_max', 'units_max_systemwide', 'units_min']
         allowed_costs: ['depreciation_rate', 'energy_cap', 'export', 'interest_rate', 'om_annual', 'om_annual_investment_fraction', 'om_con', 'om_prod', 'purchase', 'resource_area']
         allowed_switches: [cap_method, resource_unit, force_resource, export, allowed_carrier_con, allowed_carrier_prod]
         essentials:
@@ -119,7 +119,7 @@ tech_groups:
 
     supply_plus:
         required_constraints: []
-        allowed_constraints: ['energy_cap_per_storage_cap_min', 'energy_cap_per_storage_cap_equals', 'energy_cap_per_storage_cap_max', 'energy_cap_equals', 'energy_cap_equals_systemwide', 'energy_cap_max', 'energy_cap_max_systemwide', 'energy_cap_min', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_cap_scale', 'energy_eff', 'energy_ramping', 'export_max', 'export_carrier', 'lifetime', 'parasitic_eff', 'resource', 'resource_area_equals', 'resource_area_max', 'resource_area_min', 'resource_area_per_energy_cap', 'resource_cap_equals', 'resource_cap_max', 'resource_cap_min', 'resource_eff', 'resource_min_use', 'resource_scale', 'storage_cap_equals', 'storage_cap_max', 'storage_cap_min', 'storage_cap_per_unit', 'storage_initial', 'storage_loss', 'units_equals', 'units_equals_systemwide', 'units_max', 'units_max_systemwide', 'units_min']
+        allowed_constraints: ['energy_cap_per_storage_cap_min', 'energy_cap_per_storage_cap_equals', 'energy_cap_per_storage_cap_max', 'energy_cap_equals_systemwide', 'energy_cap_max', 'energy_cap_max_systemwide', 'energy_cap_min', 'energy_cap_min_use', 'energy_cap_per_unit', 'energy_cap_scale', 'energy_eff', 'energy_ramping', 'export_max', 'export_carrier', 'lifetime', 'parasitic_eff', 'resource', 'resource_area_max', 'resource_area_min', 'resource_area_per_energy_cap', 'resource_cap_max', 'resource_cap_min', 'resource_eff', 'resource_min_use', 'resource_scale', 'storage_cap_max', 'storage_cap_min', 'storage_cap_per_unit', 'storage_initial', 'storage_loss', 'units_equals_systemwide', 'units_max', 'units_max_systemwide', 'units_min']
         allowed_costs: ['depreciation_rate', 'energy_cap', 'export', 'interest_rate', 'om_annual', 'om_annual_investment_fraction', 'om_con', 'om_prod', 'purchase', 'resource_area', 'resource_cap', 'storage_cap']
         allowed_switches: [cap_method, include_storage, resource_unit, resource_cap_equals_energy_cap, force_resource, export, allowed_carrier_con, allowed_carrier_prod]
         essentials:
@@ -137,7 +137,7 @@ tech_groups:
 
     transmission:
         required_constraints: []
-        allowed_constraints: ['energy_cap_equals', 'energy_cap_min', 'energy_cap_max', 'energy_cap_per_unit', 'energy_cap_scale', 'energy_eff', 'energy_eff_per_distance', 'force_asynchronous_prod_con', 'lifetime', 'one_way']
+        allowed_constraints: ['energy_cap_min', 'energy_cap_max', 'energy_cap_per_unit', 'energy_cap_scale', 'energy_eff', 'energy_eff_per_distance', 'force_asynchronous_prod_con', 'lifetime', 'one_way']
         allowed_costs: ['depreciation_rate', 'energy_cap', 'energy_cap_per_distance', 'interest_rate', 'om_annual', 'om_annual_investment_fraction', 'om_prod', 'purchase', 'purchase_per_distance']
         allowed_switches: [cap_method, one_way, allowed_carrier_con, allowed_carrier_prod]
         essentials:
@@ -181,7 +181,6 @@ techs:
             energy_cap_per_storage_cap_min: 0 # name: Minimum energy capacity per storage capacity ¦ unit: hour :sup:`-1` ¦ ratio of minimum charge/discharge (kW) for a given storage capacity (kWh).
             energy_cap_per_storage_cap_max: .inf # name: Maximum energy capacity per storage capacity ¦ unit: hour :sup:`-1` ¦ ratio of maximum charge/discharge (kW) for a given storage capacity (kWh).
             energy_cap_per_storage_cap_equals: null # name: Tie energy capacity to storage capacity ¦ unit: hour :sup:`-1` ¦
-            energy_cap_equals: null  # name: Specific installed energy capacity ¦ unit: kW ¦ fixes maximum/minimum if decision variables ``carrier_prod``/``carrier_con`` and overrides ``_max`` and ``_min`` constraints.
             energy_cap_equals_systemwide: null   # name: System-wide specific installed energy capacity ¦ unit: kW ¦ fixes the sum to a maximum/minimum, for a particular technology, of the decision variables ``carrier_prod``/``carrier_con`` over all nodes.
             energy_cap_max: .inf  # name: Maximum installed energy capacity ¦ unit: kW ¦ Limits decision variables ``carrier_prod``/``carrier_con`` to a maximum/minimum.
             energy_cap_max_systemwide: .inf  # name: System-wide maximum installed energy capacity ¦ unit: kW ¦ Limits the sum to a maximum/minimum, for a particular technology, of the decision variables ``carrier_prod``/``carrier_con`` over all nodes.
@@ -197,24 +196,20 @@ techs:
             lifetime: null  # name: Technology lifetime ¦ unit: years ¦ Must be defined if fixed capital costs are defined. A reasonable value for many technologies is around 20-25 years.
             parasitic_eff: 1.0  # name: Plant parasitic efficiency ¦ unit: fraction ¦ Additional losses as energy gets transferred from the plant to the carrier (static, or from file as timeseries), e.g. due to plant parasitic consumption
             resource: .inf  # name: Available resource ¦ unit: kWh | kWh/m\ :sup:`2` | kWh/kW ¦ Maximum available resource (static, or from file as timeseries). Unit dictated by ``resource_unit``
-            resource_area_equals: null  # name: Specific installed resource area ¦ unit: m\ :sup:`2` ¦
             resource_area_max: .inf  # name: Maximum usable resource area ¦ unit: m\ :sup:`2` ¦ If set to a finite value, restricts the usable area of the technology to this value.
             resource_area_min: 0  # name: Minimum usable resource area ¦ unit: m\ :sup:`2` ¦
             resource_area_per_energy_cap: null  # name: Resource area per energy capacity ¦ unit: m\ :sup: `2`/kW ¦ If set, forces ``resource_area`` to follow ``energy_cap`` with the given numerical ratio (e.g. setting to 1.5 means that ``resource_area == 1.5 * energy_cap``)
-            resource_cap_equals: null  # name: Specific installed resource consumption capacity ¦ unit: kW ¦ overrides ``_max`` and ``_min`` constraints.
             resource_cap_max: .inf  # name: Maximum installed resource consumption capacity ¦ unit: kW ¦
             resource_cap_min: 0  # name: Minimum installed resource consumption capacity ¦ unit: kW ¦
             resource_eff: 1.0  # name: Resource efficiency ¦ unit: fraction ¦ Efficiency (static, or from file as timeseries) in capturing resource before it reaches storage (if storage is present) or conversion to carrier.
             resource_min_use: 0 # name: Minimum resource consumption ¦ unit: fraction ¦ Set to a value between 0 and 1 to force minimum resource consumption for production technologies
             resource_scale: 1.0  # name: Resource scale ¦ unit: fraction ¦ Scale resource (either static value or all values in timeseries) by this value
-            storage_cap_equals: null  # name: Specific storage capacity ¦ unit: kWh ¦ If not defined, ``energy_cap_equals`` * ``energy_cap_per_storage_cap_max`` will be used as the capacity and overrides ``_max`` and ``_min`` constraints.
             storage_cap_max: .inf  # name: Maximum storage capacity ¦ unit: kWh ¦ If not defined, ``energy_cap_max`` * ``energy_cap_per_storage_cap_max`` will be used as the capacity.
             storage_cap_min: 0  # name: Minimum storage capacity ¦ unit: kWh ¦
             storage_cap_per_unit: null # name: Storage capacity per purchased unit ¦ unit: kWh/unit ¦ Set the storage capacity of each integer unit of a technology purchased.
             storage_discharge_depth: 0 # name: Storage depth of discharge ¦ unit: fraction ¦ Defines the minimum level of storage state of charge, as a fraction of total storage capacity
             storage_initial: 0  # name: Initial storage level ¦ unit: fraction ¦ Set stored energy in device at the first timestep, as a fraction of total storage capacity
             storage_loss: 0  # name: Storage loss rate ¦ unit: fraction/hour ¦ rate of storage loss per hour (static, or from file as timeseries), used to calculate lost stored energy as ``(1 - storage_loss)^hours_per_timestep``
-            units_equals: null  # name: Specific number of purchased units ¦ unit: integer ¦ Turns the model from LP to MILP.
             units_equals_systemwide: null   # name: System-wide specific installed energy capacity ¦ unit: kW ¦ fixes the sum to a specific value, for a particular technology, of the decision variables ``carrier_prod``/``carrier_con`` over all nodes.
             units_max: .inf  # name: Maximum number of purchased units ¦ unit: integer ¦ Turns the model from LP to MILP.
             units_max_systemwide: .inf  # name: System-wide maximum installed energy capacity ¦ unit: kW ¦ Limits the sum to a maximum/minimum, for a particular technology, of the decision variables ``carrier_prod``/``carrier_con`` over all nodes.

--- a/calliope/config/subsets.yaml
+++ b/calliope/config/subsets.yaml
@@ -18,7 +18,7 @@ constraints:
 
     force_zero_resource_area:
         foreach: [nodes, techs]
-        where: "(resource_area_min OR resource_area_max OR resource_area_equals OR resource_unit=energy_per_area) AND NOT run.mode=operate AND energy_cap_max=0"
+        where: "(resource_area_min OR resource_area_max OR resource_unit=energy_per_area) AND NOT run.mode=operate AND energy_cap_max=0"
 
     resource_area_per_energy_capacity:
         foreach: [nodes, techs]
@@ -26,7 +26,7 @@ constraints:
 
     resource_area_capacity_per_loc:
         foreach: [nodes]
-        where: "available_area AND (resource_area_min OR resource_area_max OR resource_area_equals OR resource_area_per_energy_cap OR resource_unit=energy_per_area) AND NOT run.mode=operate"
+        where: "available_area AND (resource_area_min OR resource_area_max OR resource_area_per_energy_cap OR resource_unit=energy_per_area) AND NOT run.mode=operate"
 
     energy_capacity_systemwide:
         foreach: [techs]
@@ -169,19 +169,19 @@ constraints:
 
     energy_capacity_max_purchase_milp:
         foreach: [nodes, techs]
-        where: "cost_purchase AND (energy_cap_max OR energy_cap_equals) AND cap_method=binary"
+        where: "cost_purchase AND (energy_cap_max) AND cap_method=binary"
 
     energy_capacity_min_purchase_milp:
         foreach: [nodes, techs]
-        where: "cost_purchase AND energy_cap_min AND NOT energy_cap_equals AND cap_method=binary"
+        where: "cost_purchase AND energy_cap_min AND NOT (energy_cap_min=energy_cap_max) AND cap_method=binary"
 
     storage_capacity_max_purchase_milp:
         foreach: [nodes, techs]
-        where: "cost_purchase AND (storage_cap_max OR storage_cap_equals) AND cap_method=binary"
+        where: "cost_purchase AND (storage_cap_max) AND cap_method=binary"
 
     storage_capacity_min_purchase_milp:
         foreach: [nodes, techs]
-        where: "cost_purchase AND storage_cap_min AND NOT storage_cap_equals AND cap_method=binary"
+        where: "cost_purchase AND storage_cap_min AND NOT (storage_cap_min=storage_cap_max) AND cap_method=binary"
 
     unit_capacity_systemwide_milp:
         foreach: [techs]
@@ -228,7 +228,6 @@ variables:
         bounds:
             min: energy_cap_min
             max: energy_cap_max
-            equals: energy_cap_equals
             scale: energy_cap_scale
 
     carrier_prod:
@@ -247,12 +246,11 @@ variables:
 
     resource_area:
         foreach: [nodes, techs]
-        where: "(resource_area_min OR resource_area_max OR resource_area_equals OR resource_area_per_energy_cap OR resource_unit=energy_per_area) AND NOT run.mode=operate"
+        where: "(resource_area_min OR resource_area_max OR resource_area_per_energy_cap OR resource_unit=energy_per_area) AND NOT run.mode=operate"
         domain: NonNegativeReals
         bounds:
             min: resource_area_min
             max: resource_area_max
-            equals: resource_area_equals
 
     storage_cap:
         foreach: [nodes, techs]
@@ -261,7 +259,6 @@ variables:
         bounds:
             min: storage_cap_min
             max: storage_cap_max
-            equals: storage_cap_equals
 
     storage_inter_cluster:
         foreach: [nodes, techs, datesteps]
@@ -295,7 +292,6 @@ variables:
         bounds:
             min: resource_cap_min
             max: resource_cap_max
-            equals: resource_cap_equals
 
     carrier_export:
         foreach: [nodes, techs, carriers, timesteps]
@@ -318,7 +314,6 @@ variables:
         bounds:
             min: units_min
             max: units_max
-            equals: units_equals
 
     operating_units:
         foreach: [nodes, techs, timesteps]

--- a/calliope/example_models/national_scale/scenarios.yaml
+++ b/calliope/example_models/national_scale/scenarios.yaml
@@ -56,28 +56,44 @@ overrides:
             horizon: 24
         model.subset_time: ['2005-01-01', '2005-01-10']
         nodes:
-            region1.techs.ccgt.constraints.energy_cap_equals: 30000
+            region1.techs.ccgt.constraints.energy_cap_max: 30000
+            region1.techs.ccgt.constraints.energy_cap_min: 30000
 
-            region2.techs.battery.constraints.energy_cap_equals: 1000
-            region2.techs.battery.constraints.storage_cap_equals: 5240
+            region2.techs.battery.constraints.energy_cap_max: 1000
+            region2.techs.battery.constraints.energy_cap_min: 1000
+            region2.techs.battery.constraints.storage_cap_max: 5240
+            region2.techs.battery.constraints.storage_cap_min: 5240
 
-            region1-1.techs.csp.constraints.energy_cap_equals: 10000
-            region1-1.techs.csp.constraints.storage_cap_equals: 244301
-            region1-1.techs.csp.constraints.resource_area_equals: 130385
+            region1-1.techs.csp.constraints.energy_cap_max: 10000
+            region1-1.techs.csp.constraints.energy_cap_min: 10000
+            region1-1.techs.csp.constraints.storage_cap_max: 244301
+            region1-1.techs.csp.constraints.storage_cap_min: 244301
+            region1-1.techs.csp.constraints.resource_area_max: 130385
+            region1-1.techs.csp.constraints.resource_area_min: 130385
 
-            region1-2.techs.csp.constraints.energy_cap_equals: 0
-            region1-2.techs.csp.constraints.storage_cap_equals: 0
-            region1-2.techs.csp.constraints.resource_area_equals: 0
+            region1-2.techs.csp.constraints.energy_cap_max: 0
+            region1-2.techs.csp.constraints.energy_cap_min: 0
+            region1-2.techs.csp.constraints.storage_cap_max: 0
+            region1-2.techs.csp.constraints.storage_cap_min: 0
+            region1-2.techs.csp.constraints.resource_area_max: 0
+            region1-2.techs.csp.constraints.resource_area_min: 0
 
-            region1-3.techs.csp.constraints.energy_cap_equals: 2534
-            region1-3.techs.csp.constraints.storage_cap_equals: 25301
-            region1-3.techs.csp.constraints.resource_area_equals: 8487
+            region1-3.techs.csp.constraints.energy_cap_max: 2534
+            region1-3.techs.csp.constraints.energy_cap_min: 2534
+            region1-3.techs.csp.constraints.storage_cap_max: 25301
+            region1-3.techs.csp.constraints.storage_cap_min: 25301
+            region1-3.techs.csp.constraints.resource_area_max: 8487
+            region1-3.techs.csp.constraints.resource_area_min: 8487
 
         links:
-            region1,region2.techs.ac_transmission.constraints.energy_cap_equals: 3231
-            region1,region1-1.techs.free_transmission.constraints.energy_cap_equals: 9000
-            region1,region1-2.techs.free_transmission.constraints.energy_cap_equals: 0
-            region1,region1-3.techs.free_transmission.constraints.energy_cap_equals: 2281
+            region1,region2.techs.ac_transmission.constraints.energy_cap_max: 3231
+            region1,region2.techs.ac_transmission.constraints.energy_cap_min: 3231
+            region1,region1-1.techs.free_transmission.constraints.energy_cap_max: 9000
+            region1,region1-1.techs.free_transmission.constraints.energy_cap_min: 9000
+            region1,region1-2.techs.free_transmission.constraints.energy_cap_max: 0
+            region1,region1-2.techs.free_transmission.constraints.energy_cap_min: 0
+            region1,region1-3.techs.free_transmission.constraints.energy_cap_max: 2281
+            region1,region1-3.techs.free_transmission.constraints.energy_cap_min: 2281
 
     check_feasibility:
         run:

--- a/calliope/preprocess/constraint_sets.py
+++ b/calliope/preprocess/constraint_sets.py
@@ -150,7 +150,6 @@ def generate_constraint_sets(model_run):
         for i in sets.loc_techs_finite_resource_supply_plus
         if any(
             [
-                constraint_exists(model_run, i, "constraints.resource_cap_equals"),
                 constraint_exists(model_run, i, "constraints.resource_cap_max"),
                 constraint_exists(model_run, i, "constraints.resource_cap_min"),
             ]
@@ -281,7 +280,12 @@ def generate_constraint_sets(model_run):
         i
         for i in sets.loc_techs_purchase
         if (
-            constraint_exists(model_run, i, "constraints.energy_cap_equals") is not None
+            (
+                constraint_exists(model_run, i, "constraints.energy_cap_max")
+                is not None
+                and constraint_exists(model_run, i, "constraints.energy_cap_min")
+                is not None
+            )
             or (
                 constraint_exists(model_run, i, "constraints.energy_cap_max")
                 is not None
@@ -294,7 +298,10 @@ def generate_constraint_sets(model_run):
         i
         for i in sets.loc_techs_purchase
         if (
-            not constraint_exists(model_run, i, "constraints.energy_cap_equals")
+            not (
+                constraint_exists(model_run, i, "constraints.energy_cap_max")
+                and constraint_exists(model_run, i, "constraints.energy_cap_min")
+            )
             and constraint_exists(model_run, i, "constraints.energy_cap_min")
         )
     ]
@@ -302,8 +309,11 @@ def generate_constraint_sets(model_run):
         i
         for i in set(sets.loc_techs_purchase).intersection(sets.loc_techs_store)
         if (
-            constraint_exists(model_run, i, "constraints.storage_cap_equals")
-            is not None
+            (constraint_exists(model_run, i, "constraints.storage_cap_max") is not None)
+            and (
+                constraint_exists(model_run, i, "constraints.storage_cap_min")
+                is not None
+            )
             or (
                 constraint_exists(model_run, i, "constraints.storage_cap_max")
                 is not None
@@ -315,10 +325,7 @@ def generate_constraint_sets(model_run):
     constraint_sets["loc_techs_storage_capacity_min_purchase_milp_constraint"] = [
         i
         for i in set(sets.loc_techs_purchase).intersection(sets.loc_techs_store)
-        if (
-            not constraint_exists(model_run, i, "constraints.storage_cap_equals")
-            and constraint_exists(model_run, i, "constraints.storage_cap_min")
-        )
+        if (constraint_exists(model_run, i, "constraints.storage_cap_min"))
     ]
     constraint_sets["loc_techs_update_costs_investment_units_milp_constraint"] = [
         i


### PR DESCRIPTION
Partial Fixes issue(s) #422

Summary of changes in this pull request:

* Remove 'equals' bounds from variables in subset.yaml
* Update defaults
* Update parsing

Work-in-progress:
* Check `operation` mode

Open questions
* shall we get rid of also those constraints such as `energy_capacity_per_storage_capacity_equals` that can be replaced by the joint action of max and min constraints? In this regard, there are other contraints which have not e.g. the min constraints as per the case of `energy_cap_equals_systemwide`.

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved