### PR TITLE
Only run py39 and py310 on ubuntu

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -27,8 +27,13 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         py3version: ["9", "10", "11"]
+        include:
+          - os: windows-latest
+            py3version: "11"
+          - os: macos-latest
+            py3version: "11"
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Fixes sheer number of CI runners.

Summary of changes in this pull request:

* macos and windows runners will only run on python version 3.11, while ubuntu tests older python versions.

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved