### PR TITLE
Add LP comparison pipeline and one example

### DIFF
--- a/calliope/test/common/lp_files/energy_cap.lp
+++ b/calliope/test/common/lp_files/energy_cap.lp
@@ -1,0 +1,16 @@
+\* Source Pyomo model name=None *\
+
+min
+objectives(0):
++1 variables(energy_cap)(test_supply_elec__a)
++1 variables(energy_cap)(test_supply_elec__b)
+
+s.t.
+
+c_e_ONE_VAR_CONSTANT:
+ONE_VAR_CONSTANT = 1.0
+
+bounds
+   1 <= variables(energy_cap)(test_supply_elec__a) <= +inf
+   0 <= variables(energy_cap)(test_supply_elec__b) <= 100
+end

--- a/calliope/test/common/util.py
+++ b/calliope/test/common/util.py
@@ -114,29 +114,29 @@ def build_lp(
         math (Optional[dict], optional): All constraint/expression/objective math to apply. Defaults to None.
         backend (Literal["pyomo"], optional): Backend to use to create the LP file. Defaults to "pyomo".
     """
-    backend_model = model._BACKENDS[backend]()
-    backend_model.add_all_parameters(model.inputs, model.run_config)
+    backend_instance = model._BACKENDS[backend]()
+    backend_instance.add_all_parameters(model.inputs, model.run_config)
     for name, dict_ in model.math["variables"].items():
-        backend_model.add_variable(model.inputs, name, dict_)
+        backend_instance.add_variable(model.inputs, name, dict_)
 
     if math is not None:
         for component_group, component_math in math.items():
             for name, dict_ in component_math.items():
-                getattr(backend_model, f"add_{component_group.removesuffix('s')}")(
+                getattr(backend_instance, f"add_{component_group.removesuffix('s')}")(
                     model.inputs, name, dict_
                 )
 
     # MUST have an objective for a valid LP file
     if math is None or "objectives" not in math.keys():
-        backend_model.add_objective(
+        backend_instance.add_objective(
             model.inputs, "dummy_obj", {"equation": "1 + 1", "sense": "minimize"}
         )
-    backend_model._instance.objectives[0].activate()
+    backend_instance._instance.objectives[0].activate()
 
-    backend_model.verbose_strings()
+    backend_instance.verbose_strings()
 
     # TODO: change to generalised `to_lp()` function
-    backend_model._instance.write(str(outfile), symbolic_solver_labels=True)
+    backend_instance._instance.write(str(outfile), symbolic_solver_labels=True)
 
     # strip trailing whitespace from `outfile` after the fact,
     # so it can be reliably compared other files in future

--- a/calliope/test/test_math.py
+++ b/calliope/test/test_math.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+import filecmp
+
+import pytest
+import numpy as np
+
+import calliope
+from calliope import AttrDict
+from calliope.test.common.util import build_lp, build_test_model
+
+
+@pytest.fixture(scope="class")
+def compare_lps(tmpdir_factory):
+    def _compare_lps(model, filename, custom_math):
+        lp_file = filename + ".lp"
+        generated_file = Path(tmpdir_factory.mktemp("lp_files")) / lp_file
+        build_lp(model, generated_file, custom_math)
+        expected_file = (
+            Path(calliope.__file__).parent / "test" / "common" / "lp_files" / lp_file
+        )
+
+        assert filecmp.cmp(generated_file, expected_file)
+
+    return _compare_lps
+
+
+@pytest.fixture(scope="class")
+def base_math():
+    return AttrDict.from_yaml(Path(calliope.__file__).parent / "math" / "base.yaml")
+
+
+class TestBaseMath:
+    TEST_REGISTER: set = set()
+
+    def test_energy_cap(self, compare_lps):
+        self.TEST_REGISTER.add("variables.energy_cap")
+        model = build_test_model(
+            {
+                "nodes.b.techs.test_supply_elec.constraints.energy_cap_max": 100,
+                "nodes.a.techs.test_supply_elec.constraints.energy_cap_min": 1,
+                "nodes.a.techs.test_supply_elec.constraints.energy_cap_max": np.nan,
+            },
+            "simple_supply,two_hours,investment_costs",
+        )
+        custom_math = {
+            # need the variable defined in a constraint/objective for it to appear in the LP file bounds
+            "objectives": {
+                "foo": {
+                    "equation": "sum(energy_cap[techs=test_supply_elec], over=nodes)",
+                    "sense": "minimise",
+                }
+            }
+        }
+        compare_lps(model, "energy_cap", custom_math)
+
+    @pytest.mark.xfail(reason="not all base math is in the test config dict yet")
+    def test_all_math_registered(self, base_math):
+        "After running all the previous tests in the class, the base_math dict should be empty, i.e. all math has been tested"
+        for key in self.TEST_REGISTER:
+            base_math.del_key(key)
+        assert not base_math

--- a/calliope/test/test_math.py
+++ b/calliope/test/test_math.py
@@ -11,7 +11,7 @@ from calliope.test.common.util import build_lp, build_test_model
 
 @pytest.fixture(scope="class")
 def compare_lps(tmpdir_factory):
-    def _compare_lps(model, filename, custom_math):
+    def _compare_lps(model, custom_math, filename):
         lp_file = filename + ".lp"
         generated_file = Path(tmpdir_factory.mktemp("lp_files")) / lp_file
         build_lp(model, generated_file, custom_math)
@@ -51,7 +51,7 @@ class TestBaseMath:
                 }
             }
         }
-        compare_lps(model, "energy_cap", custom_math)
+        compare_lps(model, custom_math, "energy_cap")
 
     @pytest.mark.xfail(reason="not all base math is in the test config dict yet")
     def test_all_math_registered(self, base_math):


### PR DESCRIPTION
Fixes issue(s) #433 

Summary of changes in this pull request:

* Add LP builder to test utils.
* Add example test for `energy_cap` decision variable and its bounds.

Following this PR, LP files for all base and custom math need to be created. This is quite a lot of manual work, but hopefully once done doesn't need to change again for a while.

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved