### PR TITLE
[work-in-progress] rename components into sub_expressions

### DIFF
--- a/calliope/backend/parsing.py
+++ b/calliope/backend/parsing.py
@@ -44,7 +44,7 @@ class UnparsedConstraintDict(TypedDict):
     where: str
     equation: NotRequired[str]
     equations: NotRequired[list[UnparsedEquationDict]]
-    components: NotRequired[dict[str, list[UnparsedEquationDict]]]
+    sub_expressions: NotRequired[dict[str, list[UnparsedEquationDict]]]
     index_slices: NotRequired[dict[str, list[UnparsedEquationDict]]]
 
 
@@ -72,7 +72,7 @@ class UnparsedObjectiveDict(TypedDict):
     description: NotRequired[str]
     equation: NotRequired[str]
     equations: NotRequired[list[UnparsedEquationDict]]
-    components: NotRequired[dict[str, list[UnparsedEquationDict]]]
+    sub_expressions: NotRequired[dict[str, list[UnparsedEquationDict]]]
     domain: str
     sense: str
 
@@ -93,7 +93,7 @@ class ParsedBackendEquation:
         sets: list[str],
         expression: pp.ParseResults,
         where_list: list[pp.ParseResults],
-        components: Optional[dict[str, pp.ParseResults]] = None,
+        sub_expressions: Optional[dict[str, pp.ParseResults]] = None,
         index_slices: Optional[dict[str, pp.ParseResults]] = None,
     ) -> None:
         """
@@ -109,8 +109,8 @@ class ParsedBackendEquation:
                 Parsed arithmetic/equation expression.
             where_list (list[pp.ParseResults]):
                 List of parsed where strings.
-            components (Optional[dict[str, pp.ParseResults]], optional):
-                Dictionary of parsed components with which to replace references to components
+            sub_expressions (Optional[dict[str, pp.ParseResults]], optional):
+                Dictionary of parsed sub expressions with which to replace references to components
                 on evaluation of the parsed expression. Defaults to None.
             index_slices (Optional[dict[str, pp.ParseResults]], optional):
                 Dictionary of parsed index slices with which to replace references to index slices
@@ -119,29 +119,31 @@ class ParsedBackendEquation:
         self.name = equation_name
         self.where = where_list
         self.expression = expression
-        self.components = components if components is not None else dict()
+        self.sub_expressions = (
+            sub_expressions if sub_expressions is not None else dict()
+        )
         self.index_slices = index_slices if index_slices is not None else dict()
         self.sets = sets
 
-    def find_components(self) -> set[str]:
-        """Identify all the references to components in the parsed expression.
+    def find_sub_expressions(self) -> set[str]:
+        """Identify all the references to sub_expressions in the parsed expression.
 
         Returns:
-            set[str]: Unique component references.
+            set[str]: Unique sub-expressions references.
         """
         valid_eval_classes: tuple = (
             equation_parser.EvalOperatorOperand,
             equation_parser.EvalFunction,
         )
         elements: list = [self.expression[0].values]
-        to_find = equation_parser.EvalComponent
+        to_find = equation_parser.EvalSubExpressions
 
         return self._find_items_in_expression(elements, to_find, valid_eval_classes)
 
     def find_index_slices(self) -> set[str]:
         """
         Identify all the references to index slices in the parsed expression or in the
-        parsed components.
+        parsed sub-expressions.
 
         Returns:
             set[str]: Unique index slice references.
@@ -154,7 +156,7 @@ class ParsedBackendEquation:
                 equation_parser.EvalSlicedParameterOrVariable,
             ]
         )
-        elements = [self.expression[0].values, *list(self.components.values())]
+        elements = [self.expression[0].values, *list(self.sub_expressions.values())]
         to_find = equation_parser.EvalIndexSlice
 
         return self._find_items_in_expression(elements, to_find, valid_eval_classes)
@@ -166,7 +168,7 @@ class ParsedBackendEquation:
         valid_eval_classes: tuple[type[equation_parser.EvalString], ...],
     ) -> set[str]:
         """
-        Recursively find components / index items defined in an equation expression.
+        Recursively find sub-expressions / index items defined in an equation expression.
 
         Args:
             parser_elements (pp.ParseResults): list of parser elements to check.
@@ -196,22 +198,22 @@ class ParsedBackendEquation:
 
     def add_expression_group_combination(
         self,
-        expression_group_name: Literal["components", "index_slices"],
+        expression_group_name: Literal["sub_expressions", "index_slices"],
         expression_group_combination: Iterable[ParsedBackendEquation],
     ) -> ParsedBackendEquation:
         """
-        Add dictionary of parsed components/index slices to a copy of self, updating
+        Add dictionary of parsed sub-expressions/index slices to a copy of self, updating
         the name and where list of self in the process.
 
         Args:
-            expression_group_name (Literal[components, index_slices]):
-                Which of `components`/`index slices` is being added.
+            expression_group_name (Literal[sub_expressions, index_slices]):
+                Which of `sub-expressions`/`index slices` is being added.
             expression_group_combination (Iterable[ParsedBackendEquation]):
                 All items of expression_group_name to be added.
 
         Returns:
             ParsedBackendEquation:
-                Copy of self with added component/index slice dictionary and updated name
+                Copy of self with added sub-expressions/index slice dictionary and updated name
                 and where list to include those corresponding to the dictionary entries.
         """
         new_where_list = [*self.where]
@@ -230,7 +232,7 @@ class ParsedBackendEquation:
             expression=self.expression,
             where_list=new_where_list,
             **{
-                "components": self.components,
+                "sub_expressions": self.sub_expressions,
                 "index_slices": self.index_slices,
                 **expression_group_dict,  # type: ignore
             },
@@ -281,7 +283,7 @@ class ParsedBackendEquation:
         return self.expression[0].eval(
             equation_name=self.name,
             index_slice_dict=self.index_slices,
-            component_dict=self.components,
+            sub_expression_dict=self.sub_expressions,
             backend_interface=backend_interface,
             backend_dataset=backend_interface._dataset,
             helper_func_dict=VALID_EXPRESSION_HELPER_FUNCTIONS,
@@ -389,7 +391,7 @@ class ParsedBackendComponent(ParsedBackendEquation):
         Returns:
             list[ParsedBackendEquation]:
                 List of parsed equations ready to be evaluated.
-                The length of the list depends on the product of provided equations and component/index_slice references.
+                The length of the list depends on the product of provided equations and sub-expression/index_slice references.
         """
         equation_expression_list: list[UnparsedEquationDict]
         if "equation" in self._unparsed.keys():
@@ -404,16 +406,16 @@ class ParsedBackendComponent(ParsedBackendEquation):
             id_prefix=self.name,
         )
 
-        component_dict = {
+        sub_expression_dict = {
             c_name: self.generate_expression_list(
-                expression_parser=equation_parser.generate_component_parser(
+                expression_parser=equation_parser.generate_sub_expression_parser(
                     valid_math_element_names
                 ),
                 expression_list=c_list,
-                expression_group="components",
+                expression_group="sub_expressions",
                 id_prefix=c_name,
             )
-            for c_name, c_list in self._unparsed.get("components", {}).items()
+            for c_name, c_list in self._unparsed.get("sub_expressions", {}).items()
         }
         index_slice_dict = {
             idx_name: self.generate_expression_list(
@@ -430,22 +432,24 @@ class ParsedBackendComponent(ParsedBackendEquation):
         if errors == "raise":
             self.raise_caught_errors()
 
-        equations_with_components = []
+        equations_with_sub_expressions = []
         for equation in equations:
-            equations_with_components.extend(
+            equations_with_sub_expressions.extend(
                 self.extend_equation_list_with_expression_group(
-                    equation, component_dict, "components"
+                    equation, sub_expression_dict, "sub_expressions"
                 )
             )
-        equations_with_components_and_index_slices: list[ParsedBackendEquation] = []
-        for equation in equations_with_components:
-            equations_with_components_and_index_slices.extend(
+        equations_with_sub_expressions_and_index_slices: list[
+            ParsedBackendEquation
+        ] = []
+        for equation in equations_with_sub_expressions:
+            equations_with_sub_expressions_and_index_slices.extend(
                 self.extend_equation_list_with_expression_group(
                     equation, index_slice_dict, "index_slices"
                 )
             )
 
-        return equations_with_components_and_index_slices
+        return equations_with_sub_expressions_and_index_slices
 
     def _parse_string(
         self,
@@ -499,17 +503,17 @@ class ParsedBackendComponent(ParsedBackendEquation):
         self,
         expression_parser: pp.ParserElement,
         expression_list: list[UnparsedEquationDict],
-        expression_group: Literal["equations", "components", "index_slices"],
+        expression_group: Literal["equations", "sub_expressions", "index_slices"],
         id_prefix: str = "",
     ) -> list[ParsedBackendEquation]:
         """
-        Align user-defined constraint equations/components by parsing expressions,
+        Align user-defined constraint equations/sub-expressions by parsing expressions,
         specifying a default "where" string if not defined,
         and providing an ID to enable returning to the initial dictionary.
 
         Args:
             expression_list (list[dict]):
-                list of constraint equations or components with arithmetic expression
+                list of constraint equations or sub-expressions with arithmetic expression
                 string and optional where string.
             expression_group (str):
                 For error reporting, the constraint dict key corresponding to the parse_string.
@@ -557,25 +561,25 @@ class ParsedBackendComponent(ParsedBackendEquation):
         self,
         parsed_equation: ParsedBackendEquation,
         parsed_items: dict[str, list[ParsedBackendEquation]],
-        expression_group: Literal["components", "index_slices"],
+        expression_group: Literal["sub_expressions", "index_slices"],
     ) -> list[ParsedBackendEquation]:
         """
-        Find all components referenced in an equation expression and return a
-        product of the component data.
+        Find all sub-expressions referenced in an equation expression and return a
+        product of the sub-expression data.
 
         Args:
             equation_data (ParsedBackendEquation): Equation data dictionary.
             parsed_items (dict[str, list[ParsedBackendEquation]]):
                 Dictionary of expressions to replace within the equation data dictionary.
-            expression_group (Literal["components", "index_slices"]):
+            expression_group (Literal["sub_expressions", "index_slices"]):
                 Name of expression group that the parsed_items dict is referencing.
 
         Returns:
             list[ParsedBackendEquation]:
                 Expanded list of parsed equations with the product of all references to items from the `expression_group` producing a new equation object. E.g., if the input equation object has a reference to an index_slice which itself has two expression options, two equation objects will be added to the return list.
         """
-        if expression_group == "components":
-            equation_items = parsed_equation.find_components()
+        if expression_group == "sub_expressions":
+            equation_items = parsed_equation.find_sub_expressions()
         elif expression_group == "index_slices":
             equation_items = parsed_equation.find_index_slices()
         if not equation_items:

--- a/calliope/math/base.yaml
+++ b/calliope/math/base.yaml
@@ -74,7 +74,7 @@ constraints:
     foreach: [nodes, techs, carrier_tiers, timesteps]
     where: "inheritance(conversion_plus) AND [in_2, out_2, in_3, out_3] in carrier_tiers AND carrier_ratios>0"
     equation: $c_1 == $c_2
-    components:
+    sub_expressions:
       c_1:
         - where: "[in_2, in_3] in carrier_tiers"
           expression: squeeze_carriers(carrier_con / carrier_ratios[carrier_tiers=in], carrier_tier=in)
@@ -95,7 +95,7 @@ constraints:
     foreach: [nodes, techs, carriers, timesteps]
     where: "carrier_ratios=0 AND inheritance(conversion_plus)"
     equation: $prod_or_con == 0
-    components:
+    sub_expressions:
       prod_or_con:
         - where: "[in, in_2, in_3] in carrier_tiers"
           expression: carrier_con
@@ -148,7 +148,7 @@ constraints:
     description: "Set the global energy balance of the optimisation problem by fixing the total production of a given energy carrier to equal the total consumption of that carrier at every node in every timestep."
     foreach: [nodes, carriers, timesteps]
     equation: "sum(carrier_prod, over=techs) + sum(carrier_con, over=techs) - $carrier_export + $unmet_demand_and_unused_supply == 0"
-    components:
+    sub_expressions:
       carrier_export:
         - where: "sum(export_carrier, over=techs)"
           expression: sum(carrier_export, over=techs)
@@ -171,7 +171,7 @@ constraints:
         expression: "carrier_prod / energy_eff <= $available_resource"
       - where: "energy_eff = 0"
         expression: "carrier_prod == 0"
-    components:
+    sub_expressions:
       available_resource: &available_resource
         - where: "resource_unit=energy_per_area"
           expression: "resource * resource_scale * resource_area"
@@ -194,7 +194,7 @@ constraints:
         expression: "$carrier_con == $required_resource"
       - where: "NOT force_resource=True"
         expression: "$carrier_con >= $required_resource"
-    components:
+    sub_expressions:
       carrier_con:
         - expression: carrier_con * energy_eff
       required_resource:
@@ -210,7 +210,7 @@ constraints:
     foreach: [nodes, techs, carriers, timesteps]
     where: "inheritance(supply_plus) AND NOT include_storage=True"
     equation: resource_con * resource_eff == $carrier_prod
-    components:
+    sub_expressions:
       carrier_prod: &carrier_prod_with_parasitic
         - where: energy_eff=0 OR parasitic_eff=0
           expression: "0"
@@ -222,7 +222,7 @@ constraints:
     foreach: [nodes, techs, carriers, timesteps]
     where: "inheritance(supply_plus) AND include_storage=True"
     equation: storage == $storage_previous_step + resource_con * resource_eff - $carrier_prod
-    components:
+    sub_expressions:
       carrier_prod: *carrier_prod_with_parasitic
       storage_previous_step: &storage_previous_step
         - where: timesteps=get_val_at_index(dim=timesteps, idx=0) AND NOT run.cyclic_storage=True
@@ -244,7 +244,7 @@ constraints:
         expression: "resource_con == $available_resource"
       - where: "NOT force_resource=True"
         expression: "resource_con <= $available_resource"
-    components:
+    sub_expressions:
       available_resource: *available_resource
 
   balance_storage:
@@ -252,7 +252,7 @@ constraints:
     foreach: [nodes, techs, carriers, timesteps]
     where: "inheritance(storage)"
     equation: storage == $storage_previous_step - $carrier_prod - carrier_con * energy_eff
-    components:
+    sub_expressions:
       carrier_prod:
         - where: energy_eff > 0
           expression: carrier_prod / energy_eff
@@ -387,7 +387,7 @@ constraints:
         expression: $summed_components == units_equals_systemwide
       - where: NOT units_equals_systemwide
         expression: $summed_components <= units_max_systemwide
-    components:
+    sub_expressions:
       summed_components:
         - where: cap_method=binary
           expression: sum(purchased, over=nodes)
@@ -411,7 +411,7 @@ constraints:
     foreach: [nodes, techs, carriers, timesteps]
     where: "energy_ramping AND NOT timesteps=get_val_at_index(dim=timesteps, idx=0)"
     equation: $flow - roll($flow, timesteps=1) <= energy_ramping * energy_cap
-    components:
+    sub_expressions:
       flow: &ramping_flow
         - where: "carrier AND allowed_carrier_prod=True AND NOT allowed_carrier_con=True"
           expression: carrier_prod / timestep_resolution
@@ -425,7 +425,7 @@ constraints:
     foreach: [nodes, techs, carriers, timesteps]
     where: "energy_ramping AND NOT timesteps=get_val_at_index(dim=timesteps, idx=0)"
     equation: -1 * energy_ramping * energy_cap <= $flow - roll($flow, timesteps=1)
-    components:
+    sub_expressions:
       flow: *ramping_flow
 
 variables:
@@ -577,7 +577,7 @@ objectives:
   minmax_cost_optimisation:
     description: "Minimise the total cost of installing and operation all technologies in the system. If multiple cost classes are present (e.g., monetary and co2 emissions), the weighted sum of total costs is minimised. Cost class weights can be defined in `run.objective_options.cost_class`."
     equation: sum(sum(cost, over=[nodes, techs]) * objective_cost_class, over=costs) + $unmet_demand
-    components:
+    sub_expressions:
       unmet_demand:
         - where: "run.ensure_feasibility=True"
           expression: sum(sum(unmet_demand - unused_supply, over=[carriers, nodes])  * timestep_weights, over=timesteps) * bigM
@@ -593,7 +593,7 @@ expressions:
     foreach: [nodes, techs, costs, timesteps]
     where: "cost_export OR cost_om_con OR cost_om_prod"
     equation: timestep_weights * ($cost_export + $cost_om_prod + $cost_om_con)
-    components:
+    sub_expressions:
       cost_export:
         - where: "export_carrier AND cost_export"
           expression: cost_export * sum(carrier_export, over=carriers)
@@ -632,7 +632,7 @@ expressions:
               ) * ($multiplier + cost_om_annual_investment_fraction)
               + cost_om_annual * energy_cap
           )
-    components:
+    sub_expressions:
       multiplier:
         - where: "inheritance(transmission)"
           expression: "0.5"
@@ -672,7 +672,7 @@ expressions:
     foreach: [nodes, techs, costs]
     where: "cost_energy_cap OR cost_om_annual OR cost_om_annual_investment_fraction OR cost_purchase OR cost_resource_area OR cost_resource_cap OR cost_storage_cap OR cost_export OR cost_om_con OR cost_om_prod"
     equation: $cost_investment + $cost_var_sum
-    components:
+    sub_expressions:
       cost_investment:
         - where: "(cost_energy_cap OR cost_om_annual OR cost_om_annual_investment_fraction OR cost_purchase OR cost_resource_area OR cost_resource_cap OR cost_storage_cap)"
           expression: cost_investment

--- a/calliope/math/storage_inter_cluster.yaml
+++ b/calliope/math/storage_inter_cluster.yaml
@@ -5,7 +5,7 @@ constraints:
     active: False
 
   balance_supply_plus_with_storage:
-    components:
+    sub_expressions:
       storage_previous_step: &storage_previous_step
         - where: timesteps=get_val_at_index(dim=timesteps, idx=0) AND NOT run.cyclic_storage=True
           expression: storage_initial * storage_cap
@@ -57,7 +57,7 @@ constraints:
     foreach: [nodes, techs, datesteps]
     where: "include_storage=True"
     equation: storage_inter_cluster == $storage_previous_step + $storage_intra
-    components:
+    sub_expressions:
       storage_previous_step:
         - where: datesteps=get_val_at_index(dim=datesteps, idx=0) AND NOT run.cyclic_storage=True
           expression: storage_initial

--- a/calliope/test/test_subset_parser.py
+++ b/calliope/test/test_subset_parser.py
@@ -9,7 +9,7 @@ from calliope.core.attrdict import AttrDict
 from calliope.exceptions import BackendError
 
 
-COMPONENT_CLASSIFIER = equation_parser.COMPONENT_CLASSIFIER
+SUB_EXPRESSION_CLASSIFIER = equation_parser.SUB_EXPRESSION_CLASSIFIER
 HELPER_FUNCS = {"dummy_func_1": lambda x: x * 10, "dummy_func_2": lambda x, y: x + y}
 
 BASE_DIMS = ["nodes", "techs", "carriers", "costs", "timesteps", "carrier_tiers"]


### PR DESCRIPTION
Fixes partially issue #418

Summary of changes in this pull request:

* replacing `components` with `sub_expressions`

To do:
* `index_slices `-> `slices`
* `expression `top level key -> `global_expressions`
* `exists `in techs/nodes -> `active `(to match math formulation)
* `optimisation_config_overrides `/ `component_config `-> `custom_math `/ `math`

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved