### PR TITLE
Update badges and remove pdf gen from rtd

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -11,6 +11,7 @@ on:
       - CITATION
       - AUTHORS
       - doc/**
+      - .readthedocs.yml
 
 defaults:
   run:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -11,6 +11,7 @@ on:
       - CITATION
       - AUTHORS
       - doc/**
+      - .readthedocs.yml
 
 defaults:
   run:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,4 @@
 version: 2 # required
-formats: [pdf]
 conda:
   environment: requirements/docs.yml
 build:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![Chat on Gitter](https://img.shields.io/gitter/room/calliope-project/calliope.svg?style=flat-square)](https://app.gitter.im/#/room/#calliope-project_calliope:gitter.im)
+[![Chat on Gitter](https://img.shields.io/gitter/room/calliope-project/calliope.svg)](https://app.gitter.im/#/room/#calliope-project_calliope:gitter.im)
 [![Main branch build status](https://github.com/calliope-project/calliope/actions/workflows/commit-ci.yml/badge.svg?branch=main)](https://github.com/calliope-project/calliope/actions/workflows/commit-ci.yml)
-[![Documentation build status](https://img.shields.io/readthedocs/calliope.svg?style=flat-square)](https://readthedocs.org/projects/calliope/builds/)
+[![Documentation build status](https://img.shields.io/readthedocs/calliope.svg?version=latest)](https://readthedocs.org/projects/calliope/builds/)
 [![Test coverage](https://codecov.io/gh/calliope-project/calliope/graph/badge.svg?token=UM542yaYrh)](https://codecov.io/gh/calliope-project/calliope)
-[![PyPI version](https://img.shields.io/pypi/v/calliope.svg?style=flat-square)](https://pypi.python.org/pypi/calliope)
-[![Anaconda.org/conda-forge version](https://img.shields.io/conda/vn/conda-forge/calliope.svg?style=flat-square&label=conda)](https://anaconda.org/conda-forge/calliope)
-[![JOSS DOI](https://img.shields.io/badge/JOSS-10.21105/joss.00825-green.svg?style=flat-square)](https://doi.org/10.21105/joss.00825)
+[![PyPI version](https://img.shields.io/pypi/v/calliope.svg)](https://pypi.python.org/pypi/calliope)
+[![Anaconda.org/conda-forge version](https://img.shields.io/conda/vn/conda-forge/calliope.svg?label=conda)](https://anaconda.org/conda-forge/calliope)
+[![JOSS DOI](https://img.shields.io/badge/JOSS-10.21105/joss.00825-green.svg)](https://doi.org/10.21105/joss.00825)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,7 @@ More fully-featured examples that have been used in peer-reviewed scientific pub
 
 ## Documentation
 
-Documentation is available on Read the Docs:
-
-- [Read the documentation online (recommended)](https://calliope.readthedocs.io/en/stable/)
-- [Download all documentation in a single PDF file](https://readthedocs.org/projects/calliope/downloads/pdf/stable/)
+Documentation is available on [Read the Docs](https://calliope.readthedocs.io/en/stable/).
 
 ## Contributing
 

--- a/doc/user/introduction.rst
+++ b/doc/user/introduction.rst
@@ -51,7 +51,7 @@ Development has been partially funded by several grants throughout throughout th
 * The `Grantham Institute <https://www.imperial.ac.uk/grantham>`_ at Imperial College London.
 * the European Institute of Innovation & Technology's `Climate-KIC program <https://www.climate-kic.org>`_.
 * `Engineering and Physical Sciences Research Council <https://gow.epsrc.ukri.org/NGBOViewGrant.aspx?GrantRef=EP/L016095/1>`_, reference number: EP/L016095/1.
-* `The Swiss Competence Center for Energy Research − Supply of Electricity (SCCER SoE) <http://sccer-soe.ch/en/home/>`_, contract number 1155002546.
+* `The Swiss Competence Center for Energy Research - Supply of Electricity (SCCER SoE) <http://sccer-soe.ch/en/home/>`_, contract number 1155002546.
 * `Swiss Federal Office for Energy (SFOE) <https://www.bfe.admin.ch/bfe/en/home.html>`_, grant number SI/501768-01.
 * `European Research Council <https://erc.europa.eu>`_ TRIPOD grant, grant agreement number 715132.
 * `The SENTINEL project <https://sentinel.energy/>`_ of the European Union's Horizon 2020 research and innovation programme under grant agreement No 837089.


### PR DESCRIPTION
Fixes badges (I tried sneakily force pushing a minor change, but realised there's more to it)

Summary of changes in this pull request:

* Update badges to work with current CI / apps
* Update badges to all rounded since some can't do flat-square styling
* Remove PDF generation of docs since the PDF build has been failing horribly for ~5 months (e.g. [here](https://readthedocs.org/projects/calliope/builds/22342627/))

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved