### PR TITLE
Update top level config

### DIFF
--- a/doc/helpers/generate_tables.py
+++ b/doc/helpers/generate_tables.py
@@ -59,8 +59,7 @@ def process():
         get_section(defaults["techs"]["default_tech"]["costs"]["default_cost"]),
     )
 
-    write_csv("./user/includes/model_settings.csv", get_section(defaults["model"]))
-    write_csv("./user/includes/run_settings.csv", get_section(defaults["run"]))
+    write_csv("./user/includes/config.csv", get_section(defaults["config"]))
 
     y = yaml.YAML()
 

--- a/doc/user/advanced_constraints.rst
+++ b/doc/user/advanced_constraints.rst
@@ -256,9 +256,9 @@ This will only allow transmission from ``location1`` to ``location2``. To swap t
 Cyclic storage
 --------------
 
-With ``storage`` and ``supply_plus`` techs, it is possible to link the storage at either end of the timeseries, using cyclic storage. This allows the user to better represent multiple years by just modelling one year. Cyclic storage is activated by default (to deactivate: ``run.cyclic_storage: false``). As a result, a technology's initial stored energy at a given location will be equal to its stored energy at the end of the model's last timestep.
+With ``storage`` and ``supply_plus`` techs, it is possible to link the storage at either end of the timeseries, using cyclic storage. This allows the user to better represent multiple years by just modelling one year. Cyclic storage is activated by default (to deactivate: ``config.build.cyclic_storage: false``). As a result, a technology's initial stored energy at a given location will be equal to its stored energy at the end of the model's last timestep.
 
-For example, for a model running over a full year at hourly resolution, the initial storage at `Jan 1st 00:00:00` will be forced equal to the storage at the end of the timestep `Dec 31st 23:00:00`. By setting ``storage_initial`` for a technology, it is also possible to fix the value in the last timestep. For instance, with ``run.cyclic_storage: true`` and a ``storage_initial`` of zero, the stored energy *must* be zero by the end of the time horizon.
+For example, for a model running over a full year at hourly resolution, the initial storage at `Jan 1st 00:00:00` will be forced equal to the storage at the end of the timestep `Dec 31st 23:00:00`. By setting ``storage_initial`` for a technology, it is also possible to fix the value in the last timestep. For instance, with ``config.build.cyclic_storage: true`` and a ``storage_initial`` of zero, the stored energy *must* be zero by the end of the time horizon.
 
 Without cyclic storage in place (as was the case prior to v0.6.2), the storage tech can have any amount of stored energy by the end of the timeseries. This may prove useful in some cases, but has less physical meaning than assuming cyclic storage.
 

--- a/doc/user/building.rst
+++ b/doc/user/building.rst
@@ -156,10 +156,12 @@ Or it can be indexed over one or more model dimension(s):
 
     parameters:
         my_indexed_param:
-            data: { monetary: 100 }
+            data: 100
+            index: [monetary]
             dims: costs
         my_multiindexed_param:
-            data: { (monetary, electricity): 2, (monetary, heat): 10 }
+            data: [2, 10]
+            index: [(monetary, electricity), (monetary, heat)]
             dims: [costs, carriers]
 
 which can be accessed in the model inputs and custom math, e.g., `model.inputs.my_multiindexed_param.sel(costs="monetary")` and `my_multiindexed_param`.

--- a/doc/user/config_defaults.rst
+++ b/doc/user/config_defaults.rst
@@ -5,24 +5,13 @@ Configuration and defaults
 This section lists the available configuration options and constraints along with their default values.
 Defaults are automatically applied in constraints whenever there is no user input for a particular value.
 
-.. _config_reference_model:
+.. _config_reference_config:
 
 Model configuration
 -------------------
 
 .. csv-table::
-   :file: includes/model_settings.csv
-   :header: Setting,Default,Comments
-   :widths: 10, 5, 15
-   :stub-columns: 0
-
-.. _config_reference_run:
-
-Run configuration
------------------
-
-.. csv-table::
-   :file: includes/run_settings.csv
+   :file: includes/config.csv
    :header: Setting,Default,Comments
    :widths: 10, 5, 15
    :stub-columns: 0

--- a/doc/user/running.rst
+++ b/doc/user/running.rst
@@ -110,7 +110,7 @@ There are two ways to override a base model when running interactively, analogou
 
         model = calliope.Model(
             'model.yaml',
-            override_dict={'run.solver': 'gurobi'}
+            override_dict={'config.solve.solver': 'gurobi'}
         )
 
 .. note:: Both `scenario` and `override_dict` can be defined at once. They will be applied in order, such that scenarios are applied first, followed by dictionary overrides. As such, the `override_dict` can be used to override scenarios.

--- a/src/calliope/backend/helper_functions.py
+++ b/src/calliope/backend/helper_functions.py
@@ -194,10 +194,16 @@ class WhereAny(ParsingHelperFunction):
                 parameter_da.notnull()
                 & (parameter_da != np.inf)
                 & (parameter_da != -np.inf)
-            ).any(dim=over, keep_attrs=True)
+            )
+        elif parameter in self._kwargs.get("backend_dataset", xr.Dataset()).data_vars:
+            bool_parameter_da = self._kwargs["backend_dataset"][parameter].notnull()
         else:
             bool_parameter_da = xr.DataArray(False)
-        return bool_parameter_da
+        if not isinstance(over, list):
+            over = [over]
+        available_dims = set(bool_parameter_da.dims).intersection(over)
+
+        return bool_parameter_da.any(dim=available_dims, keep_attrs=True)
 
 
 class Sum(ParsingHelperFunction):

--- a/src/calliope/cli.py
+++ b/src/calliope/cli.py
@@ -292,7 +292,7 @@ def run(
             click.secho("Starting model run...")
 
             if save_logs:
-                model.run_config["save_logs"] = save_logs
+                model.config.set_key("solve.save_logs", save_logs)
 
             if save_csv is None and save_netcdf is None:
                 click.secho(
@@ -304,12 +304,11 @@ def run(
             # If save_netcdf is used, override the 'save_per_spore_path' to point to a
             # directory of the same name as the planned netcdf
 
-            if save_netcdf and model.run_config.get("spores_options", {}).get(
-                "save_per_spore", False
-            ):
-                model.run_config["spores_options"][
-                    "save_per_spore_path"
-                ] = save_netcdf.replace(".nc", "/spore_{}.nc")
+            if save_netcdf and model.config.solve.spores_save_per_spore:
+                model.config.set_key(
+                    "solve.spores_save_per_spore_path",
+                    save_netcdf.replace(".nc", "/spore_{}.nc"),
+                )
 
             model.build()
             model.solve()

--- a/src/calliope/config/defaults.yaml
+++ b/src/calliope/config/defaults.yaml
@@ -8,62 +8,51 @@
 # Model-wide default settings
 ##
 
-run:
-  backend: pyomo # Backend to use to build and solve the model. As of v0.6.0, only `pyomo` is available
-  bigM: 1e9 # Used for unmet demand, but should be of a similar order of magnitude as the largest cost that the model could achieve. Too high and the model will not converge
-  cyclic_storage: true # If true, storage in the last timestep of the timeseries is considered to be the 'previous timestep' in the first timestep of the timeseries
-  ensure_feasibility: false # If true, unmet_demand will be a decision variable, to account for an ability to meet demand with the available supply. If False and a mismatch occurs, the optimisation will fail due to infeasibility
-  mode: plan # Which mode to run the model in: 'plan', 'operation' or 'spores'
-  objective_options: { "cost_class": { "monetary": 1 }, "sense": "minimize" } # Arguments to pass to objective function. If cost-based objective function in use, should include 'cost_class' and 'sense' (maximize/minimize)
-  objective: minmax_cost_optimisation # Name of internal objective function to use, currently only min/max cost-based optimisation is available
-  operation: # Settings for operational mode
-    window: null
-    horizon: null
-    use_cap_results: false
-  spores_options: # settings for SPORES (spatially-explicit, practically optimal results) mode
-    spores_number: 3 # The number of SPORES to generate
-    slack: 0.1 # The fraction above the cost-optimal cost to set the maximum cost during SPORES
-    score_cost_class: spores_score # The cost class to optimise against when generating SPORES
-    objective_cost_class: { spores_score: 1, monetary: 0 } # The updated cost class weightings inthe objective when running SPORES
-    slack_cost_group: null # The group constraint name in which the `cost_max` constraint is assigned, for use alongside the slack and cost-optimal cost
-    save_per_spore: false # whether or not to save each SPORE run results separately or as one concatenated NetCDF. If True, "save_per_spore_path" or CLI argument "--to_netcdf" must be defined (to_netcdf will take precendence and be used a the directory name).
-    save_per_spore_path: null # file path for each spore run, which will be used if save_per_spore is used, and CLI command "--to_netcdf" is not defined. Will apply spore number using the python "format" method, so the path should include a "{}" at the position where the spore number should be included (e.g. "/path/to/spores/spore_{}.nc" will save results for SPORE 1 to "/path/to/spores/spore_1.nc"). The cost-optimal solution will be saved by using spore number 0.
-    skip_cost_op: false # whether or not to run the initial cost optimisation model to ascertain the cost-optimal cost and initial spores scores. If True, will take the group constraint and cost_flow_cap values directly.
-  save_logs: null # Directory into which to save logs and temporary files. Also turns on symbolic solver labels in the Pyomo backend
-  solver_io: null # What method the Pyomo backend should use to communicate with the solver
-  solver_options: null # A list of options, which are passed on to the chosen solver, and are therefore solver-dependent
-  solver: cbc # Which solver to use
-  zero_threshold: 1e-10 # Any value coming out of the backend that is smaller than this threshold (due to floating point errors, probably) will be set to zero
+config:
+  init:
+    name: null # Model name
+    calliope_version: null # Calliope framework version this model is intended for
+    random_seed: null # Seed for random number generator used during clustering
+    subset_time: null # Subset of timesteps as a two-element list giving the range, e.g. ['2005-01-01', '2005-01-05'], or a single string, e.g. '2005-01'
+    time: null # Optional settings to adjust time resolution, see :ref:`time_clustering` for the available options
+    timeseries_data_path: null # Path to time series data
+    timeseries_dateformat: "ISO8601" # Timestamp format of all time series data when read from file
+    custom_math: [] # List of references to files which contain custom mathematical formulations. If referring to an in-built Calliope custom math file (see documentation for available files), do not append the reference with ".yaml". If referring to your own custom math file, ensure the file type is given as a suffix (".yaml" or ".yml"). Relative paths will be assumed to be relative to the `config` file given when creating a calliope Model (`calliope.Model(config)`)
+  build:
+    backend: pyomo
+    cyclic_storage: true
+    ensure_feasibility: false
+    mode: plan
+    objective: minmax_cost_optimisation # Name of internal objective function to use, currently only min/max cost-based optimisation is available
+  solve:
+    operate_window: null
+    operate_horizon: null
+    operate_use_cap_results: false
+    spores_number: 3
+    spores_score_cost_class: spores_score
+    spores_slack_cost_group: null
+    spores_save_per_spore: false
+    spores_save_per_spore_path: null
+    spores_skip_cost_op: false
+    save_logs: null
+    solver_io: null
+    solver_options: null
+    solver: cbc
+    zero_threshold: 1e-10
 
-model:
-  calliope_version: null # Calliope framework version this model is intended for
-  name: null # Model name
-  random_seed: null # Seed for random number generator used during clustering
-  reserve_margin: {} # Per-carrier system-wide reserve margins
-  subset_time: null # Subset of timesteps as a two-element list giving the range, e.g. ['2005-01-01', '2005-01-05'], or a single string, e.g. '2005-01'
-  time: {} # Optional settings to adjust time resolution, see :ref:`time_clustering` for the available options
-  timeseries_data_path: null # Path to time series data
-  timeseries_data: null # Dict of dataframes with time series data (when passing in dicts rather than YAML files to Model constructor)
-  timeseries_dateformat: "ISO8601" # Timestamp format of all time series data when read from file. "ISO8601" means "YYYY-mm-dd HH:MM:SS".
-  file_allowed: [
-      "clustering_func",
-      "flow_eff",
-      "flow_ramping",
-      "export",
-      "om_con",
-      "om_prod",
-      "parasitic_eff",
-      "sink_min",
-      "sink_max",
-      "sink_equals",
-      "source_min",
-      "source_max",
-      "source_equals",
-      "source_eff",
-      "storage_loss",
-      "carrier_ratios",
-    ] # List of configuration options allowed to specify "file=" to load timeseries data. This can be updated if you're adding a new custom constraint that requires a newly defined parameter to be a timeseries. If updating existing parameters, you can expect existing constraints to not change behaviour or to break on being constructed.
-  custom_math: [] # List of references to files which contain custom mathematical formulations. If referring to an in-built Calliope custom math file (see documentation for available files), do not append the reference with ".yaml". If referring to your own custom math file, ensure the file type is given as a suffix (".yaml" or ".yml"). Relative paths will be assumed to be relative to the `config` file given when creating a calliope Model (`calliope.Model(config)`)
+parameters:
+  bigM:
+    data: 1e9
+  objective_cost_class:
+    data: { "monetary": 1 }
+    dims: costs
+  spores_slack:
+    data: 0.1
+  spores_objective_cost_class:
+    data:
+      spores_score: 1
+      monetary: 0
+    dims: costs
 
 ##
 # Base technology groups

--- a/src/calliope/config/defaults.yaml
+++ b/src/calliope/config/defaults.yaml
@@ -40,18 +40,13 @@ config:
     solver: cbc
     zero_threshold: 1e-10
 
+
 parameters:
   bigM:
     data: 1e9
   objective_cost_class:
-    data: { "monetary": 1 }
-    dims: costs
-  spores_slack:
-    data: 0.1
-  spores_objective_cost_class:
-    data:
-      spores_score: 1
-      monetary: 0
+    data: 1
+    index: [monetary]
     dims: costs
 
 ##

--- a/src/calliope/core/model.py
+++ b/src/calliope/core/model.py
@@ -10,11 +10,14 @@ Implements the core Model class.
 """
 from __future__ import annotations
 
+import importlib
 import logging
 import warnings
+from copy import deepcopy
 from pathlib import Path
-from typing import Callable, Literal, Optional, TypeVar, Union
+from typing import Callable, Optional, TypeVar, Union
 
+import pandas as pd
 import xarray
 
 import calliope
@@ -52,16 +55,15 @@ class Model(object):
     """
 
     _BACKENDS: dict[str, Callable] = {"pyomo": PyomoBackendModel}
-    _MATH_SCHEMA = AttrDict.from_yaml(
-        Path(calliope.__file__).parent / "config" / "math_schema.yaml"
-    )
 
     def __init__(
         self,
-        config: Optional[Union[str, dict]],
+        model_definition: Optional[Union[str, dict]] = None,
         model_data: Optional[xarray.Dataset] = None,
         debug: bool = False,
-        *args,
+        scenario: Optional[str] = None,
+        override_dict: Optional[dict] = None,
+        timeseries_dataframes: Optional[dict[str, pd.DataFrame]] = None,
         **kwargs,
     ):
         """
@@ -79,40 +81,50 @@ class Model(object):
             debug (bool, optional):
                 If True, additional debug data will be included in the built model.
                 Defaults to False.
-
-        Keyword Args:
-            timeseries_dataframes (dict[str, pd.DataFrame]):
-                If supplying `config` as a dictionary, in-memory timeseries data can be referred to using `df=...`.
-                The referenced data must be supplied here as a dicitionary of dataframes.
             scenario (str):
                 Comma delimited string of pre-defined `scenarios` to apply to the model,
             override_dict (dict):
                 Additional overrides to apply to `config`.
                 These will be applied *after* applying any defined `scenario` overrides.
+            timeseries_dataframes (dict[str, pd.DataFrame], optional):
+                If supplying `config` as a dictionary, in-memory timeseries data can be referred to using `df=...`.
+                The referenced data must be supplied here as a dicitionary of dataframes.
+                Defaults to None.
 
         Raises:
             ValueError: `config` must be provided (as one of `str`, `int`, `None`).
         """
         self._timings: dict = {}
         self.defaults: AttrDict
-        self.model_config: AttrDict
-        self.run_config: AttrDict
+        self.config: AttrDict
         self.math: AttrDict
-        self._config_path: Optional[str]
-        self.math_documentation = MathDocumentation(self._build)
+        self._model_def_path: Optional[str]
+        self.math_documentation = MathDocumentation()
 
         # try to set logging output format assuming python interactive. Will
         # use CLI logging format if model called from CLI
         log_time(LOGGER, self._timings, "model_creation", comment="Model: initialising")
-        if isinstance(config, str):
-            self._config_path = config
-            model_run, debug_data = model_run_from_yaml(config, *args, **kwargs)
+        if isinstance(model_definition, str):
+            self._model_def_path = model_definition
+            model_run, debug_data = model_run_from_yaml(
+                model_definition,
+                scenario,
+                override_dict,
+                timeseries_dataframes,
+                **kwargs,
+            )
             self._init_from_model_run(model_run, debug_data, debug)
-        elif isinstance(config, dict):
-            self._config_path = None
-            model_run, debug_data = model_run_from_dict(config, *args, **kwargs)
+        elif isinstance(model_definition, dict):
+            self._model_def_path = None
+            model_run, debug_data = model_run_from_dict(
+                model_definition,
+                scenario,
+                override_dict,
+                timeseries_dataframes,
+                **kwargs,
+            )
             self._init_from_model_run(model_run, debug_data, debug)
-        elif model_data is not None and config is None:
+        elif model_data is not None and model_definition is None:
             self._init_from_model_data(model_data)
         else:
             # expected input is a string pointing to a YAML file of the run
@@ -121,6 +133,10 @@ class Model(object):
             raise ValueError(
                 "Input configuration must either be a string or a dictionary."
             )
+
+    @property
+    def name(self):
+        return self._model_data.attrs["name"]
 
     def _init_from_model_run(
         self, model_run: calliope.AttrDict, debug_data: calliope.AttrDict, debug: bool
@@ -162,20 +178,19 @@ class Model(object):
         )
 
         # Ensure model and run attributes of _model_data update themselves
-        model_config = {
-            k: v for k, v in model_run.get("model", {}).items() if k != "file_allowed"
-        }
+        init_config = model_run.config.pop("init")
+        build_solve_config = model_run.config
 
-        self._add_observed_dict("model_config", model_config)
-        self._add_observed_dict("run_config", model_run["run"])
+        self._add_observed_dict("config", build_solve_config)
         self._add_observed_dict("defaults", self._generate_default_dict())
 
-        math = self._add_math(model_config["custom_math"])
+        math = self._add_math(init_config.custom_math)
         self._add_observed_dict("math", math)
 
         self.inputs = self._model_data.filter_by_attrs(is_result=0)
         self.math_documentation.inputs = self._model_data
 
+        self._model_data.attrs["name"] = init_config["name"]
         log_time(
             LOGGER,
             self._timings,
@@ -220,8 +235,7 @@ class Model(object):
         """
         self.inputs = self._model_data.filter_by_attrs(is_result=0)
         self.results = self._model_data.filter_by_attrs(is_result=1)
-        self._add_observed_dict("model_config")
-        self._add_observed_dict("run_config")
+        self._add_observed_dict("config")
         self._add_observed_dict("math")
 
         self.inputs = self._model_data.filter_by_attrs(is_result=0)
@@ -291,7 +305,7 @@ class Model(object):
             if not f"{filename}".endswith((".yaml", ".yml")):
                 yaml_filepath = math_dir / f"{filename}.yaml"
             else:
-                yaml_filepath = Path(relative_path(self._config_path, filename))
+                yaml_filepath = Path(relative_path(self._model_def_path, filename))
 
             if not yaml_filepath.is_file():
                 file_errors.append(filename)
@@ -304,6 +318,7 @@ class Model(object):
             raise exceptions.ModelError(
                 f"Attempted to load custom math that does not exist: {file_errors}"
             )
+        self._model_data.attrs["applied_custom_math"] = custom_math
         return base_math
 
     def _generate_default_dict(self) -> AttrDict:
@@ -335,26 +350,7 @@ class Model(object):
             }
         )
 
-    def _add_run_mode_custom_math(self) -> None:
-        """If not given in the custom_math list, override model math with run mode math"""
-        run_mode = self.run_config["mode"]
-        # FIXME: available modes should not be hardcoded here.
-        # They should come from a YAML schema.
-        not_run_mode = {"plan", "operate", "spores"}.difference([run_mode])
-        run_mode_mismatch = not_run_mode.intersection(self.model_config["custom_math"])
-        if run_mode_mismatch:
-            exceptions.warn(
-                f"Running in {run_mode} mode, but run mode(s) {run_mode_mismatch} custom "
-                "math being loaded from file via the model configuration"
-            )
-
-        if run_mode != "plan" and run_mode not in self.model_config["custom_math"]:
-            filepath = Path(calliope.__file__).parent / "math" / f"{run_mode}.yaml"
-            self.math.union(AttrDict.from_yaml(filepath), allow_override=True)
-
-    def build(
-        self, force: bool = False, backend_interface: Literal["pyomo"] = "pyomo"
-    ) -> None:
+    def build(self, force: bool = False, **kwargs) -> None:
         """Build description of the optimisation problem in the chosen backend interface.
 
         Args:
@@ -370,41 +366,13 @@ class Model(object):
                 "This model object already has a built optimisation problem. Use model.build(force=True) "
                 "to force the existing optimisation problem to be overwritten with a new one."
             )
-        backend = self._BACKENDS[backend_interface](self._model_data)
-        self.backend = self._build(backend)
+        backend_name = kwargs.get("backend", self.config.build.backend)
 
-    def _build(self, backend: T) -> T:
-        log_time(
-            LOGGER,
-            self._timings,
-            "backend_parameters_generated",
-            comment="Model: Generated optimisation problem parameters",
-        )
-        self._add_run_mode_custom_math()
-        validate_dict(self.math, self._MATH_SCHEMA, "math")
-        # The order of adding components matters!
-        # 1. Variables, 2. Global Expressions, 3. Constraints, 4. Objectives
-        for components in [
-            "variables",
-            "global_expressions",
-            "constraints",
-            "objectives",
-        ]:
-            component = components.removesuffix("s")
-            if components in ["variables", "global_expressions"]:
-                backend.valid_math_element_names.update(self.math[components].keys())
-            for name in self.math[components]:
-                getattr(backend, f"add_{component}")(name)
+        backend = self._BACKENDS[backend_name](self._model_data, **kwargs)
+        backend._build()
+        self.backend = backend
 
-            log_time(
-                LOGGER,
-                self._timings,
-                f"backend_{components}_generated",
-                comment=f"Model: Generated optimisation problem {components}",
-            )
-        return backend
-
-    def solve(self, force: bool = False, warmstart: bool = False) -> None:
+    def solve(self, force: bool = False, warmstart: bool = False, **kwargs) -> None:
         """
         Run the built optimisation problem.
 
@@ -426,7 +394,9 @@ class Model(object):
             exceptions.ModelError: Cannot run the model if there are already results loaded, unless `force` is True.
             exceptions.ModelError: Some preprocessing steps will stop a run mode of "operate" from being possible.
         """
-        run_mode = self.run_config["mode"]
+        run_mode = self.config.build.mode
+        solver_config = deepcopy(self.config.solve)
+        solver_config.union(AttrDict(kwargs), allow_override=True)
 
         # Check that results exist and are non-empty
         if not hasattr(self, "backend"):
@@ -461,10 +431,10 @@ class Model(object):
         )
 
         termination_condition = self.backend.solve(
-            solver=self.run_config["solver"],
-            solver_io=self.run_config.get("solver_io", None),
-            solver_options=self.run_config.get("solver_options", None),
-            save_logs=self.run_config.get("save_logs", None),
+            solver=solver_config["solver"],
+            solver_io=solver_config["solver_io"],
+            solver_options=solver_config["solver_options"],
+            save_logs=solver_config["save_logs"],
             warmstart=warmstart,
         )
 
@@ -560,7 +530,7 @@ class Model(object):
             str: Basic description of the model.
         """
         info_strings = []
-        model_name = self.model_config.get("name", "None")
+        model_name = self.name
         info_strings.append(f"Model name:   {model_name}")
         msize = dict(self._model_data.dims)
         msize_exists = (self._model_data.node_tech * self._model_data.carrier).sum()
@@ -593,8 +563,10 @@ class Model(object):
             If all components of the dictionary are parsed successfully, this function will log a success message to the INFO logging level and return None.
             Otherwise, a calliope.ModelError will be raised with parsing issues listed.
         """
-
-        validate_dict(math_dict, self._MATH_SCHEMA, "math")
+        math_schema = AttrDict.from_yaml(
+            importlib.resources.files("calliope") / "config" / "math_schema.yaml"
+        )
+        validate_dict(math_dict, math_schema, "math")
         valid_math_element_names = [
             *self.math["variables"].keys(),
             *self.math["global_expressions"].keys(),
@@ -602,9 +574,6 @@ class Model(object):
             *math_dict.get("global_expressions", {}).keys(),
             *self.inputs.data_vars.keys(),
             *self.defaults.keys(),
-            # FIXME: these should not be hardcoded, but rather end up in model data keys
-            "bigM",
-            *["objective_" + k for k in self.run_config["objective_options"].keys()],
         ]
         collected_errors: dict = dict()
         for component_group, component_dicts in math_dict.items():

--- a/src/calliope/example_models/national_scale/model.yaml
+++ b/src/calliope/example_models/national_scale/model.yaml
@@ -4,27 +4,27 @@ import: # Import other files from paths relative to this file, or absolute paths
   - "scenarios.yaml" # Scenario and override group definitions
 
 # Model configuration: all settings that affect the built model
-model:
-  name: National-scale example model
+config:
+  init:
+    name: National-scale example model
+    # What version of Calliope this model is intended for
+    calliope_version: 0.7.0
+    # Time series data path - can either be a path relative to this file, or an absolute path
+    timeseries_data_path: "timeseries_data"
+    subset_time: ["2005-01-01", "2005-01-05"] # Subset of timesteps
 
-  # What version of Calliope this model is intended for
-  calliope_version: 0.7.0
+  build:
+    ensure_feasibility: true # Switches on the "unmet demand" constraint
+    mode: plan # Choices: plan, operate
 
-  # Time series data path - can either be a path relative to this file, or an absolute path
-  timeseries_data_path: "timeseries_data"
+  solve:
+    solver: cbc
+    zero_threshold: 1e-10 # Any value coming out of the backend that is smaller than this (due to floating point errors, probably) will be set to zero
 
-  subset_time: ["2005-01-01", "2005-01-05"] # Subset of timesteps
+parameters:
+  objective_cost_class:
+    data: { monetary: 1 }
+    dims: costs
 
-# Run configuration: all settings that affect how the built model is run
-run:
-  solver: cbc
-
-  ensure_feasibility: true # Switches on the "unmet demand" constraint
-
-  bigM: 1e6 # Sets the scale of unmet demand, which cannot be too high, otherwise the optimisation will not converge
-
-  zero_threshold: 1e-10 # Any value coming out of the backend that is smaller than this (due to floating point errors, probably) will be set to zero
-
-  mode: plan # Choices: plan, operate
-
-  objective_options.cost_class: { monetary: 1 }
+  bigM:
+    data: 1e6 # Sets the scale of unmet demand, which cannot be too high, otherwise the optimisation will not converge

--- a/src/calliope/example_models/national_scale/model.yaml
+++ b/src/calliope/example_models/national_scale/model.yaml
@@ -23,7 +23,8 @@ config:
 
 parameters:
   objective_cost_class:
-    data: { monetary: 1 }
+    data: 1
+    index: [monetary]
     dims: costs
 
   bigM:

--- a/src/calliope/example_models/national_scale/scenarios.yaml
+++ b/src/calliope/example_models/national_scale/scenarios.yaml
@@ -40,10 +40,16 @@ overrides:
       solve:
         spores_score_cost_class: "spores_score"
         spores_number: 3
-        spores_objective_cost_class: { "monetary": 0, "spores_score": 1 }
     parameters:
-      spores_slack: 0.1
-      objective_cost_class.data: { "monetary": 1, "spores_score": 0 }
+      spores_slack:
+        data: 0.1
+      objective_cost_class:
+        data: [1, 0]
+        index: ["monetary", "spores_score"]
+      spores_objective_cost_class:
+        data: [1, 0]
+        index: [spores_score, monetary]
+        dims: costs
     # FIXME: replace group constraint in SPORES mode
     # group_constraints:
     #    systemwide_cost_max.cost_max.monetary: 1e10  # very large, non-infinite value
@@ -103,7 +109,8 @@ overrides:
       # forcing enough installed capacity to cover demand in
       # the maximum demand timestep
       reserve_margin:
-        data: { power: 0.10 } # 10% reserve margin for power
+        data: 0.10 # 10% reserve margin for power
+        index: power
         dims: carriers
 
   ##

--- a/src/calliope/example_models/national_scale/scenarios.yaml
+++ b/src/calliope/example_models/national_scale/scenarios.yaml
@@ -10,35 +10,40 @@ scenarios:
 ##
 overrides:
   profiling:
-    model.name: "National-scale example model (profiling run)"
-    model.subset_time: ["2005-01-01", "2005-01-15"]
-    run.solver: cbc
+    config:
+      init.name: "National-scale example model (profiling run)"
+      init.subset_time: ["2005-01-01", "2005-01-15"]
+      solve.solver: cbc
 
   time_resampling:
-    model.name: "National-scale example model with time resampling"
-    model.subset_time: ["2005-01", "2005-01"]
-    # Resample time resolution to 6-hourly
-    model.time: { function: resample, function_options: { "resolution": "6H" } }
+    config:
+      init:
+        name: "National-scale example model with time resampling"
+        subset_time: ["2005-01", "2005-01"]
+        # Resample time resolution to 6-hourly
+        time: { function: resample, function_options: { "resolution": "6H" } }
 
   time_clustering:
-    model.random_seed: 23
-    model.name: "National-scale example model with time clustering"
-    model.subset_time: null # No time subsetting
-    # Cluster timesteps using k-means
-    model.time:
-      {
-        function: apply_clustering,
-        function_options: { clustering_func: "kmeans", how: "closest", k: 10 },
-      }
+    config:
+      init:
+        random_seed: 23
+        name: "National-scale example model with time clustering"
+        subset_time: null # No time subsetting
+        # Cluster timesteps using k-means
+        time:
+          function: apply_clustering
+          function_options: { clustering_func: "kmeans", how: "closest", k: 10 }
 
   spores:
-    run.mode: spores
-    run.spores_options:
-      score_cost_class: "spores_score"
-      slack: 0.1
-      spores_number: 3
-      objective_cost_class: { "monetary": 0, "spores_score": 1 }
-    run.objective_options.cost_class: { "monetary": 1, "spores_score": 0 }
+    config:
+      build.mode: spores
+      solve:
+        spores_score_cost_class: "spores_score"
+        spores_number: 3
+        spores_objective_cost_class: { "monetary": 0, "spores_score": 1 }
+    parameters:
+      spores_slack: 0.1
+      objective_cost_class.data: { "monetary": 1, "spores_score": 0 }
     # FIXME: replace group constraint in SPORES mode
     # group_constraints:
     #    systemwide_cost_max.cost_max.monetary: 1e10  # very large, non-infinite value
@@ -53,11 +58,12 @@ overrides:
     techs.ac_transmission.costs.spores_score.interest_rate: 1
 
   operate:
-    run.mode: operate
-    run.operation:
-      window: 12
-      horizon: 24
-    model.subset_time: ["2005-01-01", "2005-01-10"]
+    config:
+      init.subset_time: ["2005-01-01", "2005-01-10"]
+      build.mode: operate
+      solve:
+        operate_window: 12
+        operate_horizon: 24
     nodes:
       region1.techs.ccgt.constraints.flow_cap_equals: 30000
 
@@ -83,31 +89,33 @@ overrides:
       region1,region1-3.techs.free_transmission.constraints.flow_cap_equals: 2281
 
   check_feasibility:
-    run:
-      ensure_feasibility: False
-      objective: "check_feasibility"
-    model:
-      subset_time: ["2005-01-04", "2005-01-04"]
+    config:
+      build:
+        ensure_feasibility: False
+        objective: "check_feasibility"
+      init:
+        subset_time: ["2005-01-04", "2005-01-04"]
 
   reserve_margin:
-    model:
+    parameters:
       # Model-wide settings for the system-wide reserve margin
       # Even setting a reserve margin of zero activates the constraint,
       # forcing enough installed capacity to cover demand in
       # the maximum demand timestep
       reserve_margin:
-        power: 0.10 # 10% reserve margin for power
+        data: { power: 0.10 } # 10% reserve margin for power
+        dims: carriers
 
   ##
   # Overrides to demonstrate the run generator ("calliope generate_runs")
   ##
 
   run1:
-    model.subset_time: ["2005-01-01", "2005-01-31"]
+    config.init.subset_time: ["2005-01-01", "2005-01-31"]
   run2:
-    model.subset_time: ["2005-02-01", "2005-02-31"]
+    config.init.subset_time: ["2005-02-01", "2005-02-31"]
   run3:
-    model.subset_time: ["2005-01-01", "2005-01-31"]
+    config.init.subset_time: ["2005-01-01", "2005-01-31"]
     nodes.region1.techs.ccgt.constraints.flow_cap_max: 0 # Disallow CCGT
   run4:
     subset_time: ["2005-02-01", "2005-02-31"]
@@ -158,9 +166,8 @@ overrides:
   #                         flow_cap_max: 100000  # Increased to keep model feasible
 
   minimize_emissions_costs:
-    run:
-      objective_options:
-        cost_class: { "emissions": 1, "monetary": 0 }
+    parameters:
+      objective_cost_class.data: { "emissions": 1, "monetary": 0 }
     techs:
       ccgt:
         costs:
@@ -172,9 +179,8 @@ overrides:
             om_prod: 10 # kgCO2/kWh
 
   maximize_utility_costs:
-    run:
-      objective_options:
-        cost_class: { "utility": -1, "monetary": 0 }
+    parameters:
+      objective_cost_class.data: { "utility": -1, "monetary": 0 }
     techs:
       ccgt:
         costs:

--- a/src/calliope/example_models/urban_scale/model.yaml
+++ b/src/calliope/example_models/urban_scale/model.yaml
@@ -3,24 +3,25 @@ import: # Import other files from paths relative to this file, or absolute paths
   - "model_config/locations.yaml"
   - "scenarios.yaml"
 
-model:
-  name: Urban-scale example model
+config:
+  init:
+    name: Urban-scale example model
+    # What version of Calliope this model is intended for
+    calliope_version: 0.7.0
+    # Time series data path - can either be a path relative to this file, or an absolute path
+    timeseries_data_path: "timeseries_data"
+    subset_time: ["2005-07-01", "2005-07-02"] # Subset of timesteps
 
-  # What version of Calliope this model is intended for
-  calliope_version: 0.7.0
+  build:
+    mode: plan # Choices: plan, operate
+    ensure_feasibility: true # Switching on unmet demand
 
-  # Time series data path - can either be a path relative to this file, or an absolute path
-  timeseries_data_path: "timeseries_data"
+  solve:
+    solver: cbc
 
-  subset_time: ["2005-07-01", "2005-07-02"] # Subset of timesteps
-
-run:
-  mode: plan # Choices: plan, operate
-
-  solver: cbc
-
-  ensure_feasibility: true # Switching on unmet demand
-
-  bigM: 1e6 # setting the scale of unmet demand, which cannot be too high, otherwise the optimisation will not converge
-
-  objective_options.cost_class: { monetary: 1 }
+parameters:
+  objective_cost_class:
+    data: { monetary: 1 }
+    dims: costs
+  bigM:
+    data: 1e6 # setting the scale of unmet demand, which cannot be too high, otherwise the optimisation will not converge

--- a/src/calliope/example_models/urban_scale/model.yaml
+++ b/src/calliope/example_models/urban_scale/model.yaml
@@ -21,7 +21,8 @@ config:
 
 parameters:
   objective_cost_class:
-    data: { monetary: 1 }
+    data: 1
+    index: [monetary]
     dims: costs
   bigM:
     data: 1e6 # setting the scale of unmet demand, which cannot be too high, otherwise the optimisation will not converge

--- a/src/calliope/example_models/urban_scale/scenarios.yaml
+++ b/src/calliope/example_models/urban_scale/scenarios.yaml
@@ -4,8 +4,9 @@
 
 overrides:
   milp:
-    model.name: "Urban-scale example model with MILP"
-    run.solver_options.mipgap: 0.05
+    config:
+      init.name: "Urban-scale example model with MILP"
+      solve.solver_options: { mipgap: 0.05 }
     techs:
       # chp-start
       chp:
@@ -47,11 +48,13 @@ overrides:
       N1,X3.techs.heat_pipes.distance: 4
 
   operate:
-    run.mode: operate
-    run.operation:
-      window: 24
-      horizon: 48
-    model.subset_time: ["2005-07-01", "2005-07-10"]
+    config:
+      init.subset_time: ["2005-07-01", "2005-07-10"]
+      build.mode: operate
+      solve:
+        operate_window: 24
+        operate_horizon: 48
+
     nodes:
       X1:
         techs:
@@ -80,17 +83,19 @@ overrides:
       N1,X3.techs.heat_pipes.constraints.flow_cap_max: 320
 
   time_masking:
-    model.name: "Urban-scale example model with time masking"
-    model.subset_time: ["2005-01", "2005-01"]
-    # Resample time resolution to 6-hourly
-    model.time:
-      masks:
-        - function: extreme_diff
-          options:
-            tech0: demand_heat
-            tech1: demand_electricity
-            how: max
-            n: 2
-            var: sink_equals
-      function: resample
-      function_options: { resolution: 6H }
+    config:
+      init:
+      name: "Urban-scale example model with time masking"
+      subset_time: ["2005-01", "2005-01"]
+      # Resample time resolution to 6-hourly
+      time:
+        masks:
+          - function: extreme_diff
+            options:
+              tech0: demand_heat
+              tech1: demand_electricity
+              how: max
+              n: 2
+              var: sink_equals
+        function: resample
+        function_options: { resolution: 6H }

--- a/src/calliope/math/base.yaml
+++ b/src/calliope/math/base.yaml
@@ -175,9 +175,9 @@ constraints:
         - where: "NOT any(export_carrier, over=techs)"
           expression: "0"
       unmet_demand_and_unused_supply:
-        - where: "run.ensure_feasibility=True"
+        - where: "config.ensure_feasibility=True"
           expression: unmet_demand + unused_supply
-        - where: "NOT run.ensure_feasibility=True"
+        - where: "NOT config.ensure_feasibility=True"
           expression: "0"
 
   balance_supply:
@@ -259,11 +259,11 @@ constraints:
     sub_expressions:
       flow_out: *flow_out_with_parasitic
       storage_previous_step: &storage_previous_step
-        - where: timesteps=get_val_at_index(timesteps=0) AND NOT run.cyclic_storage=True
+        - where: timesteps=get_val_at_index(timesteps=0) AND NOT config.cyclic_storage=True
           expression: storage_initial * storage_cap
-        - where: ((timesteps=get_val_at_index(timesteps=0) AND run.cyclic_storage=True) OR NOT timesteps=get_val_at_index(timesteps=0)) AND NOT lookup_cluster_first_timestep=True
+        - where: ((timesteps=get_val_at_index(timesteps=0) AND config.cyclic_storage=True) OR NOT timesteps=get_val_at_index(timesteps=0)) AND NOT lookup_cluster_first_timestep=True
           expression: (1 - storage_loss) ** roll(timestep_resolution, timesteps=1) * roll(storage, timesteps=1)
-        - where: lookup_cluster_first_timestep=True AND NOT (timesteps=get_val_at_index(timesteps=0) AND NOT run.cyclic_storage=True)
+        - where: lookup_cluster_first_timestep=True AND NOT (timesteps=get_val_at_index(timesteps=0) AND NOT config.cyclic_storage=True)
           expression: (1 - storage_loss) ** select_from_lookup_arrays(timestep_resolution, timesteps=lookup_cluster_last_timestep) * select_from_lookup_arrays(storage, timesteps=lookup_cluster_last_timestep)
 
   source_availability_supply_plus:
@@ -295,7 +295,7 @@ constraints:
   set_storage_initial:
     description: "Fix the relationship between carrier stored in a `storage` technology at the start and end of the whole model period."
     foreach: [nodes, techs]
-    where: "storage AND storage_initial AND run.cyclic_storage=True"
+    where: "storage AND storage_initial AND config.cyclic_storage=True"
     equations:
       - expression: storage[timesteps=$final_step] * ((1 - storage_loss) ** timestep_resolution[timesteps=$final_step]) == storage_initial * storage_cap
     slices:
@@ -608,7 +608,7 @@ variables:
     description: "Virtual source of carrier flow to ensure model feasibility. This should only be considered a debugging rather than a modelling tool as it may distort the model in other ways due to the large impact it has on the objective function value. When present in a model in which it has been requested, it indicates an inability for technologies in the model to reach a sufficient combined supply capacity to meet demand."
     unit: energy
     foreach: [nodes, carriers, timesteps]
-    where: "run.ensure_feasibility=True"
+    where: "config.ensure_feasibility=True"
     bounds:
       min: 0
       max: .inf
@@ -617,21 +617,24 @@ variables:
     description: "Virtual sink of carrier flow to ensure model feasibility. This should only be considered a debugging rather than a modelling tool as it may distort the model in other ways due to the large impact it has on the objective function value. In model results, the negation of this variable is combined with `unmet_demand` and presented as only one variable: `unmet_demand`. When present in a model in which it has been requested, it indicates an inability for technologies in the model to reach a sufficient combined consumption capacity to meet required outflow (e.g. from renewables without the possibility of curtailment)."
     unit: energy
     foreach: [nodes, carriers, timesteps]
-    where: "run.ensure_feasibility=True"
+    where: "config.ensure_feasibility=True"
     bounds:
       min: -.inf
       max: 0
 
 objectives:
   minmax_cost_optimisation:
-    description: "Minimise the total cost of installing and operation all technologies in the system. If multiple cost classes are present (e.g., monetary and co2 emissions), the weighted sum of total costs is minimised. Cost class weights can be defined in `run.objective_options.cost_class`."
+    description: "Minimise the total cost of installing and operation all technologies in the system. If multiple cost classes are present (e.g., monetary and co2 emissions), the weighted sum of total costs is minimised. Cost class weights can be defined in `config.objective_options.cost_class`."
     equations:
-      - expression: sum(sum(cost, over=[nodes, techs]) * objective_cost_class, over=costs) + $unmet_demand
+      - where: "any(cost, over=[nodes, techs, costs])"
+        expression: sum(sum(cost, over=[nodes, techs]) * objective_cost_class, over=costs) + $unmet_demand
+      - where: "NOT any(cost, over=[nodes, techs, costs])"
+        expression: $unmet_demand
     sub_expressions:
       unmet_demand:
-        - where: "run.ensure_feasibility=True"
+        - where: "config.ensure_feasibility=True"
           expression: sum(sum(unmet_demand - unused_supply, over=[carriers, nodes])  * timestep_weights, over=timesteps) * bigM
-        - where: "NOT run.ensure_feasibility=True"
+        - where: "NOT config.ensure_feasibility=True"
           expression: "0"
     sense: minimise
 

--- a/src/calliope/math/operate.yaml
+++ b/src/calliope/math/operate.yaml
@@ -6,11 +6,13 @@ constraints:
   force_zero_area_use.active: false
   area_use_per_flow_capacity.active: false
   area_use_capacity_per_loc.active: false
-  flow_capacity_systemwide.active: false
+  flow_capacity_systemwide_max.active: false
+  flow_capacity_systemwide_min.active: false
   symmetric_transmission.active: false
   storage_capacity_units_milp.active: false
   flow_capacity_units_milp.active: false
-  unit_capacity_systemwide_milp.active: false
+  unit_capacity_max_systemwide_milp.active: false
+  unit_capacity_min_systemwide_milp.active: false
 
 variables:
   flow_cap.active: false

--- a/src/calliope/math/storage_inter_cluster.yaml
+++ b/src/calliope/math/storage_inter_cluster.yaml
@@ -7,11 +7,11 @@ constraints:
   balance_supply_plus_with_storage:
     sub_expressions:
       storage_previous_step: &storage_previous_step
-        - where: timesteps=get_val_at_index(timesteps=0) AND NOT run.cyclic_storage=True
+        - where: timesteps=get_val_at_index(timesteps=0) AND NOT config.cyclic_storage=True
           expression: storage_initial * storage_cap
-        - where: ((timesteps=get_val_at_index(timesteps=0) AND run.cyclic_storage=True) OR NOT timesteps=get_val_at_index(timesteps=0)) AND NOT lookup_cluster_last_timestep
+        - where: ((timesteps=get_val_at_index(timesteps=0) AND config.cyclic_storage=True) OR NOT timesteps=get_val_at_index(timesteps=0)) AND NOT lookup_cluster_last_timestep
           expression: (1 - storage_loss) ** roll(timestep_resolution, timesteps=1) * roll(storage, timesteps=1)
-        - where: lookup_cluster_last_timestep AND NOT (timesteps=get_val_at_index(timesteps=0) AND NOT run.cyclic_storage=True)
+        - where: lookup_cluster_last_timestep AND NOT (timesteps=get_val_at_index(timesteps=0) AND NOT config.cyclic_storage=True)
           expression: "0"
 
   balance_storage:
@@ -69,14 +69,14 @@ constraints:
       - expression: storage_inter_cluster == $storage_previous_step + $storage_intra
     sub_expressions:
       storage_previous_step:
-        - where: datesteps=get_val_at_index(datesteps=0) AND NOT run.cyclic_storage=True
+        - where: datesteps=get_val_at_index(datesteps=0) AND NOT config.cyclic_storage=True
           expression: storage_initial
-        - where: (datesteps=get_val_at_index(datesteps=0) AND run.cyclic_storage=True) OR NOT datesteps=get_val_at_index(datesteps=0)
+        - where: (datesteps=get_val_at_index(datesteps=0) AND config.cyclic_storage=True) OR NOT datesteps=get_val_at_index(datesteps=0)
           expression: ((1 - storage_loss) ** 24) * roll(storage_inter_cluster, datesteps=1)
       storage_intra:
-        - where: datesteps=get_val_at_index(datesteps=0) AND NOT run.cyclic_storage=True
+        - where: datesteps=get_val_at_index(datesteps=0) AND NOT config.cyclic_storage=True
           expression: "0"
-        - where: NOT (datesteps=get_val_at_index(datesteps=0) AND NOT run.cyclic_storage=True)
+        - where: NOT (datesteps=get_val_at_index(datesteps=0) AND NOT config.cyclic_storage=True)
           expression: storage[timesteps=$final_step]
     slices:
       final_step:

--- a/src/calliope/postprocess/results.py
+++ b/src/calliope/postprocess/results.py
@@ -42,7 +42,7 @@ def postprocess_model_results(results, model_data, timings):
     """
     log_time(logger, timings, "post_process_start", comment="Postprocessing: started")
 
-    run_config = model_data.attrs["run_config"]
+    zero_threshold = model_data.config.solve.zero_threshold
     results["capacity_factor"] = capacity_factor(results, model_data)
     results["systemwide_capacity_factor"] = capacity_factor(
         results, model_data, systemwide=True
@@ -53,7 +53,7 @@ def postprocess_model_results(results, model_data, timings):
     results["total_levelised_cost"] = systemwide_levelised_cost(
         results, model_data, total=True
     )
-    results = clean_results(results, run_config.get("zero_threshold", 0), timings)
+    results = clean_results(results, zero_threshold, timings)
 
     for var_data in results.data_vars.values():
         if "is_result" not in var_data.attrs.keys():

--- a/src/calliope/preprocess/checks.py
+++ b/src/calliope/preprocess/checks.py
@@ -298,22 +298,18 @@ def check_initial(config_model: AttrDict):
             "(i.e. `one_way: true`).".format(tech_end, ", ".join(duplicated_techs))
         )
 
-    # We no longer allow cost_class in objective_obtions to be a string
+    # We no longer allow cost_class in objective_options to be a string
     _cost_class = config_model.parameters.objective_cost_class
 
-    if not isinstance(_cost_class.data, dict):
-        errors.append(
-            "`parameters.objective_cost_class` must be a dictionary."
-            "If you want to minimise or maximise with a single cost class, "
-            'use e.g. "{"costs": {monetary: 1}}", which gives the monetary cost class a weight '
-            "of 1 in the objective, and ignores any other cost classes."
-        )
+    if not isinstance(_cost_class.data, list):
+        _data = [_cost_class.data]
     else:
-        for _class, _val in _cost_class.data.as_dict_flat().items():
-            if not isinstance(_val, (int, float)):
-                errors.append(
-                    f"Objective cost class weights must be numeric, received {_class}:{_val}"
-                )
+        _data = _cost_class.data
+    for _val in _data:
+        if not isinstance(_val, (int, float)):
+            errors.append(
+                f"Objective cost class weights must be numeric, received:{_val}"
+            )
 
     return model_warnings, errors
 

--- a/src/calliope/preprocess/model_run.py
+++ b/src/calliope/preprocess/model_run.py
@@ -13,7 +13,7 @@ AttrDict, and building of associated debug information.
 import itertools
 import logging
 import os
-import warnings
+from typing import Optional
 
 import pandas as pd
 
@@ -42,7 +42,7 @@ _DEFAULT_PALETTE = [
 
 
 def model_run_from_yaml(
-    model_file, timeseries_dataframes=None, scenario=None, override_dict=None
+    model_file, scenario=None, override_dict=None, timeseries_dataframes=None, **kwargs
 ):
     """
     Generate processed ModelRun configuration from a
@@ -64,11 +64,12 @@ def model_run_from_yaml(
 
     """
     config = AttrDict.from_yaml(model_file)
-    config.config_path = model_file
+    config._model_def_path = model_file
 
     config_with_overrides, debug_comments, overrides, scenario = apply_overrides(
         config, scenario=scenario, override_dict=override_dict
     )
+    config_with_overrides.union(AttrDict({"config.init": kwargs}), allow_override=True)
 
     return generate_model_run(
         config_with_overrides,
@@ -80,7 +81,7 @@ def model_run_from_yaml(
 
 
 def model_run_from_dict(
-    config_dict, timeseries_dataframes=None, scenario=None, override_dict=None
+    config_dict, scenario=None, override_dict=None, timeseries_dataframes=None, **kwargs
 ):
     """
     Generate processed ModelRun configuration from a
@@ -104,11 +105,12 @@ def model_run_from_dict(
         config = AttrDict(config_dict)
     else:
         config = config_dict
-    config.config_path = None
+    config._model_def_path = None
 
     config_with_overrides, debug_comments, overrides, scenario = apply_overrides(
         config, scenario=scenario, override_dict=override_dict
     )
+    config_with_overrides.union(AttrDict({"config.init": kwargs}), allow_override=True)
 
     return generate_model_run(
         config_with_overrides,
@@ -140,13 +142,13 @@ def combine_overrides(config_model, overrides):
     return override_dict
 
 
-def apply_overrides(config, scenario=None, override_dict=None):
+def apply_overrides(model_dict, scenario=None, override_dict=None):
     """
     Generate processed Model configuration, applying any scenarios overrides.
 
     Parameters
     ----------
-    config : AttrDict
+    model_dict : AttrDict
         a model configuration AttrDict
     scenario : str, optional
     override_dict : str or dict or AttrDict, optional
@@ -155,24 +157,19 @@ def apply_overrides(config, scenario=None, override_dict=None):
     """
     debug_comments = AttrDict()
 
-    config_model = AttrDict.from_yaml(
+    default_model_dict = AttrDict.from_yaml(
         os.path.join(os.path.dirname(calliope.__file__), "config", "defaults.yaml")
     )
 
     # Interpret timeseries_data_path as relative
-    if "timeseries_data_path" in config.model:
-        config.model.timeseries_data_path = relative_path(
-            config.config_path, config.model.timeseries_data_path
+    if "timeseries_data_path" in model_dict.config.init:
+        model_dict.config.init.timeseries_data_path = relative_path(
+            model_dict._model_def_path, model_dict.config.init.timeseries_data_path
         )
 
-    # FutureWarning: check if config includes an explicit objective cost class.
-    # Added in 0.6.4-dev, to be removed in v0.7.0-dev.
-    has_explicit_cost_class = isinstance(
-        config.get_key("run.objective_options.cost_class", None), dict
-    )
-
     # The input files are allowed to override other model defaults
-    config_model.union(config, allow_override=True)
+    default_model_dict.union(model_dict, allow_override=True)
+    config_model = default_model_dict.copy()
 
     # First pass of applying override dict before applying scenarios,
     # so that can override scenario definitions by override_dict
@@ -184,13 +181,6 @@ def apply_overrides(config, scenario=None, override_dict=None):
 
         warning_messages = checks.check_overrides(config_model, override_dict)
         exceptions.print_warnings_and_raise_errors(warnings=warning_messages)
-
-        # FutureWarning: If config does not include an explicit objective cost class, check override dict.
-        # Added in 0.6.4-dev, to be removed in v0.7.0-dev.
-        if has_explicit_cost_class is False:
-            has_explicit_cost_class = isinstance(
-                override_dict.get_key("run.objective_options.cost_class", None), dict
-            )
 
         config_model.union(override_dict, allow_override=True, allow_replacement=True)
 
@@ -211,16 +201,6 @@ def apply_overrides(config, scenario=None, override_dict=None):
         warning_messages = checks.check_overrides(config_model, overrides_from_scenario)
         exceptions.print_warnings_and_raise_errors(warnings=warning_messages)
 
-        # FutureWarning: If config nor override_dict include an explicit objective cost class, check scenario dict.
-        # Added in 0.6.4-dev, to be removed in v0.7.0-dev
-        if has_explicit_cost_class is False:
-            has_explicit_cost_class = isinstance(
-                overrides_from_scenario.get_key(
-                    "run.objective_options.cost_class", None
-                ),
-                dict,
-            )
-
         config_model.union(
             overrides_from_scenario, allow_override=True, allow_replacement=True
         )
@@ -237,19 +217,6 @@ def apply_overrides(config, scenario=None, override_dict=None):
             debug_comments.set_key(
                 "{}".format(k), "Overridden via override dictionary."
             )
-
-    # FutureWarning: raise cost class warning here.
-    # Warning that there will be no default cost class in 0.7.0 #
-    # Added in 0.6.4-dev, to be removed in v0.7.0-dev
-    if has_explicit_cost_class is False:
-        warnings.warn(
-            "There will be no default cost class for the objective function in "
-            'v0.7.0 (currently "monetary" with a weight of 1). '
-            "Explicitly specify the cost class(es) you would like to use "
-            'under `run.objective_options.cost_class`. E.g. `{"monetary": 1}` to '
-            "replicate the current default.",
-            FutureWarning,
-        )
 
     # Drop default nodes, links, and techs
     config_model.del_key("techs.default_tech")
@@ -468,8 +435,8 @@ def process_tech_groups(config_model, techs):
     return tech_groups
 
 
-def load_timeseries_from_file(config_model, tskey):
-    file_path = os.path.join(config_model.model.timeseries_data_path, tskey)
+def load_timeseries_from_file(timeseries_data_path, tskey):
+    file_path = os.path.join(timeseries_data_path, tskey)
     df = pd.read_csv(file_path, index_col=0)
     df.columns = pd.MultiIndex.from_product(
         [[tskey], df.columns], names=["source", "column"]
@@ -542,22 +509,24 @@ def _get_names(config):
     return set(tsnames), set(tsvars)
 
 
-def process_timeseries_data(config_model, model_run, timeseries_dataframes):
-    timeseries_data = config_model.model.get("timeseries_data", None)
-
-    dtformat = config_model.model["timeseries_dateformat"]
-
+def process_timeseries_data(
+    model_run: AttrDict,
+    timeseries_dfs: Optional[pd.DataFrame],
+    timeseries_data_path: Optional[str],
+    time_config: Optional[AttrDict],
+    subset_time_config: Optional[list[str]],
+    datetime_format: str,
+):
     # Generate set of all files and dataframes we want to load
-    node_config = model_run.nodes.as_dict_flat()
-    model_config = config_model.model.as_dict_flat()
-
-    constraint_tsnames, constraint_tsvars = _get_names(node_config)
-    cluster_tsnames, cluster_tsvars = _get_names(model_config)
+    constraint_tsnames, constraint_tsvars = _get_names(model_run.nodes.as_dict_flat())
+    cluster_tsnames = set()
+    if time_config is not None:
+        cluster_tsnames, _ = _get_names(time_config.as_dict_flat())
 
     # Check if timeseries_dataframes is in the correct format (dict of
     # pandas DataFrames)
-    if timeseries_dataframes is not None:
-        check_timeseries_dataframes(timeseries_dataframes)
+    if timeseries_dfs is not None:
+        check_timeseries_dataframes(timeseries_dfs)
 
     # Check there is at least one timeseries present
     if len(constraint_tsnames) == 0:
@@ -568,13 +537,14 @@ def process_timeseries_data(config_model, model_run, timeseries_dataframes):
 
     # Load each timeseries into timeseries data. tskey is either a filename
     # (called by file=...) or a key in timeseries_dataframes (called by df=...)
+    timeseries_data = pd.DataFrame(dtype=float)
     for tskey in constraint_tsnames | cluster_tsnames:
         # If tskey is a CSV path, load the CSV, else load the dataframe
 
         if tskey[0] == "file":
-            df = load_timeseries_from_file(config_model, tskey[1])
+            df = load_timeseries_from_file(timeseries_data_path, tskey[1])
         elif tskey[0] == "df":
-            df = load_timeseries_from_dataframe(timeseries_dataframes, tskey[1])
+            df = load_timeseries_from_dataframe(timeseries_dfs, tskey[1])
         else:
             raise KeyError(f"Unrecognised timeseries data source {tskey[0]}")
 
@@ -587,19 +557,15 @@ def process_timeseries_data(config_model, model_run, timeseries_dataframes):
             )
         # Parse the dates, checking for errors specific to this
         try:
-            df.index = _parser(df.index, dtformat)
+            df.index = _parser(df.index, datetime_format)
         except ValueError as e:
             raise exceptions.ModelError(
                 "Error in parsing dates in timeseries data from {}, "
-                "using datetime format `{}`: {}".format(tskey[1], dtformat, e)
+                "using datetime format `{}`: {}".format(tskey[1], datetime_format, e)
             )
-        if timeseries_data is None:
-            timeseries_data = df
-        else:
-            timeseries_data = pd.concat([timeseries_data, df], axis=1)
+        timeseries_data = pd.concat([timeseries_data, df], axis=1)
 
     # Apply time subsetting, if supplied in model_run
-    subset_time_config = config_model.model.get("subset_time", None)
     if subset_time_config is not None:
         # Test parsing dates first, to make sure they fit our required subset format
         try:
@@ -711,11 +677,18 @@ def generate_model_run(
     (
         model_run["timeseries_data"],
         model_run["timeseries_vars"],
-    ) = process_timeseries_data(config, model_run, timeseries_dataframes)
+    ) = process_timeseries_data(
+        model_run,
+        timeseries_dataframes,
+        config.config.init.timeseries_data_path,
+        config.config.init.time,
+        config.config.init.subset_time,
+        config.config.init.timeseries_dateformat,
+    )
 
     # 6) Grab additional relevant bits from run and model config
-    model_run["run"] = config["run"]
-    model_run["model"] = config["model"]
+    model_run["config"] = config.config
+    model_run["parameters"] = config.parameters
 
     # 8) Final sense-checking
     final_check_comments, warning_messages, errors = checks.check_final(model_run)

--- a/src/calliope/time/funcs.py
+++ b/src/calliope/time/funcs.py
@@ -111,7 +111,7 @@ def apply_clustering(
     normalize=True,
     scale_clusters="mean",
     storage_inter_cluster=True,
-    model_run=None,
+    clustering_timeseries=None,
     **kwargs,
 ):
     """
@@ -173,7 +173,7 @@ def apply_clustering(
         else:
             column = None
 
-        df = model_run.timeseries_data[file]
+        df = clustering_timeseries[file]
         if isinstance(df, pd.Series) and column is not None:
             exceptions.warn(
                 "{} given as time clustering column, but only one column to "

--- a/tests/common/test_model/energy_cap_per_storage_cap.yaml
+++ b/tests/common/test_model/energy_cap_per_storage_cap.yaml
@@ -1,13 +1,15 @@
-model:
-  name: Test model for flow capacity per storage capacity
-  timeseries_data_path: "timeseries_data"
-  subset_time: ["2005-01-01 00:00", "2005-01-01 01:00"]
+config:
+  init:
+    name: Test model for energy capacity per storage capacity
+    timeseries_data_path: "timeseries_data"
+    subset_time: ["2005-01-01 00:00", "2005-01-01 01:00"]
 
-run:
-  mode: plan
-  solver: cbc
-  cyclic_storage: False # necessary so demand can be fed from stored carrier
-  ensure_feasibility: true
+  build:
+    mode: plan
+    cyclic_storage: False # necessary so demand can be fed from stored energy
+    ensure_feasibility: true
+  solve:
+    solver: cbc
 
 techs:
   electricity_demand:
@@ -45,8 +47,7 @@ overrides:
     techs.my_storage.constraints.flow_cap_per_storage_cap_min: 1
   operate_mode_min:
     techs.my_storage.constraints.flow_cap_per_storage_cap_min: 1
-    techs.my_storage.constraints.storage_cap_equals: 900
-    run.mode: operate
-    run.operation:
-      window: 24
-      horizon: 24
+    config:
+      build.mode: operate
+      solve.operate_window: 24
+      solve.operate_horizon: 24

--- a/tests/common/test_model/model.yaml
+++ b/tests/common/test_model/model.yaml
@@ -11,14 +11,14 @@
 import:
   - scenarios.yaml
 
-model:
-  name: Test model
-
-  timeseries_data_path: "timeseries_data"
-
-run:
-  mode: plan
-  solver: cbc
+config:
+  init:
+    name: Test model
+    timeseries_data_path: "timeseries_data"
+  build:
+    mode: plan
+  solve:
+    solver: cbc
 
 techs:
   test_supply_gas:

--- a/tests/common/test_model/model_minimal.yaml
+++ b/tests/common/test_model/model_minimal.yaml
@@ -1,15 +1,19 @@
 import:
   - scenarios.yaml
 
-model:
-  name: Minimal test model
+config:
+  init:
+    name: Minimal test model
+    timeseries_data_path: "timeseries_data"
+  build:
+    mode: plan
+  solve:
+    solver: cbc
 
-  timeseries_data_path: "timeseries_data"
-
-run:
-  mode: plan
-  solver: cbc
-  objective_options.cost_class.monetary: 1
+parameters:
+  objective_cost_class:
+    data: { monetary: 1 }
+    dims: costs
 
 techs:
   test_supply_elec:

--- a/tests/common/test_model/model_minimal.yaml
+++ b/tests/common/test_model/model_minimal.yaml
@@ -12,7 +12,8 @@ config:
 
 parameters:
   objective_cost_class:
-    data: { monetary: 1 }
+    data: 1
+    index: [monetary]
     dims: costs
 
 techs:

--- a/tests/common/test_model/scenarios.yaml
+++ b/tests/common/test_model/scenarios.yaml
@@ -319,6 +319,3 @@ overrides:
           monetary:
             interest_rate: 0.1
             flow_cap: 10
-
-  explicit_cost_class:
-    parameters.objective_cost_class.data: { moentary: 1 }

--- a/tests/common/test_model/scenarios.yaml
+++ b/tests/common/test_model/scenarios.yaml
@@ -241,7 +241,7 @@ overrides:
     links.a,b.exists: false
 
   clustering:
-    model.time:
+    config.init.time:
       function: apply_clustering
       function_options:
         clustering_func: file=cluster_days.csv:a
@@ -249,36 +249,38 @@ overrides:
         storage_inter_cluster: True
 
   spores:
-    run.mode: spores
-    run.spores_options:
-      score_cost_class: "spores_score"
-      slack: 0.1
-      spores_number: 3
-    run.objective_options.cost_class: { "monetary": 1, "spores_score": 0 }
+    config:
+      build.mode: spores
+      solve:
+        spores_score_cost_class: "spores_score"
+        spores_number: 3
+      parameters:
+        spores_slack: 0.1
+        objective_cost_class.data: { "monetary": 1, "spores_score": 0 }
 
     techs.test_supply_elec.costs.spores_score.flow_cap: 0
     techs.test_supply_elec.costs.spores_score.interest_rate: 0
     techs.test_supply_elec.constraints.lifetime: 1
 
   one_day:
-    model.subset_time: ["2005-01-01", "2005-01-01"]
+    config.init.subset_time: ["2005-01-01", "2005-01-01"]
 
   two_hours:
-    model.subset_time: ["2005-01-01 00:00:00", "2005-01-01 01:00:00"]
+    config.init.subset_time: ["2005-01-01 00:00:00", "2005-01-01 01:00:00"]
 
   resample_two_days:
-    model:
-      subset_time: ["2005-01-01", "2005-01-02"]
-      time:
-        function: resample
-        function_options.resolution: 24h
+    config:
+      init:
+        subset_time: ["2005-01-01", "2005-01-02"]
+        time:
+          function: resample
+          function_options.resolution: 24h
 
   operate:
-    run.mode: operate
-    model.subset_time: ["2005-01-01", "2005-01-04"]
-    run.operation:
-      window: 12
-      horizon: 24
+    config.build.mode: operate
+    config.init.subset_time: ["2005-01-01", "2005-01-04"]
+    config.solve.operate_window: 12
+    config.solve.operate_horizon: 24
 
   investment_costs:
     tech_groups:
@@ -319,4 +321,4 @@ overrides:
             flow_cap: 10
 
   explicit_cost_class:
-    run.objective_options.cost_class.monetary: 1
+    parameters.objective_cost_class.data: { moentary: 1 }

--- a/tests/common/test_model/weighted_obj_func.yaml
+++ b/tests/common/test_model/weighted_obj_func.yaml
@@ -79,13 +79,22 @@ overrides:
   illegal_string_cost_class:
     parameters.objective_cost_class.data: "monetary"
   emissions_objective_without_removing_monetary_default:
-    parameters.objective_cost_class.data: { "emissions": 0.1 }
+    parameters.objective_cost_class:
+      data: 0.1
+      index: ["emissions"]
   monetary_objective:
-    parameters.objective_cost_class.data: { "monetary": 1 }
+    parameters.objective_cost_class:
+      data: 1
+      index: ["monetary"]
   emissions_objective:
-    parameters.objective_cost_class.data: { "monetary": 0, "emissions": 1 }
+    parameters.objective_cost_class:
+      data: [0, 1]
+      index: [monetary, emissions]
   weighted_objective:
-    parameters.objective_cost_class.data: { "monetary": 0.9, "emissions": 0.1 }
+    parameters.objective_cost_class:
+      data: [0.9, 0.1]
+      index: [monetary, emissions]
   undefined_class_objective:
-    parameters.objective_cost_class.data:
-      { "monetary": 0.8, "emissions": 0.1, "random_class": 0.2 }
+    parameters.objective_cost_class:
+      data: [0.8, 0.1, 0.2]
+      index: ["monetary", "emissions", "random_class"]

--- a/tests/common/test_model/weighted_obj_func.yaml
+++ b/tests/common/test_model/weighted_obj_func.yaml
@@ -1,11 +1,12 @@
-model:
-  name: Cost capacity constraint test model
-  timeseries_data_path: "timeseries_data"
-  subset_time: ["2005-01-01", "2005-01-01"]
-
-run:
-  mode: plan
-  solver: cbc
+config:
+  init:
+    name: Cost capacity constraint test model
+    timeseries_data_path: "timeseries_data"
+    subset_time: ["2005-01-01", "2005-01-01"]
+  build:
+    mode: plan
+  solve:
+    solver: cbc
 
 techs:
   cheap_polluting_supply:
@@ -76,15 +77,15 @@ nodes:
 
 overrides:
   illegal_string_cost_class:
-    run.objective_options.cost_class: "monetary"
+    parameters.objective_cost_class.data: "monetary"
   emissions_objective_without_removing_monetary_default:
-    run.objective_options.cost_class: { "emissions": 0.1 }
+    parameters.objective_cost_class.data: { "emissions": 0.1 }
   monetary_objective:
-    run.objective_options.cost_class: { "monetary": 1 }
+    parameters.objective_cost_class.data: { "monetary": 1 }
   emissions_objective:
-    run.objective_options.cost_class: { "monetary": 0, "emissions": 1 }
+    parameters.objective_cost_class.data: { "monetary": 0, "emissions": 1 }
   weighted_objective:
-    run.objective_options.cost_class: { "monetary": 0.9, "emissions": 0.1 }
+    parameters.objective_cost_class.data: { "monetary": 0.9, "emissions": 0.1 }
   undefined_class_objective:
-    run.objective_options.cost_class:
+    parameters.objective_cost_class.data:
       { "monetary": 0.8, "emissions": 0.1, "random_class": 0.2 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -217,10 +217,18 @@ def dummy_model_data():
     for param in model_data.data_vars.values():
         param.attrs["is_result"] = 0
 
-    model_data.attrs["run_config"] = AttrDict(
-        {"foo": True, "bar": {"foobar": "baz"}, "foobar": {"baz": {"foo": np.inf}}}
+    model_data.attrs["config"] = AttrDict(
+        {
+            "build": {
+                "foo": True,
+                "FOO": "baz",
+                "foo1": np.inf,
+                "bar": {"foobar": "baz"},
+                "a_b": 0,
+                "b_a": [1, 2],
+            }
+        }
     )
-    model_data.attrs["model_config"] = AttrDict({"a_b": 0, "b_a": [1, 2]})
 
     model_data.attrs["defaults"] = AttrDict(
         {"all_inf": np.inf, "all_nan": np.nan, "with_inf": 100, "only_techs": 5}

--- a/tests/test_backend_pyomo.py
+++ b/tests/test_backend_pyomo.py
@@ -1,4 +1,6 @@
+import importlib
 import logging
+from copy import deepcopy
 from itertools import product
 
 import calliope.exceptions as exceptions
@@ -7,6 +9,8 @@ import pandas as pd
 import pyomo.kernel as pmo
 import pytest  # noqa: F401
 import xarray as xr
+from calliope.backend.pyomo_backend_model import PyomoBackendModel
+from calliope.core.attrdict import AttrDict
 
 from .common.util import build_test_model as build_model
 from .common.util import check_error_or_warning, check_variable_exists
@@ -22,13 +26,13 @@ class TestChecks:
             m = build_model(
                 override, "simple_supply_and_supply_plus,operate,investment_costs"
             )
-            assert m.run_config["cyclic_storage"] is True
+            assert m.config.build["cyclic_storage"] is True
         elif on is False:
-            override = {"run.cyclic_storage": False}
+            override = {"config.build.cyclic_storage": False}
             m = build_model(
                 override, "simple_supply_and_supply_plus,operate,investment_costs"
             )
-            assert m.run_config["cyclic_storage"] is False
+            assert m.config.build["cyclic_storage"] is False
         with pytest.warns(exceptions.ModelWarning) as warning:
             m.build()
         check_warn = check_error_or_warning(
@@ -38,7 +42,7 @@ class TestChecks:
             assert check_warn
         elif on is True:
             assert not check_warn
-        assert m._model_data.attrs["run_config"].cyclic_storage is False
+        assert m._model_data.attrs["config"].build.cyclic_storage is False
 
     @pytest.mark.parametrize("param", [("flow_eff"), ("source_eff"), ("parasitic_eff")])
     def test_loading_timeseries_operate_efficiencies(self, param):
@@ -154,7 +158,7 @@ class TestChecks:
             {
                 "techs.test_supply_elec": {
                     "constraints": {
-                        "source": "file=supply_plus_resource.csv:1",
+                        "source_max": "file=supply_plus_resource.csv:1",
                         "flow_cap_max": 15,
                     },
                     "switches": {
@@ -490,7 +494,6 @@ class TestCostConstraints:
         """
         assert "cost_investment" in simple_conversion.backend.expressions
 
-    @pytest.mark.filterwarnings("ignore:(?s).*Integer:calliope.exceptions.ModelWarning")
     def test_loc_techs_cost_investment_milp_constraint(self):
         m = build_model(
             {
@@ -660,7 +663,6 @@ class TestCapacityConstraints:
             == 20
         )
 
-    @pytest.mark.filterwarnings("ignore:(?s).*Integer:calliope.exceptions.ModelWarning")
     def test_loc_techs_storage_capacity_milp_constraint(self):
         m = build_model(
             {
@@ -704,7 +706,7 @@ class TestCapacityConstraints:
             )
 
     @pytest.mark.filterwarnings("ignore:(?s).*Integer:calliope.exceptions.ModelWarning")
-    @pytest.mark.parametrize("override", (("max", "equals", "min")))
+    @pytest.mark.parametrize("override", (("max", "min")))
     def test_loc_techs_flow_capacity_milp_storage_constraint(self, override):
         """
         i for i in sets.loc_techs_store if constraint_exists(model_run, i, 'constraints.flow_cap_per_storage_cap_max')
@@ -923,7 +925,6 @@ class TestCapacityConstraints:
             * 5
         )
 
-    @pytest.mark.filterwarnings("ignore:(?s).*Integer:calliope.exceptions.ModelWarning")
     def test_loc_techs_flow_capacity_milp_constraint(self):
         m = build_model(
             {}, "supply_milp,two_hours,investment_costs"
@@ -1029,7 +1030,6 @@ class TestDispatchConstraints:
         """
         assert "flow_out_max" in simple_supply.backend.constraints
 
-    @pytest.mark.filterwarnings("ignore:(?s).*Integer:calliope.exceptions.ModelWarning")
     def test_loc_tech_carriers_flow_out_max_milp_constraint(self, supply_milp):
         assert "flow_out_max" not in supply_milp.backend.constraints
 
@@ -1049,7 +1049,6 @@ class TestDispatchConstraints:
         m.build()
         assert "flow_out_min" in m.backend.constraints
 
-    @pytest.mark.filterwarnings("ignore:(?s).*Integer:calliope.exceptions.ModelWarning")
     def test_loc_tech_carriers_flow_out_min_milp_constraint(self, supply_milp):
         assert "flow_out_min" not in supply_milp.backend.constraints
 
@@ -1069,7 +1068,6 @@ class TestDispatchConstraints:
         """
         assert "flow_in_max" in simple_supply.backend.constraints
 
-    @pytest.mark.filterwarnings("ignore:(?s).*Integer:calliope.exceptions.ModelWarning")
     def test_loc_tech_carriers_flow_in_max_milp_constraint(self, supply_milp):
         assert "flow_in_max" in supply_milp.backend.constraints
 
@@ -1124,7 +1122,6 @@ class TestDispatchConstraints:
         assert "ramping_down" in m.backend.constraints
 
 
-@pytest.mark.filterwarnings("ignore:(?s).*Integer:calliope.exceptions.ModelWarning")
 @pytest.mark.skip(reason="to be reimplemented by comparison to LP files")
 class TestMILPConstraints:
     # milp.py
@@ -1517,45 +1514,14 @@ class TestMILPConstraints:
         }
         m = build_model(override_max, "conversion_plus_milp,two_hours,investment_costs")
         m.build()
-        assert "unit_capacity_systemwide_milp" in m.backend.constraints
+        assert "unit_capacity_max_systemwide_milp" in m.backend.constraints
         assert (
             m.backend.get_constraint(
-                "unit_capacity_systemwide_milp", as_backend_objs=False
+                "unit_capacity_max_systemwide_milp", as_backend_objs=False
             )
             .sel(techs="test_conversion_plus")
             .ub.item()
             == 2
-        )
-
-    def test_techs_unit_capacity_equals_systemwide_milp_constraint(self):
-        """
-        sets.techs if unit_cap_max_systemwide or unit_cap_equals_systemwide
-        """
-        override_equals = {
-            "links.a,b.exists": True,
-            "techs.test_conversion_plus.constraints.units_equals_systemwide": 1,
-            "nodes.b.techs.test_conversion_plus.costs.monetary.purchase": 1,
-        }
-        m = build_model(
-            override_equals, "conversion_plus_milp,two_hours,investment_costs"
-        )
-        m.build()
-        assert "unit_capacity_systemwide_milp" in m.backend.constraints
-        assert (
-            m.backend.get_constraint(
-                "unit_capacity_systemwide_milp", as_backend_objs=False
-            )
-            .sel(techs="test_conversion_plus")
-            .lb.item()
-            == 1
-        )
-        assert (
-            m.backend.get_constraint(
-                "unit_capacity_systemwide_milp", as_backend_objs=False
-            )
-            .sel(techs="test_conversion_plus")
-            .ub.item()
-            == 1
         )
 
     # TODO: always have transmission techs be independent of node names
@@ -1603,7 +1569,7 @@ class TestMILPConstraints:
             model_file="model_minimal.yaml",
         )
         m.build()
-        assert "unit_capacity_systemwide_milp" in m.backend.constraints
+        assert "unit_capacity_max_systemwide_milp" in m.backend.constraints
 
     @pytest.mark.parametrize("tech", (("test_storage"), ("test_transmission_elec")))
     def test_asynchronous_flow_constraint(self, tech):
@@ -1676,18 +1642,18 @@ class TestClusteringConstraints:
         storage_initial=False,
     ):
         override = {
-            "model.subset_time": ["2005-01-01", "2005-01-04"],
-            "model.time": {
+            "config.init.subset_time": ["2005-01-01", "2005-01-04"],
+            "config.init.time": {
                 "function": "apply_clustering",
                 "function_options": {
                     "clustering_func": "file=cluster_days.csv:a",
                     "how": how,
                 },
             },
-            "model.custom_math": ["storage_inter_cluster"]
+            "config.init.custom_math": ["storage_inter_cluster"]
             if storage_inter_cluster
             else [],
-            "run.cyclic_storage": cyclic,
+            "config.build.cyclic_storage": cyclic,
         }
         if storage_initial:
             override.update({"techs.test_storage.constraints.storage_initial": 0})
@@ -1740,7 +1706,7 @@ class TestLogging:
         model = build_model(
             model_file=model_file,
             scenario="simple_supply,investment_costs",
-            override_dict={"run": {"solver": "gurobi", "solver_io": "python"}},
+            override_dict={"config.solve": {"solver": "gurobi", "solver_io": "python"}},
         )
         model.build()
         return model
@@ -1762,12 +1728,71 @@ class TestNewBackend:
         m.backend.verbose_strings()
         return m
 
+    @pytest.fixture
+    def temp_path(self, tmpdir_factory):
+        return tmpdir_factory.mktemp("custom_math")
+
     def test_new_build_has_backend(self, simple_supply):
         assert hasattr(simple_supply, "backend")
 
     def test_new_build_optimal(self, simple_supply):
         assert hasattr(simple_supply, "results")
         assert simple_supply._model_data.attrs["termination_condition"] == "optimal"
+
+    @pytest.mark.parametrize("mode", ["operate", "spores"])
+    def test_add_run_mode_custom_math(self, caplog, mode):
+        caplog.set_level(logging.DEBUG)
+        mode_custom_math = AttrDict.from_yaml(
+            importlib.resources.files("calliope") / "math" / f"{mode}.yaml"
+        )
+        m = build_model({}, "simple_supply,two_hours,investment_costs")
+
+        base_math = deepcopy(m.math)
+        base_math.union(mode_custom_math, allow_override=True)
+
+        backend = PyomoBackendModel(m.inputs, mode=mode)
+        backend._add_run_mode_custom_math()
+
+        assert f"Updating math formulation with {mode} mode custom math." in caplog.text
+        assert m.math != base_math
+        assert backend.inputs.attrs["math"].as_dict() == base_math.as_dict()
+
+    def test_add_run_mode_custom_math_before_build(self, caplog, temp_path):
+        """A user can override the run mode custom math by including it directly in the custom math string"""
+        caplog.set_level(logging.DEBUG)
+        custom_math = AttrDict({"variables": {"flow_cap": {"active": True}}})
+        file_path = temp_path.join("custom-math.yaml")
+        custom_math.to_yaml(file_path)
+
+        m = build_model(
+            {"config.init.custom_math": ["operate", file_path]},
+            "simple_supply,two_hours,investment_costs",
+        )
+        m.build(mode="operate")
+
+        # We set operate mode explicitly in our custom math so it won't be added again
+        assert (
+            "Updating math formulation with operate mode custom math."
+            not in caplog.text
+        )
+
+        # operate mode set it to false, then our custom math set it back to active
+        assert m.math.variables.flow_cap.active
+        # operate mode set it to false and our custom math did not override that
+        assert not m.math.variables.storage_cap.active
+
+    def test_run_mode_mismatch(self):
+        m = build_model(
+            {"config.init.custom_math": ["operate"]},
+            "simple_supply,two_hours,investment_costs",
+        )
+        backend = PyomoBackendModel(m.inputs, mode="plan")
+        with pytest.warns(exceptions.ModelWarning) as excinfo:
+            backend._add_run_mode_custom_math()
+
+        assert check_error_or_warning(
+            excinfo, "Running in plan mode, but run mode(s) {'operate'}"
+        )
 
     @pytest.mark.parametrize(
         "component_type", ["variable", "global_expression", "parameter", "constraint"]
@@ -1913,7 +1938,7 @@ class TestNewBackend:
         assert check_error_or_warning(excinfo, "This model object already has results.")
 
     def test_solve_operate_not_allowed(self, simple_supply):
-        simple_supply.run_config["mode"] = "operate"
+        simple_supply.config.build.mode = "operate"
         simple_supply._model_data.attrs["allow_operate_mode"] = False
 
         try:
@@ -1921,11 +1946,11 @@ class TestNewBackend:
                 simple_supply.solve(force=True)
             assert check_error_or_warning(excinfo, "Unable to run this model in op")
         except AssertionError as e:
-            simple_supply.run_config["mode"] = "plan"
+            simple_supply.config.build.mode = "plan"
             simple_supply._model_data.attrs["allow_operate_mode"] = True
             raise e
         else:
-            simple_supply.run_config["mode"] = "plan"
+            simple_supply.config.build.mode = "plan"
             simple_supply._model_data.attrs["allow_operate_mode"] = True
 
     def test_solve_warmstart_not_possible(self, simple_supply):

--- a/tests/test_backend_pyomo_objective.py
+++ b/tests/test_backend_pyomo_objective.py
@@ -11,7 +11,7 @@ class TestCostMinimisationObjective:
     def test_nationalscale_minimize_emissions(self):
         model = calliope.examples.national_scale(
             scenario="minimize_emissions_costs",
-            override_dict={"model.subset_time": ["2005-01-01", "2005-01-01"]},
+            override_dict={"config.init.subset_time": ["2005-01-01", "2005-01-01"]},
         )
         model.build()
         model.solve()
@@ -34,7 +34,7 @@ class TestCostMinimisationObjective:
     def test_nationalscale_maximize_utility(self):
         model = calliope.examples.national_scale(
             scenario="maximize_utility_costs",
-            override_dict={"model.subset_time": ["2005-01-01", "2005-01-01"]},
+            override_dict={"config.init.subset_time": ["2005-01-01", "2005-01-01"]},
         )
         model.build()
         model.solve()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,7 +41,7 @@ class TestCLI:
                     "--save_netcdf=output.nc",
                     # FIXME: should be CBC but a timeout error causes issues on OSX CI
                     # (likely fixed by updating pyomo)
-                    "--override_dict={'run.solver': 'glpk'}",
+                    "--override_dict={'config.solve.solver': 'glpk'}",
                 ],
             )
             assert result.exit_code == 0
@@ -62,7 +62,7 @@ class TestCLI:
                     _MODEL_NATIONAL,
                     "--save_netcdf=output.nc",
                     "--scenario=spores",
-                    "--override_dict={'run.spores_options.save_per_spore': True}",
+                    "--override_dict={'config.solve.spores_save_per_spore': True}",
                 ],
             )
             print(os.listdir(os.path.join(tempdir, "output")))
@@ -88,7 +88,7 @@ class TestCLI:
         assert result.exit_code == 1
 
     @pytest.mark.parametrize(
-        "arg", (("--scenario=test"), ("--override_dict={'model.name': 'test'}"))
+        "arg", (("--scenario=test"), ("--override_dict={'config.init.name': 'test'}"))
     )
     def test_unavailable_arguments(self, arg):
         runner = CliRunner()

--- a/tests/test_core_preprocess.py
+++ b/tests/test_core_preprocess.py
@@ -1381,26 +1381,15 @@ class TestChecks:
             "Integer and / or binary decision variables are included in this model",
         )
 
-    def test_fail_on_string(self):
-        with pytest.raises(calliope.exceptions.ModelError) as exception:
-            build_model(
-                model_file="weighted_obj_func.yaml",
-                scenario="illegal_string_cost_class",
-            )
-
-        assert check_error_or_warning(
-            exception, "`parameters.objective_cost_class` must be a dictionary."
-        )
-
     @pytest.mark.parametrize(
         "override",
         [
-            ({"parameters.objective_cost_class.data": {"monetary": None}}),
+            ({"parameters.objective_cost_class.data": None}),
             (
                 {
-                    "parameters.objective_cost_class.data": {
-                        "monetary": None,
-                        "emissions": None,
+                    "parameters.objective_cost_class": {
+                        "data": [None, 1],
+                        "index": ["monetary", "emissions"],
                     }
                 }
             ),

--- a/tests/test_core_time.py
+++ b/tests/test_core_time.py
@@ -13,8 +13,8 @@ class TestClustering:
     def model_national(self, scope="module"):
         return calliope.examples.national_scale(
             override_dict={
-                "model.random_seed": 23,
-                "model.subset_time": ["2005-01-01", "2005-03-31"],
+                "config.init.random_seed": 23,
+                "config.init.subset_time": ["2005-01-01", "2005-03-31"],
             }
         )
 
@@ -108,7 +108,7 @@ class TestClustering:
         # it is only different for '2005-01-02'
         override = {
             "techs.test_demand_elec.constraints.sink_equals": "file=demand_elec_15mins.csv",
-            "model.subset_time": None,
+            "config.init.subset_time": None,
         }
 
         model = build_test_model(override, scenario="simple_supply,one_day")
@@ -151,7 +151,7 @@ class TestClustering:
         # it is only different for '2005-01-02'
         override = {
             "techs.test_demand_elec.constraints.sink_equals": "file=demand_elec_15T_to_2h.csv",
-            "model.subset_time": None,
+            "config.init.subset_time": None,
         }
 
         model = build_test_model(override, scenario="simple_supply,one_day")
@@ -235,8 +235,8 @@ class TestClustering:
     @pytest.fixture
     def predefined_cluster_override(self):
         return {
-            "model.subset_time": ["2005-01-01", "2005-01-04"],
-            "model.time": {
+            "config.init.subset_time": ["2005-01-01", "2005-01-04"],
+            "config.init.time": {
                 "function": "apply_clustering",
                 "function_options": {
                     "clustering_func": "file=clusters.csv:a",
@@ -255,7 +255,7 @@ class TestClustering:
         override2 = {
             **predefined_cluster_override,
             **{
-                "model.time.function_options.clustering_func": "file=cluster_days.csv:b"
+                "config.init.time.function_options.clustering_func": "file=cluster_days.csv:b"
             },
         }
 
@@ -272,8 +272,8 @@ class TestClustering:
         override3 = {
             **predefined_cluster_override,
             **{
-                "model.time.function_options.clustering_func": "file=cluster_days.csv:b",
-                "model.time.function_options.how": "closest",
+                "config.init.time.function_options.clustering_func": "file=cluster_days.csv:b",
+                "config.init.time.function_options.how": "closest",
             },
         }
 
@@ -283,8 +283,8 @@ class TestClustering:
 
     def test_predefined_clusters_fail(self):
         override = {
-            "model.subset_time": ["2005-01-01", "2005-01-04"],
-            "model.time": {
+            "config.init.subset_time": ["2005-01-01", "2005-01-04"],
+            "config.init.time": {
                 "function": "apply_clustering",
                 "function_options": {
                     "clustering_func": "file=clusters.csv:a",
@@ -295,7 +295,9 @@ class TestClustering:
         # should fail - no CSV data column defined
         override1 = {
             **override,
-            **{"model.time.function_options.clustering_func": "file=clusters.csv"},
+            **{
+                "config.init.time.function_options.clustering_func": "file=clusters.csv"
+            },
         }
         with pytest.raises(exceptions.ModelError) as error:
             build_test_model(override1, scenario="simple_supply")
@@ -305,7 +307,9 @@ class TestClustering:
         # should fail - unknown CSV data column defined
         override2 = {
             **override,
-            **{"model.time.function_options.clustering_func": "file=clusters.csv:1"},
+            **{
+                "config.init.time.function_options.clustering_func": "file=clusters.csv:1"
+            },
         }
 
         with pytest.raises(KeyError) as error:
@@ -316,7 +320,9 @@ class TestClustering:
         # should fail - more than one cluster given to any one day
         override3 = {
             **override,
-            **{"model.time.function_options.clustering_func": "file=clusters.csv:b"},
+            **{
+                "config.init.time.function_options.clustering_func": "file=clusters.csv:b"
+            },
         }
 
         with pytest.raises(exceptions.ModelError) as error:
@@ -330,8 +336,8 @@ class TestClustering:
         override4 = {
             **override,
             **{
-                "model.subset_time": ["2005-01-01", "2005-01-06"],
-                "model.time.function_options.clustering_func": "file=cluster_days.csv:b",
+                "config.init.subset_time": ["2005-01-01", "2005-01-06"],
+                "config.init.time.function_options.clustering_func": "file=cluster_days.csv:b",
             },
         }
 
@@ -348,13 +354,13 @@ class TestMasks:
     @pytest.fixture
     def model_national(self, scope="module"):
         return calliope.examples.national_scale(
-            override_dict={"model.subset_time": ["2005-01-01", "2005-01-31"]}
+            override_dict={"config.init.subset_time": ["2005-01-01", "2005-01-31"]}
         )
 
     @pytest.fixture
     def model_urban(self, scope="module"):
         return calliope.examples.urban_scale(
-            override_dict={"model.subset_time": ["2005-01-01", "2005-01-31"]}
+            override_dict={"config.init.subset_time": ["2005-01-01", "2005-01-31"]}
         )
 
     def test_zero(self, model_national):
@@ -611,7 +617,7 @@ class TestMasks:
         # it is only different for '2005-01-02'
         override = {
             "techs.test_demand_elec.constraints.sink_equals": "file=demand_elec_15mins.csv",
-            "model.subset_time": None,
+            "config.init.subset_time": None,
         }
 
         model = build_test_model(override, scenario="simple_supply,one_day")
@@ -729,7 +735,7 @@ class TestMasks:
         # it is only different for '2005-01-02'
         override = {
             "techs.test_demand_elec.constraints.sink_equals": "file=demand_elec_15T_to_2h.csv",
-            "model.subset_time": None,
+            "config.init.subset_time": None,
         }
 
         model = build_test_model(override, scenario="simple_supply,one_day")
@@ -774,8 +780,8 @@ class TestResampling:
         # it is only different for '2005-01-02'
         override = {
             "techs.test_demand_elec.constraints.sink_equals": "file=demand_elec_15mins.csv",
-            "model.subset_time": None,
-            "model.time": {
+            "config.init.subset_time": None,
+            "config.init.time": {
                 "masks": [
                     {
                         "function": "extreme",
@@ -926,8 +932,8 @@ class TestResampling:
         # it is only different for '2005-01-02'
         override = {
             "techs.test_demand_elec.constraints.sink_equals": "file=demand_elec_15mins.csv",
-            "model.subset_time": None,
-            "model.time": {
+            "config.init.subset_time": None,
+            "config.init.time": {
                 "function": "resample",
                 "function_options": {"resolution": "6H"},
             },
@@ -961,8 +967,8 @@ class TestResampling:
         """
         override = {
             "techs.test_demand_elec.constraints.sink_equals": "file=demand_elec_15T_to_2h.csv",
-            "model.subset_time": None,
-            "model.time": {
+            "config.init.subset_time": None,
+            "config.init.time": {
                 "function": "resample",
                 "function_options": {"resolution": "2H"},
             },
@@ -1019,7 +1025,7 @@ class TestFuncs:
     @pytest.fixture
     def model_national(self, scope="module"):
         return calliope.examples.national_scale(
-            override_dict={"model.subset_time": ["2005-01", "2005-01"]}
+            override_dict={"config.init.subset_time": ["2005-01", "2005-01"]}
         )
 
     def test_drop_invalid_timesteps(self, model_national):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -102,8 +102,7 @@ class TestIO:
                     "foo_dict",
                     "foo_attrdict",
                     "defaults",
-                    "model_config",
-                    "run_config",
+                    "config",
                     "math",
                 ],
             ),
@@ -166,7 +165,8 @@ class TestIO:
     @pytest.mark.xfail(reason="Not reimplemented the 'check feasibility' objective")
     def test_save_csv_not_optimal(self):
         model = calliope.examples.national_scale(
-            scenario="check_feasibility", override_dict={"run.cyclic_storage": False}
+            scenario="check_feasibility",
+            override_dict={"config.build.cyclic_storage": False},
         )
 
         model.build()
@@ -177,7 +177,7 @@ class TestIO:
             with pytest.warns(exceptions.ModelWarning):
                 model.to_csv(out_path, dropna=False)
 
-    @pytest.mark.parametrize("attr", ["run_config", "model_config", "math"])
+    @pytest.mark.parametrize("attr", ["config", "math"])
     def test_dicts_as_model_attrs_and_property(self, model_from_file, attr):
         assert attr in model_from_file._model_data.attrs.keys()
         assert hasattr(model_from_file, attr)
@@ -221,17 +221,12 @@ class TestIO:
     def test_save_per_spore(self):
         with tempfile.TemporaryDirectory() as tempdir:
             os.mkdir(os.path.join(tempdir, "output"))
-            model = calliope.examples.national_scale(
-                scenario="spores",
-                override_dict={
-                    "run.spores_options.save_per_spore": True,
-                    "run.spores_options.save_per_spore_path": os.path.join(
-                        tempdir, "output/spore_{}.nc"
-                    ),
-                },
-            )
+            model = calliope.examples.national_scale(scenario="spores")
             model.build()
-            model.solve()
+            model.solve(
+                spores_save_per_spore=True,
+                save_per_spore_path=os.path.join(tempdir, "output/spore_{}.nc"),
+            )
 
             for i in ["0", "1", "2", "3"]:
                 assert os.path.isfile(os.path.join(tempdir, "output", f"spore_{i}.nc"))

--- a/tests/test_model_data.py
+++ b/tests/test_model_data.py
@@ -269,7 +269,7 @@ class TestModelData:
         model_data._model_run_dict_to_dataset(
             "foo", "node", ["FOO"], ["nodes", "foobar"]
         )
-        assert "No relevant data found for `foo` group of parameters" in caplog.text
+        assert "No relevant data found for `FOO` group of parameters" in caplog.text
 
     @pytest.mark.parametrize(
         ("data", "idx", "cols", "out_idx"),


### PR DESCRIPTION
Fixes issue #452 

Possible TODO: allow init kwargs to be passed to the built-in example models on their initialisation (e.g., `calliope.examples.national_scale(override_dict={"config.init.subset_time": ...})` -> `calliope.examples.national_scale(subset_time=...)`)

Summary of changes in this pull request:

* `run` and `model` config split into `init`/`build`/`solve` config keys with a flat dict layout in each.
*  parameters moved out of config into a top-level parameters key with a syntax discussed in #452 and in a number of discussions.

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved