### PR TITLE
Remove `_equals` and `_scale` parameters

### DIFF
--- a/doc/user/advanced_constraints.rst
+++ b/doc/user/advanced_constraints.rst
@@ -198,7 +198,7 @@ To make use of these constraints, one should set ``source_unit: per_area`` for t
 
 The following related settings are available:
 
-* ``area_use_equals``, ``area_use_max``, ``area_use_min``: Set uppper or lower bounds on area_use or force it to a specific value
+* ``area_use_max``, ``area_use_min``: Set upper or lower bounds on area_use
 * ``area_use_per_flow_cap``: False by default, but if set to true, it forces ``area_use`` to follow ``flow_cap`` with the given numerical ratio (e.g. setting to 1.5 means that ``area_use == 1.5 * flow_cap``)
 
 By default, ``area_use_max`` is infinite and ``area_use_min`` is 0 (zero).

--- a/doc/user/advanced_constraints.rst
+++ b/doc/user/advanced_constraints.rst
@@ -274,47 +274,6 @@ Export is an extension of this, allowing a carrier to be removed from the system
 
 .. note:: Negative costs can be applied to capacity costs, but the user must an ensure a capacity limit has been set. Otherwise, optimisation will be unbounded.
 
-.. _group_share:
-
--------------------------------------------
-The ``group_share`` constraint (deprecated)
--------------------------------------------
-
-.. Warning:: ``group_share`` is deprecated as of v0.6.4 and will be removed in v0.7.0.
-
-The ``group_share`` constraint can be used to force groups of technologies to fulfill certain shares of supply or capacity.
-
-For example, assuming a model containing a ``csp`` and a ``cold_fusion`` power generation technology, we could force at least 85% of power generation in the model to come from these two technologies with the following constraint definition in the ``model`` settings:
-
-.. code-block:: yaml
-
-    model:
-        group_share:
-            csp,cold_fusion:
-                carrier_prod_min:
-                    power: 0.85
-
-Possible ``group_share`` constraints with carrier-specific settings are:
-
-* ``carrier_prod_min``
-* ``carrier_prod_max``
-* ``carrier_prod_equals``
-
-Possible ``group_share`` constraints with carrier-independent settings are:
-
-* ``flow_cap_min``
-* ``flow_cap_max``
-* ``flow_cap_equals``
-
-These can be implemented as, for example, to force at most 20% of ``flow_cap`` to come from the two listed technologies:
-
-.. code-block:: yaml
-
-    model:
-        group_share:
-            csp,cold_fusion:
-                flow_cap_max: 0.20
-
 ------------------------------------
 Binary and mixed-integer constraints
 ------------------------------------
@@ -323,7 +282,7 @@ Calliope models are purely linear by default. However, several constraints can t
 
 By applying a ``purchase`` cost to a technology, that technology will have a binary variable associated with it, describing whether or not it has been "purchased".
 
-By applying ``units.max``, ``units.min``, or ``units.equals`` to a technology, that technology will have a integer variable associated with it, describing how many of that technology have been "purchased". If a ``purchase`` cost has been applied to this same technology, the purchasing cost will be applied per unit.
+By applying ``units_max`` or ``units_min`` to a technology, that technology will have a integer variable associated with it, describing how many of that technology have been "purchased". If a ``purchase`` cost has been applied to this same technology, the purchasing cost will be applied per unit.
 
 .. Warning::
 

--- a/doc/user/advanced_features.rst
+++ b/doc/user/advanced_features.rst
@@ -150,7 +150,7 @@ Operational mode
 
 In planning mode, constraints are given as upper and lower boundaries and the model decides on an optimal system configuration. In operational mode, all capacity constraints are fixed and the system is operated with a receding horizon control algorithm.
 
-To specify a runnable operational model, capacities for all technologies at all locations must have be defined. This can be done by specifying ``flow_cap_equals``. In the absence of ``flow_cap_equals``, constraints given as ``flow_cap_max`` are assumed to be fixed in operational mode.
+To specify a runnable operational model, capacities for all technologies at all locations must be defined. This can be done by specifying ``flow_cap_max``, which will be assumed to be the fixed capacity of the technology in operational mode.
 
 Operational mode runs a model with a receding horizon control algorithm. This requires two additional settings:
 

--- a/doc/user/tutorials_03_milp.rst
+++ b/doc/user/tutorials_03_milp.rst
@@ -16,7 +16,7 @@ The capacity of a technology is usually a continuous decision variable, which ca
    :start-after: # chp-start
    :end-before: # chp-end
 
-A unit maximum allows a discrete, integer number of CHP to be purchased, each having a capacity of ``flow_cap_per_unit``. Any of ``flow_cap_max``, ``flow_cap_min``, or ``flow_cap_equals`` are now ignored, in favour of ``units_max``, ``units_min``, or ``units_equals``. A useful feature unlocked by introducing this is the ability to set a minimum operating capacity which is *only* enforced when the technology is operating. In the LP model, ``flow_out_min_relative`` would force the technology to operate at least at that proportion of its maximum capacity at each time step. In this model, the newly introduced ``flow_out_min_relative`` of 0.2 will ensure that the output of the CHP is 20% of its maximum capacity in any time step in which it has a non-zero output.
+A unit maximum allows a discrete, integer number of CHP to be purchased, each having a capacity of ``flow_cap_per_unit``. ``flow_cap_max`` and ``flow_cap_min`` are now ignored, in favour of ``units_max`` or ``units_min``. A useful feature unlocked by introducing this is the ability to set a minimum operating capacity which is *only* enforced when the technology is operating. In the LP model, ``flow_out_min_relative`` would force the technology to operate at least at that proportion of its maximum capacity at each time step. In this model, the newly introduced ``flow_out_min_relative`` of 0.2 will ensure that the output of the CHP is 20% of its maximum capacity in any time step in which it has a non-zero output.
 
 Purchase cost
 =============

--- a/src/calliope/backend/parsing.py
+++ b/src/calliope/backend/parsing.py
@@ -128,7 +128,7 @@ class ParsedBackendEquation:
         """Identify all the references to sub_expressions in the parsed expression.
 
         Returns:
-            set[str]: Unique sub-expressions references.
+            set[str]: Unique sub-expression references.
         """
         valid_eval_classes: tuple = (
             expression_parser.EvalOperatorOperand,

--- a/src/calliope/config/defaults.yaml
+++ b/src/calliope/config/defaults.yaml
@@ -74,21 +74,18 @@ tech_groups:
     required_constraints: []
     allowed_constraints:
       [
-        "flow_cap_equals",
-        "flow_cap_equals_systemwide",
         "flow_cap_max",
         "flow_cap_max_systemwide",
         "flow_cap_min",
+        "flow_cap_min_systemwide",
         "flow_out_min_relative",
         "flow_cap_per_unit",
-        "flow_cap_scale",
         "flow_eff",
         "flow_ramping",
         "export_max",
         "export_carrier",
         "lifetime",
-        "units_equals",
-        "units_equals_systemwide",
+        "units_min_systemwide",
         "units_max",
         "units_max_systemwide",
         "units_min",
@@ -119,21 +116,18 @@ tech_groups:
     allowed_constraints:
       [
         "carrier_ratios",
-        "flow_cap_equals",
-        "flow_cap_equals_systemwide",
+        "flow_cap_min_systemwide",
         "flow_cap_max",
         "flow_cap_max_systemwide",
         "flow_cap_min",
         "flow_out_min_relative",
         "flow_cap_per_unit",
-        "flow_cap_scale",
         "flow_eff",
         "flow_ramping",
         "export_max",
         "export_carrier",
         "lifetime",
-        "units_equals",
-        "units_equals_systemwide",
+        "units_min_systemwide",
         "units_max",
         "units_max_systemwide",
         "units_min",
@@ -160,15 +154,7 @@ tech_groups:
       allowed_flow_out: true
   demand:
     required_constraints: []
-    allowed_constraints:
-      [
-        "sink_min",
-        "sink_max",
-        "sink_equals",
-        "area_use_equals",
-        "sink_scale",
-        "sink_unit",
-      ]
+    allowed_constraints: ["sink_min", "sink_max", "sink_equals", "sink_unit"]
     allowed_costs: [om_con]
     allowed_switches: [sink_unit, allowed_flow_in, allowed_flow_out]
     essentials:
@@ -182,23 +168,19 @@ tech_groups:
     allowed_constraints:
       [
         "flow_cap_per_storage_cap_min",
-        "flow_cap_per_storage_cap_equals",
         "flow_cap_per_storage_cap_max",
-        "flow_cap_equals",
-        "flow_cap_equals_systemwide",
+        "flow_cap_min_systemwide",
         "flow_cap_max",
         "flow_cap_max_systemwide",
         "flow_cap_min",
         "flow_out_min_relative",
         "flow_cap_per_unit",
-        "flow_cap_scale",
         "flow_eff",
         "flow_ramping",
         "export_max",
         "export_carrier",
         "force_async_flow",
         "lifetime",
-        "storage_cap_equals",
         "storage_cap_max",
         "storage_cap_min",
         "storage_cap_per_unit",
@@ -206,8 +188,7 @@ tech_groups:
         "storage_loss",
         "storage_time_max",
         "storage_discharge_depth",
-        "units_equals",
-        "units_equals_systemwide",
+        "units_min_systemwide",
         "units_max",
         "units_max_systemwide",
         "units_min",
@@ -238,29 +219,24 @@ tech_groups:
     required_constraints: []
     allowed_constraints:
       [
-        "flow_cap_equals",
-        "flow_cap_equals_systemwide",
+        "flow_cap_min_systemwide",
         "flow_cap_max",
         "flow_cap_max_systemwide",
         "flow_cap_min",
         "flow_out_min_relative",
         "flow_cap_per_unit",
-        "flow_cap_scale",
         "flow_eff",
         "flow_ramping",
         "export_max",
         "export_carrier",
         "lifetime",
-        "area_use_equals",
         "area_use_max",
         "area_use_min",
         "area_use_per_flow_cap",
         "source_min",
         "source_max",
         "source_equals",
-        "source_scale",
-        "units_equals",
-        "units_equals_systemwide",
+        "units_min_systemwide",
         "units_max",
         "units_max_systemwide",
         "units_min",
@@ -294,42 +270,34 @@ tech_groups:
     allowed_constraints:
       [
         "flow_cap_per_storage_cap_min",
-        "flow_cap_per_storage_cap_equals",
         "flow_cap_per_storage_cap_max",
-        "flow_cap_equals",
-        "flow_cap_equals_systemwide",
+        "flow_cap_min_systemwide",
         "flow_cap_max",
         "flow_cap_max_systemwide",
         "flow_cap_min",
         "flow_out_min_relative",
         "flow_cap_per_unit",
-        "flow_cap_scale",
         "flow_eff",
         "flow_ramping",
         "export_max",
         "export_carrier",
         "lifetime",
         "parasitic_eff",
-        "area_use_equals",
         "area_use_max",
         "area_use_min",
         "area_use_per_flow_cap",
-        "source_cap_equals",
         "source_cap_max",
         "source_cap_min",
         "source_eff",
         "source_min",
         "source_max",
         "source_equals",
-        "source_scale",
-        "storage_cap_equals",
         "storage_cap_max",
         "storage_cap_min",
         "storage_cap_per_unit",
         "storage_initial",
         "storage_loss",
-        "units_equals",
-        "units_equals_systemwide",
+        "units_min_systemwide",
         "units_max",
         "units_max_systemwide",
         "units_min",
@@ -375,11 +343,9 @@ tech_groups:
     required_constraints: []
     allowed_constraints:
       [
-        "flow_cap_equals",
         "flow_cap_min",
         "flow_cap_max",
         "flow_cap_per_unit",
-        "flow_cap_scale",
         "flow_eff",
         "flow_eff_per_distance",
         "force_async_flow",
@@ -440,18 +406,16 @@ techs:
       flow_cap_per_storage_cap_min: 0 # name: Minimum flow capacity per storage capacity ¦ unit: hour :sup:`-1` ¦ ratio of minimum charge/discharge (kW) for a given storage capacity (kWh).
       flow_cap_per_storage_cap_max: .inf # name: Maximum flow capacity per storage capacity ¦ unit: hour :sup:`-1` ¦ ratio of maximum charge/discharge (kW) for a given storage capacity (kWh).
       flow_cap_per_storage_cap_equals: null # name: Tie flow capacity to storage capacity ¦ unit: hour :sup:`-1` ¦
-      flow_cap_equals: null # name: Specific installed flow capacity ¦ unit: kW ¦ fixes maximum/minimum if decision variables ``flow_out``/``flow_in`` and overrides ``_max`` and ``_min`` constraints.
-      flow_cap_equals_systemwide: null # name: System-wide specific installed flow capacity ¦ unit: kW ¦ fixes the sum to a maximum/minimum, for a particular technology, of the decision variables ``flow_out``/``flow_in`` over all nodes.
       flow_cap_max: .inf # name: Maximum installed flow capacity ¦ unit: kW ¦ Limits decision variables ``flow_out``/``flow_in`` to a maximum/minimum.
       flow_cap_max_systemwide: .inf # name: System-wide maximum installed flow capacity ¦ unit: kW ¦ Limits the sum to a maximum/minimum, for a particular technology, of the decision variables ``flow_out``/``flow_in`` over all nodes.
       flow_cap_min: 0 # name: Minimum installed flow capacity ¦ unit: kW ¦ Limits decision variables ``flow_out``/``flow_in`` to a minimum/maximum.
+      flow_cap_min_systemwide: 0 # name: System-wide specific installed flow capacity ¦ unit: kW ¦ sets the lower bound of the sum across all nodes of the decision variable `flow_cap` for a particular technology.
       flow_out_min_relative: 0 # name: Minimum outflow ¦ unit: fraction ¦ Set to a value between 0 and 1 to force minimum outflow as a fraction of the technology maximum flow capacity. If non-zero and technology is not defined by ``units``, this will force the technology to operate above its minimum value at every timestep.
       flow_cap_per_unit: null # name: Flow capacity per purchased unit ¦ unit: kW/unit ¦ Set the capacity of each integer unit of a technology purchased
-      flow_cap_scale: 1.0 # name: Flow capacity scale ¦ unit: float ¦ Scale all ``flow_cap`` min/max/equals/total_max/total_equals constraints by this value
       flow_eff: 1.0 # name: Flow efficiency ¦ unit: fraction ¦ conversion efficiency (static, or from file as timeseries), from ``source``/``flow_in`` (tech dependent) to ``flow_out``/``sink``.
-      flow_eff_per_distance: 1.0 # name: Flow efficiency per distance ¦ unit: fraction/distance ¦ Set as value between 1 (no loss) and 0 (all flow lost).
+      flow_eff_per_distance: 1.0 # name: Flow efficiency per distance ¦ unit: fraction/distance ¦ Set as value between 1 (no loss) and 0 (all lost).
       flow_ramping: 1 # name: Ramping rate ¦ unit: fraction / hour ¦ Set to ``false`` to disable ramping constraints, otherwise limit maximum outflow to a fraction of maximum capacity, which increases by that fraction at each timestep.
-      export_max: .inf # name: Maximum allowed export ¦ unit: kW ¦ Maximum allowed export of produced flow carrier for a technology.
+      export_max: .inf # name: Maximum allowed export ¦ unit: kW ¦ Maximum allowed export of produced carrier for a technology.
       export_carrier: null # name: Export carrier ¦ unit: N/A ¦ Name of carrier to be exported. Must be an output carrier of the technology
       lifetime: null # name: Technology lifetime ¦ unit: years ¦ Must be defined if fixed capital costs are defined. A reasonable value for many technologies is around 20-25 years.
       parasitic_eff: 1.0 # name: Plant parasitic efficiency ¦ unit: fraction ¦ Additional losses as flow gets transferred from the plant to the carrier (static, or from file as timeseries), e.g. due to plant parasitic consumption
@@ -461,28 +425,22 @@ techs:
       source_min: 0 # name: Minimum bound on source to add to the system (e.g., biofuel, coal, rainfall, wind flow) ¦ unit: kWh | kWh/m\ :sup:`2` | kWh/kW ¦ Minimum available source (static, or from file as timeseries). Unit dictated by ``source_unit``.
       source_max: .inf # name: Maximum bound on source to add to the system (e.g., biofuel, coal, rainfall, wind flow) ¦ unit: kWh | kWh/m\ :sup:`2` | kWh/kW ¦ Maximum available source (static, or from file as timeseries). Unit dictated by ``source_unit``.
       source_equals: null # name: Exact amount of source to add to the system (e.g., biofuel, coal, rainfall, wind flow) ¦ unit: kWh | kWh/m\ :sup:`2` | kWh/kW ¦ Required source (static, or from file as timeseries). Unit dictated by ``source_unit``.
-      area_use_equals: null # name: Specific installed area use ¦ unit: m\ :sup:`2` ¦
       area_use_max: .inf # name: Maximum usable area ¦ unit: m\ :sup:`2` ¦ If set to a finite value, restricts the usable area of the technology to this value.
       area_use_min: 0 # name: Minimum usable area ¦ unit: m\ :sup:`2` ¦
       area_use_per_flow_cap: null # name: Area use per flow capacity ¦ unit: m\ :sup: `2`/kW ¦ If set, forces ``area_use`` to follow ``flow_cap`` with the given numerical ratio (e.g. setting to 1.5 means that ``area_use == 1.5 * flow_cap``)
-      source_cap_equals: null # name: Specific installed source consumption capacity ¦ unit: kW ¦ overrides ``_max`` and ``_min`` constraints.
       source_cap_max: .inf # name: Maximum installed source consumption capacity ¦ unit: kW ¦
       source_cap_min: 0 # name: Minimum installed source consumption capacity ¦ unit: kW ¦
       source_eff: 1.0 # name: Efficiency of converting a source into usable resource ¦ unit: fraction ¦ Efficiency (static, or from file as timeseries) in capturing source before it reaches storage (if storage is present) or conversion to carrier.
-      sink_scale: 1.0 # name: Sink scale ¦ unit: fraction ¦ Scale sink (either static value or all values in timeseries) by this value
-      source_scale: 1.0 # name: Source scale ¦ unit: fraction ¦ Scale source (either static value or all values in timeseries) by this value
-      storage_cap_equals: null # name: Specific storage capacity ¦ unit: kWh ¦ If not defined, ``flow_cap_equals`` * ``flow_cap_per_storage_cap_max`` will be used as the capacity and overrides ``_max`` and ``_min`` constraints.
       storage_cap_max: .inf # name: Maximum storage capacity ¦ unit: kWh ¦ If not defined, ``flow_cap_max`` * ``flow_cap_per_storage_cap_max`` will be used as the capacity.
       storage_cap_min: 0 # name: Minimum storage capacity ¦ unit: kWh ¦
       storage_cap_per_unit: null # name: Storage capacity per purchased unit ¦ unit: kWh/unit ¦ Set the storage capacity of each integer unit of a technology purchased.
       storage_discharge_depth: 0 # name: Storage depth of discharge ¦ unit: fraction ¦ Defines the minimum level of storage state of charge, as a fraction of total storage capacity
       storage_initial: 0 # name: Initial storage level ¦ unit: fraction ¦ Set stored flow in device at the first timestep, as a fraction of total storage capacity
       storage_loss: 0 # name: Storage loss rate ¦ unit: fraction/hour ¦ rate of storage loss per hour (static, or from file as timeseries), used to calculate lost stored flow as ``(1 - storage_loss)^hours_per_timestep``
-      units_equals: null # name: Specific number of purchased units ¦ unit: integer ¦ Turns the model from LP to MILP.
-      units_equals_systemwide: null # name: System-wide specific installed flow capacity ¦ unit: kW ¦ fixes the sum to a specific value, for a particular technology, of the decision variables ``flow_out``/``flow_in`` over all nodes.
-      units_max: .inf # name: Maximum number of purchased units ¦ unit: integer ¦ Turns the model from LP to MILP.
-      units_max_systemwide: .inf # name: System-wide maximum installed flow capacity ¦ unit: kW ¦ Limits the sum to a maximum/minimum, for a particular technology, of the decision variables ``flow_out``/``flow_in`` over all nodes.
+      units_min_systemwide: 0 # name: System-wide minimum installed flow capacity ¦ unit: integer ¦ sets the lower bound of the sum across all nodes of the decision variable `units`for a particular technology.
+      units_max_systemwide: .inf # name: System-wide minimum installed flow capacity ¦ unit: integer ¦ sets the upper bound of the sum across all nodes of the decision variable `units`for a particular technology.
       units_min: 0 # name: Minimum number of purchased units ¦ unit: integer ¦ Turns the model from LP to MILP.
+      units_max: .inf # name: Maximum number of purchased units ¦ unit: integer ¦ Turns the model from LP to MILP.
     costs:
       default_cost: # These costs are used for any value not defined for a given cost class
         flow_cap: 0 # name: Cost of flow capacity ¦ unit: kW :sub:`gross` :sup:`-1` ¦
@@ -497,7 +455,6 @@ techs:
         area_use: 0 # name: Cost of area use ¦ unit: m\ :sup:`-2` ¦
         source_cap: 0 # name: Cost of source flow capacity ¦ unit: kW :sup:`-1` ¦
         storage_cap: 0 # name: Cost of storage capacity ¦ unit: kWh :sup:`-1` ¦
-        depreciation_rate: 1 # name: Depreciation rate for annualisation of investment costs ¦ unit: fraction ¦
     exists: true
 
 nodes:
@@ -505,7 +462,7 @@ nodes:
     transmission_node: false # true only if no techs are defined (including complete omission of the `techs` key). Automatically added during processing if not defined by user.
     coordinates: {} # The node's x-y coordinates for distance calculations and plotting: {lat: ..., lon: ...} or {x: ..., y: ...}
     available_area: .inf # This node's available land area (required if constraining technology deployment by area).
-    techs: null # A list of technologies, optionally with node-specific settings overriding the technology's global settings.
+    techs: None # A list of technologies, optionally with node-specific settings overriding the technology's global settings.
     exists: true
 
 links:

--- a/src/calliope/config/defaults.yaml
+++ b/src/calliope/config/defaults.yaml
@@ -462,7 +462,7 @@ nodes:
     transmission_node: false # true only if no techs are defined (including complete omission of the `techs` key). Automatically added during processing if not defined by user.
     coordinates: {} # The node's x-y coordinates for distance calculations and plotting: {lat: ..., lon: ...} or {x: ..., y: ...}
     available_area: .inf # This node's available land area (required if constraining technology deployment by area).
-    techs: None # A list of technologies, optionally with node-specific settings overriding the technology's global settings.
+    techs: null # A list of technologies, optionally with node-specific settings overriding the technology's global settings.
     exists: true
 
 links:

--- a/src/calliope/config/defaults.yaml
+++ b/src/calliope/config/defaults.yaml
@@ -455,6 +455,7 @@ techs:
         area_use: 0 # name: Cost of area use ¦ unit: m\ :sup:`-2` ¦
         source_cap: 0 # name: Cost of source flow capacity ¦ unit: kW :sup:`-1` ¦
         storage_cap: 0 # name: Cost of storage capacity ¦ unit: kWh :sup:`-1` ¦
+        depreciation_rate: 1 # name: Depreciation rate for annualisation of investment costs ¦ unit: fraction ¦
     exists: true
 
 nodes:

--- a/src/calliope/config/math_schema.yaml
+++ b/src/calliope/config/math_schema.yaml
@@ -139,12 +139,6 @@ properties:
               max:
                 type: [string, number]
                 description: Decision variable upper bound, either as a reference to an input parameter or as a number.
-              equals:
-                type: [string, number]
-                description: Decision variable equality bound, either as a reference to an input parameter or as a number, which simultanously forces the lower and uppere bound to the same value.
-              scale:
-                type: [string, number]
-                description: Scaling factor, either as a reference to an input parameter or as a number, which will be applied to all bounds.
 
   objectives:
     type: object

--- a/src/calliope/example_models/national_scale/scenarios.yaml
+++ b/src/calliope/example_models/national_scale/scenarios.yaml
@@ -59,28 +59,28 @@ overrides:
       horizon: 24
     model.subset_time: ["2005-01-01", "2005-01-10"]
     nodes:
-      region1.techs.ccgt.constraints.flow_cap_equals: 30000
+      region1.techs.ccgt.constraints.flow_cap_max: 30000
 
-      region2.techs.battery.constraints.flow_cap_equals: 1000
-      region2.techs.battery.constraints.storage_cap_equals: 5240
+      region2.techs.battery.constraints.flow_cap_max: 1000
+      region2.techs.battery.constraints.storage_cap_max: 5240
 
-      region1-1.techs.csp.constraints.flow_cap_equals: 10000
-      region1-1.techs.csp.constraints.storage_cap_equals: 244301
-      region1-1.techs.csp.constraints.area_use_equals: 130385
+      region1-1.techs.csp.constraints.flow_cap_max: 10000
+      region1-1.techs.csp.constraints.storage_cap_max: 244301
+      region1-1.techs.csp.constraints.area_use_max: 130385
 
-      region1-2.techs.csp.constraints.flow_cap_equals: 0
-      region1-2.techs.csp.constraints.storage_cap_equals: 0
-      region1-2.techs.csp.constraints.area_use_equals: 0
+      region1-2.techs.csp.constraints.flow_cap_max: 0
+      region1-2.techs.csp.constraints.storage_cap_max: 0
+      region1-2.techs.csp.constraints.area_use_max: 0
 
-      region1-3.techs.csp.constraints.flow_cap_equals: 2534
-      region1-3.techs.csp.constraints.storage_cap_equals: 25301
-      region1-3.techs.csp.constraints.area_use_equals: 8487
+      region1-3.techs.csp.constraints.flow_cap_max: 2534
+      region1-3.techs.csp.constraints.storage_cap_max: 25301
+      region1-3.techs.csp.constraints.area_use_max: 8487
 
     links:
-      region1,region2.techs.ac_transmission.constraints.flow_cap_equals: 3231
-      region1,region1-1.techs.free_transmission.constraints.flow_cap_equals: 9000
-      region1,region1-2.techs.free_transmission.constraints.flow_cap_equals: 0
-      region1,region1-3.techs.free_transmission.constraints.flow_cap_equals: 2281
+      region1,region2.techs.ac_transmission.constraints.flow_cap_max: 3231
+      region1,region1-1.techs.free_transmission.constraints.flow_cap_max: 9000
+      region1,region1-2.techs.free_transmission.constraints.flow_cap_max: 0
+      region1,region1-3.techs.free_transmission.constraints.flow_cap_max: 2281
 
   check_feasibility:
     run:
@@ -174,7 +174,8 @@ overrides:
   maximize_utility_costs:
     run:
       objective_options:
-        cost_class: { "utility": -1, "monetary": 0 }
+        cost_class: { "utility": 1, "monetary": 0 }
+        sense: maximize
     techs:
       ccgt:
         costs:

--- a/src/calliope/math/base.yaml
+++ b/src/calliope/math/base.yaml
@@ -2,23 +2,16 @@ constraints:
   flow_capacity_per_storage_capacity_min:
     description: "Set the lower bound of a `storage`/`supply_plus` technology's flow capacity relative to its storage capacity."
     foreach: [nodes, techs]
-    where: "storage_cap AND flow_cap_per_storage_cap_min AND NOT flow_cap_per_storage_cap_equals"
+    where: "storage_cap AND flow_cap_per_storage_cap_min"
     equations:
       - expression: flow_cap >= storage_cap * flow_cap_per_storage_cap_min
 
   flow_capacity_per_storage_capacity_max:
     description: "Set the upper bound of a `storage`/`supply_plus` technology's flow capacity relative to its storage capacity."
     foreach: [nodes, techs]
-    where: "storage_cap AND flow_cap_per_storage_cap_max AND NOT flow_cap_per_storage_cap_equals"
+    where: "storage_cap AND flow_cap_per_storage_cap_max"
     equations:
       - expression: flow_cap <= storage_cap * flow_cap_per_storage_cap_max
-
-  flow_capacity_per_storage_capacity_equals:
-    description: "Set a fixed relationship between a `storage`/`supply_plus` technology's flow capacity and its storage capacity."
-    foreach: [nodes, techs]
-    where: "storage_cap AND flow_cap_per_storage_cap_equals"
-    equations:
-      - expression: flow_cap == storage_cap * flow_cap_per_storage_cap_equals
 
   source_capacity_equals_flow_capacity:
     description: "Set a `supply_plus` technology's flow capacity to equal its source capacity."
@@ -48,15 +41,19 @@ constraints:
     equations:
       - expression: sum(area_use, over=techs) <= available_area
 
-  flow_capacity_systemwide:
-    description: "Set an upper bound on, or a fixed total of, flow capacity of a technology across all nodes in which the technology exists."
+  flow_capacity_systemwide_max:
+    description: "Set an upper bound on flow capacity of a technology across all nodes in which the technology exists."
     foreach: [techs]
-    where: "(flow_cap_equals_systemwide OR flow_cap_max_systemwide)"
+    where: "flow_cap_max_systemwide"
     equations:
-      - where: "flow_cap_equals_systemwide"
-        expression: sum(flow_cap, over=nodes) == flow_cap_equals_systemwide
-      - where: "NOT flow_cap_equals_systemwide"
-        expression: sum(flow_cap, over=nodes) <= flow_cap_max_systemwide
+      - expression: sum(flow_cap, over=nodes) <= flow_cap_max_systemwide
+
+  flow_capacity_systemwide_min:
+    description: "Set a lower bound on flow capacity of a technology across all nodes in which the technology exists."
+    foreach: [techs]
+    where: "flow_cap_min_systemwide"
+    equations:
+      - expression: sum(flow_cap, over=nodes) >= flow_cap_min_systemwide
 
   balance_conversion_plus_primary:
     description: "Fix the relationship between total outflow and total inflow of `conversion_plus` technologies for `in` (consumption) and `out` (production) carrier flows."
@@ -194,11 +191,11 @@ constraints:
     sub_expressions:
       source_scaler: &source_scaler
         - where: "source_unit=per_area"
-          expression: "source_scale * area_use"
+          expression: "area_use"
         - where: "source_unit=per_cap"
-          expression: "source_scale * flow_cap"
+          expression: "flow_cap"
         - where: "source_unit=absolute"
-          expression: "source_scale"
+          expression: "1"
 
   balance_supply_min_use:
     description: "Set the lower bound on the quantity of its source a `supply` technology must use in each timestep."
@@ -222,11 +219,11 @@ constraints:
         - expression: flow_in * flow_eff
       sink_scaler: &sink_scaler
         - where: "sink_unit=per_area"
-          expression: "sink_scale * area_use"
+          expression: "area_use"
         - where: "sink_unit=per_cap"
-          expression: "sink_scale * flow_cap"
+          expression: "flow_cap"
         - where: "sink_unit=absolute"
-          expression: "sink_scale"
+          expression: "1"
 
   balance_demand_min_use:
     description: "Set the lower bound on the quantity of flow a `demand` technology must dump to its sink in each timestep."
@@ -392,29 +389,23 @@ constraints:
   flow_capacity_max_purchase_milp:
     description: "Set the upper bound on, or a fixed total of, a technology's flow capacity, for any technology with binary capacity purchasing."
     foreach: [nodes, techs]
-    where: "purchased AND (flow_cap_max OR flow_cap_equals)"
+    where: "purchased AND flow_cap_max"
     equations:
-      - where: flow_cap_equals
-        expression: flow_cap == flow_cap_equals * flow_cap_scale * purchased
-      - where: NOT flow_cap_equals
-        expression: flow_cap <= flow_cap_max * flow_cap_scale * purchased
+      - expression: flow_cap <= flow_cap_max * purchased
 
   flow_capacity_min_purchase_milp:
     description: "Set the lower bound on a technology's flow capacity, for any technology with binary capacity purchasing."
     foreach: [nodes, techs]
     where: "purchased AND flow_cap_min AND NOT flow_cap_equals"
     equations:
-      - expression: flow_cap >= flow_cap_min * flow_cap_scale * purchased
+      - expression: flow_cap >= flow_cap_min * purchased
 
   storage_capacity_max_purchase_milp:
     description: "Set the upper bound on, or a fixed total of, a technology's storage capacity, for any technology with binary capacity purchasing."
     foreach: [nodes, techs]
-    where: "purchased AND (storage_cap_max OR storage_cap_equals)"
+    where: "purchased AND storage_cap_max"
     equations:
-      - where: storage_cap_equals
-        expression: storage_cap == storage_cap_equals * purchased
-      - where: NOT storage_cap_equals
-        expression: storage_cap <= storage_cap_max * purchased
+      - expression: storage_cap <= storage_cap_max * purchased
 
   storage_capacity_min_purchase_milp:
     description: "Set the lower bound on a technology's storage capacity, for any technology with binary capacity purchasing."
@@ -423,21 +414,26 @@ constraints:
     equations:
       - expression: storage_cap >= storage_cap_min * purchased
 
-  unit_capacity_systemwide_milp:
-    description: "Set the upper bound on, or a fixed total of, the total number of units of a technology that can be purchased across all nodes where the technology can exist, for any technology using integer units to define its capacity."
+  unit_capacity_max_systemwide_milp:
+    description: "Set the upper bound on the total number of units of a technology that can be purchased across all nodes where the technology can exist, for any technology using integer units to define its capacity."
     foreach: [techs]
-    where: "(purchased OR units) AND (units_max_systemwide OR units_equals_systemwide)"
+    where: "(purchased OR units) AND units_max_systemwide"
     equations:
-      - where: units_equals_systemwide
-        expression: $summed_components == units_equals_systemwide
-      - where: NOT units_equals_systemwide
-        expression: $summed_components <= units_max_systemwide
-    sub_expressions:
+      - expression: $summed_components <= units_max_systemwide
+    sub_expressions: &unit_capacity_systemwide_milp_sub_exprs
       summed_components:
         - where: purchased
           expression: sum(purchased, over=nodes)
         - where: units
           expression: sum(units, over=nodes)
+
+  unit_capacity_min_systemwide_milp:
+    description: "Set the lower bound on the total number of units of a technology that can be purchased across all nodes where the technology can exist, for any technology using integer units to define its capacity."
+    foreach: [techs]
+    where: "(purchased OR units) AND units_min_systemwide"
+    equations:
+      - expression: $summed_components >= units_min_systemwide
+    sub_expressions: *unit_capacity_systemwide_milp_sub_exprs
 
   async_flow_in_milp:
     description: "Set a technology's ability to have inflow in the same timestep that it has outflow, for any technology using the asynchronous flow binary switch."
@@ -485,8 +481,6 @@ variables:
     bounds:
       min: flow_cap_min
       max: flow_cap_max
-      equals: flow_cap_equals
-      scale: flow_cap_scale
 
   flow_out:
     description: "The outflow of a technology per timestep, also known as the flow discharged (from `storage` technologies) or the flow received (by `transmission` technologies) on a link."
@@ -519,11 +513,10 @@ variables:
     description: "The area in space utilised directly (e.g., solar PV panels) or indirectly (e.g., biofuel crops) by a technology."
     unit: area
     foreach: [nodes, techs]
-    where: "(area_use_min OR area_use_max OR area_use_equals OR area_use_per_flow_cap OR sink_unit=per_area OR source_unit=per_area)"
+    where: "(area_use_min OR area_use_max OR area_use_per_flow_cap OR sink_unit=per_area OR source_unit=per_area)"
     bounds:
       min: area_use_min
       max: area_use_max
-      equals: area_use_equals
 
   source_use:
     description: "The carrier flow consumed from outside the system boundaries by a `supply_plus` technology."
@@ -542,7 +535,6 @@ variables:
     bounds:
       min: source_cap_min
       max: source_cap_max
-      equals: source_cap_equals
 
   storage_cap:
     description: "The upper limit on a carrier that can be stored by a `supply_plus` or `storage` technology in any timestep."
@@ -552,7 +544,6 @@ variables:
     bounds:
       min: storage_cap_min
       max: storage_cap_max
-      equals: storage_cap_equals
 
   storage:
     description: "The carrier stored by a `supply_plus` or `storage` technology in each timestep."
@@ -582,7 +573,6 @@ variables:
     bounds:
       min: units_min
       max: units_max
-      equals: units_equals
 
   operating_units:
     description: "Integer number of a technology that is operating in each timestep, for any technology set to require inteter capacity purchasing."

--- a/src/calliope/math/operate.yaml
+++ b/src/calliope/math/operate.yaml
@@ -1,7 +1,6 @@
 constraints:
   flow_capacity_per_storage_capacity_min.active: false
   flow_capacity_per_storage_capacity_max.active: false
-  flow_capacity_per_storage_capacity_equals.active: false
   source_capacity_equals_flow_capacity.active: false
   force_zero_area_use.active: false
   area_use_per_flow_capacity.active: false

--- a/src/calliope/preprocess/checks.py
+++ b/src/calliope/preprocess/checks.py
@@ -435,7 +435,7 @@ def _check_tech_final(
     ):
         errors.append(
             f"`{tech_id}` at `{loc_id}` fails to define flow_cap_per_unit when "
-            "specifying technology in units_max/min/equals"
+            "specifying technology in units_max/min"
         )
 
     # If a technology is defined by units & is a storage tech, it must define storage_cap_per_unit
@@ -447,7 +447,7 @@ def _check_tech_final(
     ):
         errors.append(
             f"`{tech_id}` at `{loc_id}` fails to define storage_cap_per_unit when "
-            "specifying technology in units_max/min/equals"
+            "specifying technology in units_max/min"
         )
 
     # Gather remaining unallowed constraints

--- a/src/calliope/preprocess/checks.py
+++ b/src/calliope/preprocess/checks.py
@@ -652,7 +652,6 @@ def check_model_data(model_data):
         if (
             (model_data[cap.group(0)] < 0)
             & model_data.get(f"{cap.group(1)}_max", xr.DataArray(np.nan)).isnull()
-            & model_data.get(f"{cap.group(1)}_equals", xr.DataArray(np.nan)).isnull()
         ).any():
             errors.append(
                 f"Cannot have a negative {cap.group(0)} as there is an unset "

--- a/tests/common/test_model/energy_cap_per_storage_cap.yaml
+++ b/tests/common/test_model/energy_cap_per_storage_cap.yaml
@@ -37,8 +37,6 @@ nodes:
     electricity_demand:
 
 overrides:
-  equals:
-    techs.my_storage.constraints.flow_cap_per_storage_cap_equals: 10
   max:
     techs.my_storage.constraints.flow_cap_per_storage_cap_max: 0.01
   min:

--- a/tests/common/test_model/energy_cap_per_storage_cap.yaml
+++ b/tests/common/test_model/energy_cap_per_storage_cap.yaml
@@ -43,7 +43,6 @@ overrides:
     techs.my_storage.constraints.flow_cap_per_storage_cap_min: 1
   operate_mode_min:
     techs.my_storage.constraints.flow_cap_per_storage_cap_min: 1
-    techs.my_storage.constraints.storage_cap_equals: 900
     run.mode: operate
     run.operation:
       window: 24

--- a/tests/test_backend_parsing.py
+++ b/tests/test_backend_parsing.py
@@ -47,6 +47,11 @@ def expression_string_parser(valid_math_element_names):
 
 
 @pytest.fixture
+def arithmetic_string_parser(valid_math_element_names):
+    return expression_parser.generate_arithmetic_parser(valid_math_element_names)
+
+
+@pytest.fixture
 def slice_parser(valid_math_element_names):
     return expression_parser.generate_slice_parser(valid_math_element_names)
 
@@ -811,6 +816,14 @@ class TestParsedBackendEquation:
 
     def test_find_single_sub_expression(self, expression_string_parser, equation_obj):
         parsed = expression_string_parser.parse_string("$foo == 1", parse_all=True)
+        equation_obj.expression = parsed
+        found_sub_expressions = equation_obj.find_sub_expressions()
+        assert found_sub_expressions == {"foo"}
+
+    def test_find_single_sub_expression_in_global_expression(
+        self, arithmetic_string_parser, equation_obj
+    ):
+        parsed = arithmetic_string_parser.parse_string("$foo", parse_all=True)
         equation_obj.expression = parsed
         found_sub_expressions = equation_obj.find_sub_expressions()
         assert found_sub_expressions == {"foo"}

--- a/tests/test_core_preprocess.py
+++ b/tests/test_core_preprocess.py
@@ -1373,7 +1373,6 @@ class TestChecks:
         "constraints,costs",
         (
             ({"units_max": 2, "flow_cap_per_unit": 5}, None),
-            ({"units_equals": 2, "flow_cap_per_unit": 5}, None),
             ({"units_min": 2, "flow_cap_per_unit": 5}, None),
             (None, {"purchase": 2}),
         ),

--- a/tests/test_example_models.py
+++ b/tests/test_example_models.py
@@ -309,7 +309,7 @@ class TestNationalScaleExampleModelSpores:
 
         return _spores_with_override
 
-    @pytest.mark.parametrize("override", ("flow_cap_min", "flow_cap_equals"))
+    @pytest.mark.parametrize("override", ("flow_cap_min"))
     def test_ignore_forced_flow_cap_spores(self, spores_with_override, override):
         # the national scale model always maxes out CCGT in the first 3 SPORES.
         # So we can force its minimum/exact capacity without influencing other tech SPORE scores.
@@ -342,10 +342,7 @@ class TestNationalScaleExampleModelSpores:
         # the national scale model always maxes out CCGT in the first 3 SPORES.
         # So we can force its minimum/exact capacity without influencing other tech SPORE scores.
         # This enables us to test our functionality that only *additional* capacity is scored.
-        override_dict = {
-            "locations.region1.techs.ccgt.constraints.flow_cap_min": 15000,
-            "locations.region1.techs.ccgt.constraints.flow_cap_equals": 30000,
-        }
+        override_dict = {"locations.region1.techs.ccgt.constraints.flow_cap_min": 15000}
         result_with_override, _ = spores_with_override(override_dict)
         assert (
             result_with_override.cost.sel(


### PR DESCRIPTION
Fixes issue #422

Summary of changes in this pull request:

* parameters defining a `_equals` variant removed in favour of using `_min` and `_max` simultaneously. For the most part this affects variable bounds, so will only increase model size if imposing `energy_cap_systemwide` or `units_systemwide` constraints, wherein two constraints are built instead of one. This is also not a massive issue since they are not built over the time dimensions so are unlikely to be particularly large constraint arrays
* scaling parameters `energy_cap_scale` and `resource_scale` parameters removed as they introduce a maintenance burden when we do not know of any cases of their actual use.

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved