### PR TITLE
Add ability to view constraint coords in LP files

### DIFF
--- a/tests/common/lp_files/balance_conversion.lp
+++ b/tests/common/lp_files/balance_conversion.lp
@@ -6,22 +6,22 @@ objectives(dummy_obj)(0):
 
 s.t.
 
-c_e_constraints(balance_conversion)(0)_:
+c_e_constraints(balance_conversion)(a__test_conversion__2005_01_01_00_00)_:
 +1 variables(carrier_prod)(a__test_conversion__heat__2005_01_01_00_00)
 +0.9 variables(carrier_con)(a__test_conversion__gas__2005_01_01_00_00)
 = 0.0
 
-c_e_constraints(balance_conversion)(1)_:
+c_e_constraints(balance_conversion)(a__test_conversion__2005_01_01_01_00)_:
 +1 variables(carrier_prod)(a__test_conversion__heat__2005_01_01_01_00)
 +0.9 variables(carrier_con)(a__test_conversion__gas__2005_01_01_01_00)
 = 0.0
 
-c_e_constraints(balance_conversion)(2)_:
+c_e_constraints(balance_conversion)(b__test_conversion__2005_01_01_00_00)_:
 +1 variables(carrier_prod)(b__test_conversion__heat__2005_01_01_00_00)
 +0.9 variables(carrier_con)(b__test_conversion__gas__2005_01_01_00_00)
 = 0.0
 
-c_e_constraints(balance_conversion)(3)_:
+c_e_constraints(balance_conversion)(b__test_conversion__2005_01_01_01_00)_:
 +1 variables(carrier_prod)(b__test_conversion__heat__2005_01_01_01_00)
 +0.9 variables(carrier_con)(b__test_conversion__gas__2005_01_01_01_00)
 = 0.0

--- a/tests/common/lp_files/carrier_production_max.lp
+++ b/tests/common/lp_files/carrier_production_max.lp
@@ -6,62 +6,62 @@ objectives(dummy_obj)(0):
 
 s.t.
 
-c_u_constraints(carrier_production_max)(0)_:
+c_u_constraints(carrier_production_max)(a__test_supply_elec__electricity__2005_01_01_00_00)_:
 +1 variables(carrier_prod)(a__test_supply_elec__electricity__2005_01_01_00_00)
 -1.0 variables(energy_cap)(a__test_supply_elec)
 <= 0.0
 
-c_u_constraints(carrier_production_max)(1)_:
+c_u_constraints(carrier_production_max)(a__test_supply_elec__electricity__2005_01_01_01_00)_:
 -1.0 variables(energy_cap)(a__test_supply_elec)
 +1 variables(carrier_prod)(a__test_supply_elec__electricity__2005_01_01_01_00)
 <= 0.0
 
-c_u_constraints(carrier_production_max)(2)_:
+c_u_constraints(carrier_production_max)(a__test_transmission_elec_b__electricity__2005_01_01_00_00)_:
 +1 variables(carrier_prod)(a__test_transmission_elec_b__electricity__2005_01_01_00_00)
 -1.0 variables(energy_cap)(a__test_transmission_elec_b)
 <= 0.0
 
-c_u_constraints(carrier_production_max)(3)_:
+c_u_constraints(carrier_production_max)(a__test_transmission_elec_b__electricity__2005_01_01_01_00)_:
 -1.0 variables(energy_cap)(a__test_transmission_elec_b)
 +1 variables(carrier_prod)(a__test_transmission_elec_b__electricity__2005_01_01_01_00)
 <= 0.0
 
-c_u_constraints(carrier_production_max)(4)_:
+c_u_constraints(carrier_production_max)(a__test_transmission_heat_b__heat__2005_01_01_00_00)_:
 +1 variables(carrier_prod)(a__test_transmission_heat_b__heat__2005_01_01_00_00)
 -1.0 variables(energy_cap)(a__test_transmission_heat_b)
 <= 0.0
 
-c_u_constraints(carrier_production_max)(5)_:
+c_u_constraints(carrier_production_max)(a__test_transmission_heat_b__heat__2005_01_01_01_00)_:
 -1.0 variables(energy_cap)(a__test_transmission_heat_b)
 +1 variables(carrier_prod)(a__test_transmission_heat_b__heat__2005_01_01_01_00)
 <= 0.0
 
-c_u_constraints(carrier_production_max)(6)_:
+c_u_constraints(carrier_production_max)(b__test_supply_elec__electricity__2005_01_01_00_00)_:
 +1 variables(carrier_prod)(b__test_supply_elec__electricity__2005_01_01_00_00)
 -1.0 variables(energy_cap)(b__test_supply_elec)
 <= 0.0
 
-c_u_constraints(carrier_production_max)(7)_:
+c_u_constraints(carrier_production_max)(b__test_supply_elec__electricity__2005_01_01_01_00)_:
 -1.0 variables(energy_cap)(b__test_supply_elec)
 +1 variables(carrier_prod)(b__test_supply_elec__electricity__2005_01_01_01_00)
 <= 0.0
 
-c_u_constraints(carrier_production_max)(8)_:
+c_u_constraints(carrier_production_max)(b__test_transmission_elec_a__electricity__2005_01_01_00_00)_:
 +1 variables(carrier_prod)(b__test_transmission_elec_a__electricity__2005_01_01_00_00)
 -1.0 variables(energy_cap)(b__test_transmission_elec_a)
 <= 0.0
 
-c_u_constraints(carrier_production_max)(9)_:
+c_u_constraints(carrier_production_max)(b__test_transmission_elec_a__electricity__2005_01_01_01_00)_:
 -1.0 variables(energy_cap)(b__test_transmission_elec_a)
 +1 variables(carrier_prod)(b__test_transmission_elec_a__electricity__2005_01_01_01_00)
 <= 0.0
 
-c_u_constraints(carrier_production_max)(10)_:
+c_u_constraints(carrier_production_max)(b__test_transmission_heat_a__heat__2005_01_01_00_00)_:
 +1 variables(carrier_prod)(b__test_transmission_heat_a__heat__2005_01_01_00_00)
 -1.0 variables(energy_cap)(b__test_transmission_heat_a)
 <= 0.0
 
-c_u_constraints(carrier_production_max)(11)_:
+c_u_constraints(carrier_production_max)(b__test_transmission_heat_a__heat__2005_01_01_01_00)_:
 -1.0 variables(energy_cap)(b__test_transmission_heat_a)
 +1 variables(carrier_prod)(b__test_transmission_heat_a__heat__2005_01_01_01_00)
 <= 0.0

--- a/tests/common/lp_files/resource_max.lp
+++ b/tests/common/lp_files/resource_max.lp
@@ -6,22 +6,22 @@ objectives(dummy_obj)(0):
 
 s.t.
 
-c_u_constraints(my_constraint)(0)_:
+c_u_constraints(my_constraint)(a__test_supply_plus__2005_01_01_00_00)_:
 +1 variables(resource_con)(a__test_supply_plus__2005_01_01_00_00)
 -24.0 variables(resource_cap)(a__test_supply_plus)
 <= 0.0
 
-c_u_constraints(my_constraint)(1)_:
+c_u_constraints(my_constraint)(a__test_supply_plus__2005_01_02_00_00)_:
 -24.0 variables(resource_cap)(a__test_supply_plus)
 +1 variables(resource_con)(a__test_supply_plus__2005_01_02_00_00)
 <= 0.0
 
-c_u_constraints(my_constraint)(2)_:
+c_u_constraints(my_constraint)(b__test_supply_plus__2005_01_01_00_00)_:
 +1 variables(resource_con)(b__test_supply_plus__2005_01_01_00_00)
 -24.0 variables(resource_cap)(b__test_supply_plus)
 <= 0.0
 
-c_u_constraints(my_constraint)(3)_:
+c_u_constraints(my_constraint)(b__test_supply_plus__2005_01_02_00_00)_:
 -24.0 variables(resource_cap)(b__test_supply_plus)
 +1 variables(resource_con)(b__test_supply_plus__2005_01_02_00_00)
 <= 0.0

--- a/tests/common/lp_files/storage_max.lp
+++ b/tests/common/lp_files/storage_max.lp
@@ -2,26 +2,26 @@
 
 min
 objectives(dummy_obj)(0):
-+2 ONE_VAR_CONSTANT
++2.0 ONE_VAR_CONSTANT
 
 s.t.
 
-c_u_constraints(storage_max)(0)_:
+c_u_constraints(storage_max)(a__test_storage__2005_01_01_00_00)_:
 +1 variables(storage)(a__test_storage__2005_01_01_00_00)
 -1 variables(storage_cap)(a__test_storage)
 <= 0.0
 
-c_u_constraints(storage_max)(1)_:
+c_u_constraints(storage_max)(a__test_storage__2005_01_01_01_00)_:
 -1 variables(storage_cap)(a__test_storage)
 +1 variables(storage)(a__test_storage__2005_01_01_01_00)
 <= 0.0
 
-c_u_constraints(storage_max)(2)_:
+c_u_constraints(storage_max)(b__test_storage__2005_01_01_00_00)_:
 +1 variables(storage)(b__test_storage__2005_01_01_00_00)
 -1 variables(storage_cap)(b__test_storage)
 <= 0.0
 
-c_u_constraints(storage_max)(3)_:
+c_u_constraints(storage_max)(b__test_storage__2005_01_01_01_00)_:
 -1 variables(storage_cap)(b__test_storage)
 +1 variables(storage)(b__test_storage__2005_01_01_01_00)
 <= 0.0

--- a/tests/test_backend_pyomo.py
+++ b/tests/test_backend_pyomo.py
@@ -2270,6 +2270,15 @@ class TestNewBackend:
                 "variables",
             ),
             ("energy_eff", {"nodes": "a", "techs": "test_supply_elec"}, "parameters"),
+            (
+                "system_balance",
+                {
+                    "nodes": "a",
+                    "carriers": "electricity",
+                    "timesteps": "2005-01-01 00:00",
+                },
+                "constraints",
+            ),
         ],
     )
     def test_verbose_strings(self, simple_supply_longnames, objname, dims, objtype):
@@ -2298,7 +2307,7 @@ class TestNewBackend:
             obj.sel(dims).body.item()
             == f"parameters[energy_eff][{energy_eff_dims}]*variables[carrier_con][{', '.join(dims[i] for i in obj.dims)}]"
         )
-        assert not obj.coords_in_name
+        assert obj.coords_in_name
 
     def test_verbose_strings_expression(self, simple_supply_longnames):
         dims = {
@@ -2403,7 +2412,6 @@ class TestNewBackend:
 
         Updating it doesn't change the model in any way, because none of the existing constraints/expressions depend on it. Therefore, no warning is raised
         """
-
         updated_param = 1
 
         simple_supply.backend.update_parameter("units_equals", updated_param)


### PR DESCRIPTION
I realised that although I added the ability for variables and expressions to be verbose, I missed out constraints. They are useful if verbose in the LP files.

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved