### PR TITLE
`flow_eff` -> `flow_in_eff` and `flow_out_eff`

### DIFF
--- a/doc/helpers/generate_math.py
+++ b/doc/helpers/generate_math.py
@@ -24,26 +24,6 @@ NONDEMAND_TECHGROUPS = [
     "supply_plus",
 ]
 
-# TODO: find another way to define this
-POSSIBLE_TIMESERIES_DATA = [
-    "clustering_func",
-    "flow_eff",
-    "flow_ramping",
-    "export",
-    "om_con",
-    "om_prod",
-    "parasitic_eff",
-    "source_max",
-    "source_min",
-    "source_equals",
-    "sink_min",
-    "sink_max",
-    "sink_equals",
-    "source_eff",
-    "storage_loss",
-    "carrier_ratios",
-]
-
 
 def generate_base_math_model(model_config: dict) -> calliope.Model:
     """Generate RST file for the base math

--- a/doc/user/advanced_constraints.rst
+++ b/doc/user/advanced_constraints.rst
@@ -23,7 +23,7 @@ An example use of ``supply_plus`` is to define a concentrating solar power (CSP)
 
 See the :ref:`listing of supply_plus configuration <abstract_base_tech_definitions>` in the abstract base tech group definitions for the additional constraints that are possible.
 
-.. Warning:: When analysing results from supply_plus, care must be taken to correctly account for the losses along the transformation from resource to carrier. For example, charging of storage from the resource may have a ``source_eff``-associated loss with it, while discharging storage to produce the carrier may have a different loss resulting from a combination of ``flow_eff`` and ``parasitic_eff``. Such intermediate conversion losses need to be kept in mind when comparing discharge from storage with ``flow_out`` in the same time step.
+.. Warning:: When analysing results from supply_plus, care must be taken to correctly account for the losses along the transformation from resource to carrier. For example, charging of storage from the resource may have a ``source_eff``-associated loss with it, while discharging storage to produce the carrier may have a different loss resulting from a combination of ``flow_out_eff`` and ``parasitic_eff``. Such intermediate conversion losses need to be kept in mind when comparing discharge from storage with ``flow_out`` in the same time step.
 
 .. _conversion_plus:
 
@@ -67,7 +67,7 @@ A combined heat and power plant produces electricity, in this case from natural 
                     carrier_out_2: heat
                     primary_carrier_out: electricity
                 constraints:
-                    flow_eff: 0.45
+                    flow_out_eff: 0.45
                     flow_cap_max: 100
                     carrier_ratios.carrier_out_2.heat: 0.8
 
@@ -89,7 +89,7 @@ The output energy from the heat pump can be *either* heat or cooling, simulating
             primary_carrier_out: heat
 
         constraints:
-            flow_eff: 1
+            flow_out_eff: 1
             flow_cap_max: 100
             carrier_ratios:
                 carrier_out:
@@ -124,14 +124,14 @@ A CCHP plant can use generated heat to produce cooling via an absorption chiller
                     primary_carrier_out: electricity
 
                 constraints:
-                    flow_eff: 0.45
+                    flow_out_eff: 0.45
                     flow_cap_max: 100
                     carrier_ratios.carrier_out_2: {heat: 0.8, cooling: 0.5}
 
 Advanced gas turbine
 --------------------
 
-This technology can choose to burn methane (CH:sub:`4`) or send hydrogen (H:sub:`2`) through a fuel cell to produce electricity. One unit of carrier_in can be met by any combination of methane and hydrogen. If all methane, 0.5 units of carrier_out would be produced for 1 unit of carrier_in (flow_eff). If all hydrogen, 0.25 units of carrier_out would be produced for the same amount of carrier_in (flow_eff * hydrogen carrier ratio).
+This technology can choose to burn methane (CH:sub:`4`) or send hydrogen (H:sub:`2`) through a fuel cell to produce electricity. One unit of carrier_in can be met by any combination of methane and hydrogen. If all methane, 0.5 units of carrier_out would be produced for 1 unit of carrier_in (`flow_out_eff`). If all hydrogen, 0.25 units of carrier_out would be produced for the same amount of carrier_in (`flow_out_eff` * hydrogen carrier ratio).
 
 .. figure:: images/conversion_plus_gas.*
 
@@ -144,7 +144,7 @@ This technology can choose to burn methane (CH:sub:`4`) or send hydrogen (H:sub:
             carrier_out: electricity
 
         constraints:
-            flow_eff: 0.5
+            flow_out_eff: 0.5
             flow_cap_max: 100
             carrier_ratios:
                 carrier_in: {methane: 1, hydrogen: 0.5}
@@ -175,7 +175,7 @@ There are few instances where using the full capacity of a conversion_plus tech 
                     primary_carrier_out: electricity
 
                 constraints:
-                    flow_eff: 1
+                    flow_out_eff: 1
                     flow_cap_max: 100
                     carrier_ratios:
                         carrier_in: {coal: 1.2, gas: 1, oil: 1.6}
@@ -207,7 +207,7 @@ By default, ``area_use_max`` is infinite and ``area_use_min`` is 0 (zero).
 Per-distance constraints and costs
 ----------------------------------
 
-Transmission technologies can additionally specify per-distance efficiency (loss) with ``flow_eff_per_distance`` and per-distance costs with ``flow_cap_per_distance``:
+Transmission technologies can additionally specify per-distance efficiency (loss) with ``flow_out_eff_per_distance`` and per-distance costs with ``flow_cap_per_distance``:
 
 .. code-block:: yaml
 
@@ -217,7 +217,7 @@ Transmission technologies can additionally specify per-distance efficiency (loss
                 ...
             constraints:
                 # "efficiency" (1-loss) per unit of distance
-                flow_eff_per_distance: 0.99
+                flow_out_eff_per_distance: 0.99
             costs:
                 monetary:
                     # cost per unit of distance

--- a/doc/user/advanced_features.rst
+++ b/doc/user/advanced_features.rst
@@ -256,7 +256,7 @@ When using overrides (see :ref:`building_overrides`), it is possible to have ``i
 .. code-block:: yaml
 
     techs:
-        some_other_tech.constraints.flow_eff: 0.1
+        some_other_tech.constraints.flow_out_eff: 0.1
 
 This is equivalent to the following override:
 
@@ -266,7 +266,7 @@ This is equivalent to the following override:
         some_override:
             techs:
                 some_tech.constraints.flow_cap_max: 10
-                some_other_tech.constraints.flow_eff: 0.1
+                some_other_tech.constraints.flow_out_eff: 0.1
 
 .. _backend_interface:
 
@@ -281,7 +281,7 @@ You can use this interface to:
     By running :python:`model.backend.get_input_params()` a user get an xarray Dataset which will look very similar to :python:`model.inputs`, except that assumed default values will be included. You may also spot a bug, where a value in :python:`model.inputs` is different to the value returned by this function.
 
 2. Update a parameter value.
-    If you are interested in updating a few values in the model, you can run :python:`model.backend.update_param()`. For example, to update the energy efficiency of your `ccgt` technology in location `region1` from 0.5 to 0.1, you can run :python:`model.backend.update_param('flow_eff', {'region1::ccgt`: 0.1})`. This will not affect results at this stage, you'll need to rerun the backend (point 4) to optimise with these new values.
+    If you are interested in updating a few values in the model, you can run :python:`model.backend.update_param()`. For example, to update the energy efficiency of your `ccgt` technology in location `region1` from 0.5 to 0.1, you can run :python:`model.backend.update_param('flow_out_eff', {'region1::ccgt`: 0.1})`. This will not affect results at this stage, you'll need to rerun the backend (point 4) to optimise with these new values.
 
 .. note:: If you are interested in updating the objective function cost class weights, you will need to set 'objective_cost_class' as the parameter, e.g. :python:`model.backend.update_param('objective_cost_class', {'monetary': 0.5})`.
 

--- a/doc/user/building.rst
+++ b/doc/user/building.rst
@@ -214,7 +214,7 @@ The following example shows the definition of a ``ccgt`` technology, i.e. a comb
             carrier_out: power
         constraints:
             source: inf
-            flow_eff: 0.5
+            flow_out_eff: 0.5
             flow_cap_max: 40000  # kW
             flow_cap_max_systemwide: 100000  # kW
             flow_ramping: 0.8
@@ -223,7 +223,7 @@ The following example shows the definition of a ``ccgt`` technology, i.e. a comb
             monetary:
                 interest_rate: 0.10
                 flow_cap: 750  # USD per kW
-                om_con: 0.02  # USD per kWh
+                flow_in: 0.02  # USD per kWh
 
 Each technology must specify some ``essentials``, most importantly a name, the abstract base technology it is inheriting from (``parent``), and its carrier (``carrier_out`` in the case of a ``supply`` technology). Specifying a ``color`` is optional but useful for using the built-in visualisation tools (see :doc:`analysing`).
 

--- a/doc/user/tutorials_01_national.rst
+++ b/doc/user/tutorials_01_national.rst
@@ -74,7 +74,7 @@ The second location allows a limited amount of battery storage to be deployed to
    :start-after: # battery-start
    :end-before: # battery-end
 
-The contraints give a maximum installed generation capacity for battery storage together with a maximum ratio of flow capacity to storage capacity (``flow_cap_per_storage_cap_max``) of 4, which in turn limits the storage capacity. The ratio is the charge/discharge rate / storage capacity (a.k.a the battery `reservoir`). In the case of a storage technology, ``flow_eff`` applies twice: on charging and discharging. In addition, storage technologies can lose stored carrier over time -- in this case, we set this loss to zero.
+The contraints give a maximum installed generation capacity for battery storage together with a maximum ratio of flow capacity to storage capacity (``flow_cap_per_storage_cap_max``) of 4, which in turn limits the storage capacity. The ratio is the charge/discharge rate / storage capacity (a.k.a the battery `reservoir`). In the case of a storage technology, ``flow_out_eff`` applies twice: on charging and discharging. In addition, storage technologies can lose stored carrier over time -- in this case, we set this loss to zero.
 
 Other technologies
 ==================

--- a/doc/user/tutorials_02_urban.rst
+++ b/doc/user/tutorials_02_urban.rst
@@ -59,7 +59,7 @@ Conversion technologies
 
 The example model defines two conversion technologies.
 
-The first is ``boiler`` (natural gas boiler), which serves as an example of a simple conversion technology with one input carrier and one output carrier. Its only constraints are the cost of built capacity (``costs.monetary.flow_cap``), a constraint on its maximum built capacity (``constraints.flow_cap.max``), and a carrier conversion efficiency (``flow_eff``).
+The first is ``boiler`` (natural gas boiler), which serves as an example of a simple conversion technology with one input carrier and one output carrier. Its only constraints are the cost of built capacity (``costs.monetary.flow_cap``), a constraint on its maximum built capacity (``constraints.flow_cap_max``), and a carrier conversion efficiency (``flow_out_eff``).
 
 .. figure:: images/conversion.*
    :alt: Simple conversion node
@@ -94,7 +94,7 @@ This definition in the example model's configuration is more verbose:
 
 .. seealso:: :ref:`conversion_plus`
 
-Again, ``chp`` has the definitions for name, color, parent, and carrier_in/out. It now has an additional carrier (``carrier_out_2``) defined in its essential information, allowing a second carrier to be produced *at the same time* as the first carrier (``carrier_out``). The carrier ratio constraint tells us the ratio of carrier_out_2 to carrier_out that we can achieve, in this case 0.8 units of heat are produced every time a unit of electricity is produced. to produce these units of energy, gas is consumed at a rate of  ``flow_out(carrier_out) / flow_eff``, so gas consumption is only a function of power output.
+Again, ``chp`` has the definitions for name, color, parent, and carrier_in/out. It now has an additional carrier (``carrier_out_2``) defined in its essential information, allowing a second carrier to be produced *at the same time* as the first carrier (``carrier_out``). The carrier ratio constraint tells us the ratio of carrier_out_2 to carrier_out that we can achieve, in this case 0.8 units of heat are produced every time a unit of electricity is produced. to produce these units of energy, gas is consumed at a rate of  ``flow_out(carrier_out) / flow_out_eff``, so gas consumption is only a function of power output.
 
 As with the ``pv``, the ``chp`` an export eletricity. The revenue gained from this export is given in the file ``export_power.csv``, in which negative values are given per time step.
 
@@ -127,7 +127,7 @@ In this district, electricity and heat can be distributed between locations. Gas
    :start-after: # transmission-start
    :end-before: # transmission-end
 
-``power_lines`` has an efficiency of 0.95, so a loss during transmission of 0.05. ``heat_pipes`` has a loss rate per unit distance of 2.5%/unit distance (or ``flow_eff_per_distance`` of 97.5%). Over the distance between the two locations of 0.5km (0.5 units of distance), this translates to :math:`2.5^{0.5}` = 1.58% loss rate.
+``power_lines`` has an efficiency of 0.95, so a loss during transmission of 0.05. ``heat_pipes`` has a loss rate per unit distance of 2.5%/unit distance (or ``flow_out_eff_per_distance`` of 97.5%). Over the distance between the two locations of 0.5km (0.5 units of distance), this translates to :math:`2.5^{0.5}` = 1.58% loss rate.
 
 
 Locations

--- a/src/calliope/backend/backend_model.py
+++ b/src/calliope/backend/backend_model.py
@@ -369,6 +369,7 @@ class BackendModelGenerator(ABC):
             self.add_parameter(
                 param_name, xr.DataArray(default_val), use_inf_as_na=False
             )
+            self.parameters[param_name].attrs["is_result"] = 0
         LOGGER.info("Optimisation Model: Generated optimisation problem parameters")
 
     @staticmethod
@@ -398,8 +399,8 @@ class BackendModelGenerator(ABC):
                 Dictionary describing the object being added, from which descriptor attributes will be extracted and added to the array attributes.
             references (set):
                 All other backend objects which are references in this backend object's linear expression(s).
-                E.g. the constraint "flow_out / flow_eff <= flow_cap" references the variables ["flow_out", "flow_cap"]
-                and the parameter ["flow_eff"].
+                E.g. the constraint "flow_out / flow_out_eff <= flow_cap" references the variables ["flow_out", "flow_cap"]
+                and the parameter ["flow_out_eff"].
                 All referenced objects will have their "references" attribute updated with this object's name.
                 Defaults to None.
         """

--- a/src/calliope/config/defaults.yaml
+++ b/src/calliope/config/defaults.yaml
@@ -67,11 +67,13 @@ tech_groups:
         "flow_cap_min_systemwide",
         "flow_out_min_relative",
         "flow_cap_per_unit",
-        "flow_eff",
+        "flow_in_eff",
+        "flow_out_eff",
         "flow_ramping",
         "export_max",
         "export_carrier",
         "lifetime",
+        "parasitic_eff",
         "units_min_systemwide",
         "units_max",
         "units_max_systemwide",
@@ -85,8 +87,8 @@ tech_groups:
         "interest_rate",
         "om_annual",
         "om_annual_investment_fraction",
-        "om_con",
-        "om_prod",
+        "flow_in",
+        "flow_out",
         "purchase",
       ]
     allowed_switches: [cap_method, export, allowed_flow_in, allowed_flow_out]
@@ -109,7 +111,8 @@ tech_groups:
         "flow_cap_min",
         "flow_out_min_relative",
         "flow_cap_per_unit",
-        "flow_eff",
+        "flow_in_eff",
+        "flow_out_eff",
         "flow_ramping",
         "export_max",
         "export_carrier",
@@ -127,8 +130,8 @@ tech_groups:
         "interest_rate",
         "om_annual",
         "om_annual_investment_fraction",
-        "om_con",
-        "om_prod",
+        "flow_in",
+        "flow_out",
         "purchase",
       ]
     allowed_switches: [cap_method, export, allowed_flow_in, allowed_flow_out]
@@ -142,7 +145,7 @@ tech_groups:
   demand:
     required_constraints: []
     allowed_constraints: ["sink_min", "sink_max", "sink_equals", "sink_unit"]
-    allowed_costs: [om_con]
+    allowed_costs: [flow_in]
     allowed_switches: [sink_unit, allowed_flow_in, allowed_flow_out]
     essentials:
       parent: null
@@ -162,12 +165,14 @@ tech_groups:
         "flow_cap_min",
         "flow_out_min_relative",
         "flow_cap_per_unit",
-        "flow_eff",
+        "flow_in_eff",
+        "flow_out_eff",
         "flow_ramping",
         "export_max",
         "export_carrier",
         "force_async_flow",
         "lifetime",
+        "parasitic_eff",
         "storage_cap_max",
         "storage_cap_min",
         "storage_cap_per_unit",
@@ -188,7 +193,7 @@ tech_groups:
         "interest_rate",
         "om_annual",
         "om_annual_investment_fraction",
-        "om_prod",
+        "flow_out",
         "purchase",
         "storage_cap",
       ]
@@ -212,11 +217,13 @@ tech_groups:
         "flow_cap_min",
         "flow_out_min_relative",
         "flow_cap_per_unit",
-        "flow_eff",
+        "flow_in_eff",
+        "flow_out_eff",
         "flow_ramping",
         "export_max",
         "export_carrier",
         "lifetime",
+        "parasitic_eff",
         "area_use_max",
         "area_use_min",
         "area_use_per_flow_cap",
@@ -236,8 +243,8 @@ tech_groups:
         "interest_rate",
         "om_annual",
         "om_annual_investment_fraction",
-        "om_con",
-        "om_prod",
+        "flow_in",
+        "flow_out",
         "purchase",
         "area_use",
       ]
@@ -264,7 +271,8 @@ tech_groups:
         "flow_cap_min",
         "flow_out_min_relative",
         "flow_cap_per_unit",
-        "flow_eff",
+        "flow_in_eff",
+        "flow_out_eff",
         "flow_ramping",
         "export_max",
         "export_carrier",
@@ -297,8 +305,8 @@ tech_groups:
         "interest_rate",
         "om_annual",
         "om_annual_investment_fraction",
-        "om_con",
-        "om_prod",
+        "flow_in",
+        "flow_out",
         "purchase",
         "area_use",
         "source_cap",
@@ -333,11 +341,14 @@ tech_groups:
         "flow_cap_min",
         "flow_cap_max",
         "flow_cap_per_unit",
-        "flow_eff",
-        "flow_eff_per_distance",
+        "flow_in_eff",
+        "flow_out_eff",
+        "flow_in_eff_per_distance",
+        "flow_out_eff_per_distance",
         "force_async_flow",
         "lifetime",
         "one_way",
+        "parasitic_eff",
       ]
     allowed_costs:
       [
@@ -347,7 +358,7 @@ tech_groups:
         "interest_rate",
         "om_annual",
         "om_annual_investment_fraction",
-        "om_prod",
+        "flow_out",
         "purchase",
         "purchase_per_distance",
       ]
@@ -399,8 +410,10 @@ techs:
       flow_cap_min_systemwide: 0 # name: System-wide specific installed flow capacity ¦ unit: kW ¦ sets the lower bound of the sum across all nodes of the decision variable `flow_cap` for a particular technology.
       flow_out_min_relative: 0 # name: Minimum outflow ¦ unit: fraction ¦ Set to a value between 0 and 1 to force minimum outflow as a fraction of the technology maximum flow capacity. If non-zero and technology is not defined by ``units``, this will force the technology to operate above its minimum value at every timestep.
       flow_cap_per_unit: null # name: Flow capacity per purchased unit ¦ unit: kW/unit ¦ Set the capacity of each integer unit of a technology purchased
-      flow_eff: 1.0 # name: Flow efficiency ¦ unit: fraction ¦ conversion efficiency (static, or from file as timeseries), from ``source``/``flow_in`` (tech dependent) to ``flow_out``/``sink``.
-      flow_eff_per_distance: 1.0 # name: Flow efficiency per distance ¦ unit: fraction/distance ¦ Set as value between 1 (no loss) and 0 (all lost).
+      flow_in_eff: 1.0 # name: Inflow efficiency ¦ unit: fraction ¦ conversion efficiency (static, or from file as timeseries), from ``source``/``flow_in`` (tech dependent) into the technology.
+      flow_out_eff: 1.0 # name: Outflow efficiency ¦ unit: fraction ¦ conversion efficiency (static, or from file as timeseries), from ``source``/``flow_in`` (tech dependent) into the technology.
+      flow_in_eff_per_distance: 1.0 # name: Inflow (i.e., export from node) efficiency per distance for transmission links ¦ unit: fraction/distance ¦ Set as value between 1 (no loss) and 0 (all lost).
+      flow_out_eff_per_distance: 1.0 # name: outflow (i.e., import from node) efficiency per distance for transmission links ¦ unit: fraction/distance ¦ Set as value between 1 (no loss) and 0 (all lost).
       flow_ramping: 1 # name: Ramping rate ¦ unit: fraction / hour ¦ Set to ``false`` to disable ramping constraints, otherwise limit maximum outflow to a fraction of maximum capacity, which increases by that fraction at each timestep.
       export_max: .inf # name: Maximum allowed export ¦ unit: kW ¦ Maximum allowed export of produced carrier for a technology.
       export_carrier: null # name: Export carrier ¦ unit: N/A ¦ Name of carrier to be exported. Must be an output carrier of the technology
@@ -436,9 +449,10 @@ techs:
         interest_rate: 0 # name: Interest rate ¦ unit: fraction ¦ Used when computing levelized costs
         om_annual: 0 # name: Yearly O&M costs ¦ unit: kW :sub:`flow_cap` :sup:`-1` ¦
         om_annual_investment_fraction: 0 # name: Fractional yearly O&M costs ¦ unit: fraction / total investment ¦
-        om_con: 0 # name: Carrier consumption cost ¦ unit: kWh :sup:`-1` ¦ Applied to carrier consumption of a technology
-        om_prod: 0 # name: outflow cost ¦ unit: kWh :sup:`-1` ¦ Applied to outflow of a technology
-        purchase: 0 # name: Purchase cost ¦ unit: unit :sup:`-1` ¦ Triggers a binary variable for that technology to say that it has been purchased or is applied to integer variable ``units``
+        flow_in: 0 # name: Carrier consumption cost ¦ unit: kWh :sup:`-1` ¦ Applied to carrier consumption of a technology
+        flow_out: 0 # name: outflow cost ¦ unit: kWh :sup:`-1` ¦ Applied to outflow of a technology
+        purchase: 0 # name: Purchase cost ¦ unit: unit :sup:`-1` ¦ Will be applied to either the binary variable `purchased` or the integer variable ``units``
+        purchase_per_distance: 0 # name: Purchase cost per unit distance for transmission techs ¦ unit: unit :sup:`-1` / distance ¦  Will be applied to either the binary variable `purchased` or the integer variable ``units``
         area_use: 0 # name: Cost of area use ¦ unit: m\ :sup:`-2` ¦
         source_cap: 0 # name: Cost of source flow capacity ¦ unit: kW :sup:`-1` ¦
         storage_cap: 0 # name: Cost of storage capacity ¦ unit: kWh :sup:`-1` ¦

--- a/src/calliope/config/math_schema.yaml
+++ b/src/calliope/config/math_schema.yaml
@@ -64,7 +64,7 @@ properties:
                       description: math equation sub-expression which can be one term or a combination of terms using the operators [+, -, *, /, **].
           slices: &slices
             type: object
-            description: Array index slices which are used to replace any instances in which they are referenced in decision variables/parameters/global expressions in the component equation(s) or sub-expressions. Index slices are referenced by their name preceded with the "$" symbol, e.g., `foo` in `flow_eff[techs=$foo]`.
+            description: Array index slices which are used to replace any instances in which they are referenced in decision variables/parameters/global expressions in the component equation(s) or sub-expressions. Index slices are referenced by their name preceded with the "$" symbol, e.g., `foo` in `flow_out_eff[techs=$foo]`.
             additionalProperties: false
             patternProperties:
               '[^\d^_\W][\w\d]+':

--- a/src/calliope/core/model.py
+++ b/src/calliope/core/model.py
@@ -340,6 +340,11 @@ class Model(object):
         default_node_dict = {
             "available_area": raw_defaults.nodes.default_node.available_area
         }
+        default_link_dict = {
+            "distance": raw_defaults.links[
+                "default_node_from,default_node_to"
+            ].techs.default_tech.distance
+        }
 
         return AttrDict(
             {
@@ -347,6 +352,7 @@ class Model(object):
                 **default_tech_dict.switches.as_dict(),
                 **default_cost_dict,
                 **default_node_dict,
+                **default_link_dict,
             }
         )
 

--- a/src/calliope/example_models/national_scale/model_config/techs.yaml
+++ b/src/calliope/example_models/national_scale/model_config/techs.yaml
@@ -18,7 +18,7 @@ techs:
       carrier_out: power
     constraints:
       source_max: inf
-      flow_eff: 0.5
+      flow_out_eff: 0.5
       flow_cap_max: 40000 # kW
       flow_cap_max_systemwide: 100000 # kW
       flow_ramping: 0.8
@@ -27,7 +27,7 @@ techs:
       monetary:
         interest_rate: 0.10
         flow_cap: 750 # USD per kW
-        om_con: 0.02 # USD per kWh
+        flow_in: 0.02 # USD per kWh
   # ccgt-end
 
   # csp-start
@@ -45,7 +45,7 @@ techs:
       flow_cap_per_storage_cap_max: 1
       storage_loss: 0.002
       source_max: file=csp_resource.csv
-      flow_eff: 0.4
+      flow_out_eff: 0.4
       parasitic_eff: 0.9
       area_use_max: inf
       flow_cap_max: 10000
@@ -57,7 +57,7 @@ techs:
         area_use: 200
         source_cap: 200
         flow_cap: 1000
-        om_prod: 0.002
+        flow_out: 0.002
   # csp-end
 
   ##
@@ -74,7 +74,9 @@ techs:
       flow_cap_max: 1000 # kW
       storage_cap_max: inf
       flow_cap_per_storage_cap_max: 4
-      flow_eff: 0.95 # 0.95 * 0.95 = 0.9025 round trip efficiency
+      # 0.95 * 0.95 = 0.9025 round trip efficiency
+      flow_out_eff: 0.95
+      flow_in_eff: 0.95
       storage_loss: 0 # No loss over time assumed
       lifetime: 25
     costs:
@@ -107,13 +109,13 @@ techs:
       parent: transmission
       carrier: power
     constraints:
-      flow_eff: 0.85
+      flow_out_eff: 0.85
       lifetime: 25
     costs:
       monetary:
         interest_rate: 0.10
         flow_cap: 200
-        om_prod: 0.002
+        flow_out: 0.002
 
   free_transmission:
     essentials:
@@ -123,8 +125,8 @@ techs:
       carrier: power
     constraints:
       flow_cap_max: inf
-      flow_eff: 1.0
+      flow_out_eff: 1.0
     costs:
       monetary:
-        om_prod: 0
+        flow_out: 0
   # transmission-end

--- a/src/calliope/example_models/national_scale/scenarios.yaml
+++ b/src/calliope/example_models/national_scale/scenarios.yaml
@@ -174,11 +174,11 @@ overrides:
       ccgt:
         costs:
           emissions:
-            om_prod: 100 # kgCO2/kWh
+            flow_out: 100 # kgCO2/kWh
       csp:
         costs:
           emissions:
-            om_prod: 10 # kgCO2/kWh
+            flow_out: 10 # kgCO2/kWh
 
   maximize_utility_costs:
     parameters:
@@ -187,11 +187,11 @@ overrides:
       ccgt:
         costs:
           utility:
-            om_prod: 10 # arbitrary utility value
+            flow_out: 10 # arbitrary utility value
       csp:
         costs:
           utility:
-            om_prod: 100 # arbitrary utility value
+            flow_out: 100 # arbitrary utility value
 
   capacity_factor:
     techs.ccgt.constraints.capacity_factor_min: 0.8

--- a/src/calliope/example_models/urban_scale/model_config/locations.yaml
+++ b/src/calliope/example_models/urban_scale/model_config/locations.yaml
@@ -21,7 +21,7 @@ nodes:
         costs.monetary.flow_cap: 43.1 # different boiler costs
       pv:
         costs.monetary:
-          om_prod: -0.0203 # revenue for just producing electricity
+          flow_out: -0.0203 # revenue for just producing electricity
           export: -0.0491 # FIT return for PV export
       supply_gas:
       demand_electricity:

--- a/src/calliope/example_models/urban_scale/model_config/techs.yaml
+++ b/src/calliope/example_models/urban_scale/model_config/techs.yaml
@@ -29,7 +29,7 @@ techs:
       monetary:
         interest_rate: 0.10
         flow_cap: 15
-        om_con: 0.1 # 10p/kWh electricity price #ppt
+        flow_in: 0.1 # 10p/kWh electricity price #ppt
 
   supply_gas:
     essentials:
@@ -45,7 +45,7 @@ techs:
       monetary:
         interest_rate: 0.10
         flow_cap: 1
-        om_con: 0.025 # 2.5p/kWh gas price #ppt
+        flow_in: 0.025 # 2.5p/kWh gas price #ppt
   # supply-end
 
   ##-Renewables-##
@@ -83,12 +83,12 @@ techs:
       carrier_in: gas
     constraints:
       flow_cap_max: 600
-      flow_eff: 0.85
+      flow_out_eff: 0.85
       lifetime: 25
     costs:
       monetary:
         interest_rate: 0.10
-        om_con: 0.004 # .4p/kWh
+        flow_in: 0.004 # .4p/kWh
   # boiler-end
 
   # Conversion_plus
@@ -107,14 +107,14 @@ techs:
     constraints:
       export_carrier: electricity
       flow_cap_max: 1500
-      flow_eff: 0.405
+      flow_out_eff: 0.405
       carrier_ratios.carrier_out_2.heat: 0.8
       lifetime: 25
     costs:
       monetary:
         interest_rate: 0.10
         flow_cap: 750
-        om_prod: 0.004 # .4p/kWh for 4500 operating hours/year
+        flow_out: 0.004 # .4p/kWh for 4500 operating hours/year
         export: file=export_power.csv
   # chp-end
 
@@ -145,7 +145,7 @@ techs:
       carrier: electricity
     constraints:
       flow_cap_max: 2000
-      flow_eff: 0.98
+      flow_out_eff: 0.98
       lifetime: 25
     costs:
       monetary:
@@ -160,7 +160,7 @@ techs:
       carrier: heat
     constraints:
       flow_cap_max: 2000
-      flow_eff_per_distance: 0.975
+      flow_out_eff_per_distance: 0.975
       lifetime: 25
     costs:
       monetary:

--- a/src/calliope/math/base.yaml
+++ b/src/calliope/math/base.yaml
@@ -60,7 +60,7 @@ constraints:
     foreach: [nodes, techs, timesteps]
     where: "inheritance(conversion_plus) AND carrier_ratios>0"
     equations:
-      - expression: reduce_carrier_dim(flow_out / carrier_ratios[carrier_tiers=out], carrier_tier=out) == reduce_carrier_dim(flow_in * carrier_ratios[carrier_tiers=in], carrier_tier=in) * flow_eff
+      - expression: reduce_carrier_dim(flow_out / carrier_ratios[carrier_tiers=out], carrier_tier=out) == reduce_carrier_dim(flow_in * carrier_ratios[carrier_tiers=in], carrier_tier=in) * flow_in_eff * flow_out_eff
 
   flow_out_max_conversion_plus:
     description: "Set the upper bound in each timestep of a `conversion_plus` technology's total outflow on its `out` carrier flows."
@@ -116,7 +116,7 @@ constraints:
     foreach: [nodes, techs, timesteps]
     where: "inheritance(conversion)"
     equations:
-      - expression: reduce_carrier_dim(flow_out, carrier_tier=out) == reduce_carrier_dim(flow_in, carrier_tier=in) * flow_eff
+      - expression: reduce_carrier_dim(flow_out, carrier_tier=out) == reduce_carrier_dim(flow_in, carrier_tier=in) * flow_in_eff * (flow_out_eff * parasitic_eff)
 
   flow_out_max:
     description: "Set the upper bound of a non-`conversion_plus` technology's outflow."
@@ -182,12 +182,10 @@ constraints:
     foreach: [nodes, techs, carriers, timesteps]
     where: "(source_equals OR source_max) AND inheritance(supply)"
     equations:
-      - where: "source_equals AND flow_eff > 0"
-        expression: "flow_out / flow_eff == source_equals * $source_scaler"
-      - where: "(NOT source_equals) AND sink_max AND flow_eff > 0"
-        expression: "flow_out / flow_eff <= source_max * $source_scaler"
-      - where: "flow_eff = 0"
-        expression: "flow_out == 0"
+      - where: "source_equals"
+        expression: "flow_out == source_equals * $source_scaler * flow_out_eff  * parasitic_eff"
+      - where: "(NOT source_equals) AND sink_max"
+        expression: "flow_out <= source_max * $source_scaler * flow_out_eff  * parasitic_eff"
     sub_expressions:
       source_scaler: &source_scaler
         - where: "source_unit=per_area"
@@ -200,9 +198,9 @@ constraints:
   balance_supply_min_use:
     description: "Set the lower bound on the quantity of its source a `supply` technology must use in each timestep."
     foreach: [nodes, techs, carriers, timesteps]
-    where: "source_min AND NOT source_equals AND inheritance(supply) AND flow_eff>0"
+    where: "source_min AND NOT source_equals AND inheritance(supply)"
     equations:
-      - expression: "flow_out / flow_eff >= source_min * $source_scaler"
+      - expression: "flow_out / (flow_out_eff * parasitic_eff) >= source_min * $source_scaler"
     sub_expressions:
       source_scaler: *source_scaler
 
@@ -211,12 +209,10 @@ constraints:
     where: "inheritance(demand)"
     equations:
       - where: "sink_equals"
-        expression: "$flow_in == sink_equals * $sink_scaler"
+        expression: "flow_in * flow_in_eff == sink_equals * $sink_scaler"
       - where: "NOT sink_equals AND sink_max"
-        expression: "$flow_in <= sink_max * $sink_scaler"
+        expression: "flow_in * flow_in_eff <= sink_max * $sink_scaler"
     sub_expressions:
-      flow_in:
-        - expression: flow_in * flow_eff
       sink_scaler: &sink_scaler
         - where: "sink_unit=per_area"
           expression: "area_use"
@@ -228,9 +224,9 @@ constraints:
   balance_demand_min_use:
     description: "Set the lower bound on the quantity of flow a `demand` technology must dump to its sink in each timestep."
     foreach: [nodes, techs, carriers, timesteps]
-    where: "sink_min AND NOT source_equals AND inheritance(supply) AND flow_eff>0"
+    where: "sink_min AND NOT source_equals AND inheritance(supply)"
     equations:
-      - expression: "sink_min * $sink_scaler <= flow_in * flow_eff"
+      - expression: "flow_in * flow_in_eff >= sink_min * $sink_scaler"
     sub_expressions:
       sink_scaler: *sink_scaler
 
@@ -239,22 +235,15 @@ constraints:
     foreach: [nodes, techs, carriers, timesteps]
     where: "inheritance(supply_plus) AND NOT include_storage=True"
     equations:
-      - expression: source_use * source_eff == $flow_out
-    sub_expressions:
-      flow_out: &flow_out_with_parasitic
-        - where: flow_eff=0 OR parasitic_eff=0
-          expression: "0"
-        - where: NOT (flow_eff=0 OR parasitic_eff=0)
-          expression: flow_out / (flow_eff * parasitic_eff)
+      - expression: flow_out == source_use * source_eff * flow_out_eff * parasitic_eff
 
   balance_supply_plus_with_storage:
     description: "Set the upper bound on, or a fixed total of, a `supply_plus` (with storage) technology's ability to produce flow based on the quantity of consumed resource and available stored carrier."
     foreach: [nodes, techs, carriers, timesteps]
     where: "storage AND inheritance(supply_plus)"
     equations:
-      - expression: storage == $storage_previous_step + source_use * source_eff - $flow_out
+      - expression: storage == $storage_previous_step + source_use * source_eff - flow_out / (flow_out_eff * parasitic_eff)
     sub_expressions:
-      flow_out: *flow_out_with_parasitic
       storage_previous_step: &storage_previous_step
         - where: timesteps=get_val_at_index(timesteps=0) AND NOT config.cyclic_storage=True
           expression: storage_initial * storage_cap
@@ -280,13 +269,8 @@ constraints:
     foreach: [nodes, techs, timesteps]
     where: "inheritance(storage)"
     equations:
-      - expression: storage == $storage_previous_step - $flow_out + reduce_carrier_dim(flow_in, carrier_tier=in) * flow_eff
+      - expression: storage == $storage_previous_step - reduce_carrier_dim(flow_out, carrier_tier=out) / (flow_out_eff * parasitic_eff) + reduce_carrier_dim(flow_in, carrier_tier=in) * flow_in_eff
     sub_expressions:
-      flow_out:
-        - where: flow_eff > 0
-          expression: reduce_carrier_dim(flow_out, carrier_tier=out) / flow_eff
-        - where: flow_eff = 0
-          expression: "0"
       storage_previous_step: *storage_previous_step
 
   set_storage_initial:
@@ -304,7 +288,18 @@ constraints:
     foreach: [nodes, techs, carriers, timesteps]
     where: "inheritance(transmission) AND allowed_flow_out=True"
     equations:
-      - expression: "flow_out == select_from_lookup_arrays(flow_in, techs=link_remote_techs, nodes=link_remote_nodes) * flow_eff"
+      - expression: "flow_out == select_from_lookup_arrays(flow_in * flow_in_eff * $distance_flow_in_eff, techs=link_remote_techs, nodes=link_remote_nodes) * (flow_out_eff * parasitic_eff * $distance_flow_out_eff)"
+    sub_expressions:
+      distance_flow_out_eff:
+        - where: flow_out_eff_per_distance AND distance
+          expression: flow_out_eff_per_distance ** distance
+        - where: NOT (flow_out_eff_per_distance AND distance)
+          expression: "1"
+      distance_flow_in_eff:
+        - where: flow_in_eff_per_distance AND distance
+          expression: flow_in_eff_per_distance ** distance
+        - where: NOT (flow_in_eff_per_distance AND distance)
+          expression: "1"
 
   symmetric_transmission:
     description: "Fix the flow capacity of two `transmission` technologies representing the same link in the system."
@@ -633,45 +628,47 @@ global_expressions:
     description: "The operating costs per timestep of a technology"
     unit: cost_per_time
     foreach: [nodes, techs, costs, timesteps]
-    where: "cost_export OR cost_om_con OR cost_om_prod"
+    where: "cost_export OR cost_flow_in OR cost_flow_out"
     equations:
-      - expression: timestep_weights * ($cost_export + $cost_om_prod + $cost_om_con)
+      - expression: timestep_weights * ($cost_export + $cost_flow_out + $cost_flow_in)
     sub_expressions:
       cost_export:
         - where: "export_carrier AND cost_export"
           expression: cost_export * sum(flow_export, over=carriers)
         - where: "NOT cost_export"
           expression: "0"
-      cost_om_con:
-        - where: "cost_om_con AND inheritance(supply_plus)"
-          expression: cost_om_con * source_use
-        - where: "cost_om_con AND inheritance(supply) AND flow_eff>0 AND [out] in carrier_tiers"
-          expression: cost_om_con * reduce_carrier_dim(flow_out, carrier_tier=out) / flow_eff
-        - where: "cost_om_con AND inheritance(conversion_plus)"
-          expression: cost_om_con * reduce_primary_carrier_dim(flow_in, carrier_tier=in)
-        - where: "cost_om_con AND NOT (inheritance(conversion_plus) OR inheritance(supply_plus) OR inheritance(supply)) AND [in] in carrier_tiers"
-          expression: cost_om_con * reduce_carrier_dim(flow_in, carrier_tier=in)
-        - where: "NOT cost_om_con"
+      cost_flow_in:
+        - where: "cost_flow_in AND inheritance(supply_plus)"
+          expression: cost_flow_in * source_use
+        - where: "cost_flow_in AND inheritance(supply) AND [out] in carrier_tiers"
+          expression: cost_flow_in * reduce_carrier_dim(flow_out, carrier_tier=out) / flow_out_eff
+        - where: "cost_flow_in AND inheritance(conversion_plus)"
+          expression: cost_flow_in * reduce_primary_carrier_dim(flow_in, carrier_tier=in)
+        - where: "cost_flow_in AND NOT (inheritance(conversion_plus) OR inheritance(supply_plus) OR inheritance(supply)) AND [in] in carrier_tiers"
+          expression: cost_flow_in * reduce_carrier_dim(flow_in, carrier_tier=in)
+        - where: "NOT cost_flow_in"
           expression: "0"
-      cost_om_prod:
-        - where: "cost_om_prod AND inheritance(conversion_plus)"
-          expression: cost_om_prod * reduce_primary_carrier_dim(flow_out, carrier_tier=out)
-        - where: "cost_om_prod AND NOT inheritance(conversion_plus)"
-          expression: cost_om_prod * reduce_carrier_dim(flow_out, carrier_tier=out)
-        - where: "NOT cost_om_prod"
+      cost_flow_out:
+        - where: "cost_flow_out AND inheritance(conversion_plus)"
+          expression: cost_flow_out * reduce_primary_carrier_dim(flow_out, carrier_tier=out)
+        - where: "cost_flow_out AND NOT inheritance(conversion_plus)"
+          expression: cost_flow_out * reduce_carrier_dim(flow_out, carrier_tier=out)
+        - where: "NOT cost_flow_out"
           expression: "0"
 
   cost_investment:
     description: "The installation costs of a technology, including annualised investment costs and annual maintenance costs."
     unit: cost
     foreach: [nodes, techs, costs]
-    where: "(cost_flow_cap OR cost_om_annual OR cost_om_annual_investment_fraction OR cost_purchase OR cost_area_use OR cost_source_cap OR cost_storage_cap)"
+    where: "(cost_flow_cap OR cost_om_annual OR cost_om_annual_investment_fraction OR cost_purchase OR cost_area_use OR cost_source_cap OR cost_storage_cap OR cost_flow_cap_per_distance OR cost_purchase_per_distance)"
     equations:
       - expression: >
           annualisation_weight * (
             cost_depreciation_rate * (
-                $cost_flow_cap + $cost_storage_cap + $cost_source_cap
-                + $cost_area_use + $cost_of_purchase
+                $cost_flow_cap + $distance_cost_flow_cap
+                + $cost_storage_cap + $cost_source_cap
+                + $cost_area_use
+                + $cost_of_purchase + $distance_cost_of_purchase
               ) * ($multiplier + cost_om_annual_investment_fraction)
               + cost_om_annual * flow_cap
           )
@@ -685,6 +682,11 @@ global_expressions:
         - where: "cost_flow_cap"
           expression: cost_flow_cap * flow_cap
         - where: "NOT cost_flow_cap"
+          expression: "0"
+      distance_cost_flow_cap:
+        - where: "cost_flow_cap_per_distance AND distance"
+          expression: cost_flow_cap_per_distance * flow_cap * distance
+        - where: "NOT (cost_flow_cap_per_distance AND distance)"
           expression: "0"
       cost_storage_cap:
         - where: "cost_storage_cap AND storage_cap"
@@ -707,6 +709,13 @@ global_expressions:
         - where: "cost_purchase AND units"
           expression: "cost_purchase * units"
         - where: "NOT (cost_purchase AND (purchased OR units))"
+          expression: "0"
+      distance_cost_of_purchase:
+        - where: "cost_purchase_per_distance AND distance AND purchased"
+          expression: cost_purchase_per_distance * purchased * distance
+        - where: "cost_purchase_per_distance AND distance AND units"
+          expression: cost_purchase_per_distance * units * distance
+        - where: "NOT (cost_purchase_per_distance AND distance AND (purchased OR units))"
           expression: "0"
 
   cost:

--- a/src/calliope/math/operate.yaml
+++ b/src/calliope/math/operate.yaml
@@ -24,6 +24,6 @@ variables:
 global_expressions:
   cost_investment.active: false
   cost:
-    where: "cost_export OR cost_om_con OR cost_om_prod"
+    where: "cost_export OR cost_flow_in OR cost_flow_out"
     equations:
       - expression: $cost_var_sum

--- a/tests/common/test_model/model.yaml
+++ b/tests/common/test_model/model.yaml
@@ -29,7 +29,7 @@ techs:
     constraints:
       flow_cap_max: 15
       source_max: .inf
-      flow_eff: 0.9
+      flow_out_eff: 0.9
 
   test_supply_elec:
     essentials:
@@ -39,7 +39,7 @@ techs:
     constraints:
       flow_cap_max: 10
       source_max: .inf
-      flow_eff: 0.9
+      flow_out_eff: 0.9
 
   test_supply_coal:
     essentials:
@@ -49,7 +49,7 @@ techs:
     constraints:
       flow_cap_max: 10
       source_max: .inf
-      flow_eff: 0.9
+      flow_out_eff: 0.9
 
   test_supply_plus:
     essentials:
@@ -60,7 +60,7 @@ techs:
       flow_cap_max: 15
       source_max: file=supply_plus_resource.csv
       source_eff: 0.9
-      flow_eff: 0.9
+      flow_out_eff: 0.9
       storage_cap_max: 35
       flow_cap_per_storage_cap_max: 0.5
       storage_loss: 0.01
@@ -76,7 +76,7 @@ techs:
       flow_cap_max: 10
       storage_cap_max: 15
       flow_cap_per_storage_cap_max: 0.5
-      flow_eff: 0.9
+      flow_out_eff: 0.9
       storage_loss: 0.01
 
   test_conversion:
@@ -87,7 +87,7 @@ techs:
       parent: conversion
     constraints:
       flow_cap_max: 15
-      flow_eff: 0.9
+      flow_out_eff: 0.9
 
   test_conversion_plus:
     essentials:

--- a/tests/common/test_model/model_minimal.yaml
+++ b/tests/common/test_model/model_minimal.yaml
@@ -25,7 +25,7 @@ techs:
     constraints:
       flow_cap_max: 10
       source_max: .inf
-      flow_eff: 0.9
+      flow_out_eff: 0.9
   test_demand_elec:
     essentials:
       name: Demand elec tech

--- a/tests/common/test_model/weighted_obj_func.yaml
+++ b/tests/common/test_model/weighted_obj_func.yaml
@@ -21,9 +21,9 @@ techs:
       monetary:
         interest_rate: 0.1
         flow_cap: 1000
-        om_prod: 1
+        flow_out: 1
       emissions:
-        om_prod: 2
+        flow_out: 2
 
   expensive_clean_supply:
     essentials:
@@ -37,9 +37,9 @@ techs:
       monetary:
         interest_rate: 0.1
         flow_cap: 2000
-        om_prod: 2
+        flow_out: 2
       emissions:
-        om_prod: 1
+        flow_out: 1
 
   mean_supply:
     essentials:
@@ -53,9 +53,9 @@ techs:
       monetary:
         interest_rate: 0.1
         flow_cap: 1500
-        om_prod: 1.5
+        flow_out: 1.5
       emissions:
-        om_prod: 1.5
+        flow_out: 1.5
 
   electricity_demand:
     essentials:

--- a/tests/test_backend_pyomo.py
+++ b/tests/test_backend_pyomo.py
@@ -515,13 +515,13 @@ class TestCostConstraints:
     @pytest.mark.parametrize(
         "tech,scenario,cost",
         (
-            ("test_supply_elec", "simple_supply", "om_prod"),
-            ("test_supply_elec", "simple_supply", "om_con"),
-            ("test_supply_plus", "simple_supply_and_supply_plus", "om_con"),
-            ("test_demand_elec", "simple_supply", "om_con"),
-            ("test_transmission_elec", "simple_supply", "om_prod"),
-            ("test_conversion", "simple_conversion", "om_con"),
-            ("test_conversion_plus", "simple_conversion_plus", "om_prod"),
+            ("test_supply_elec", "simple_supply", "flow_out"),
+            ("test_supply_elec", "simple_supply", "flow_in"),
+            ("test_supply_plus", "simple_supply_and_supply_plus", "flow_in"),
+            ("test_demand_elec", "simple_supply", "flow_in"),
+            ("test_transmission_elec", "simple_supply", "flow_out"),
+            ("test_conversion", "simple_conversion", "flow_in"),
+            ("test_conversion_plus", "simple_conversion_plus", "flow_out"),
         ),
     )
     def test_loc_techs_cost_var_constraint(self, tech, scenario, cost):
@@ -538,11 +538,11 @@ class TestCostConstraints:
 
     def test_one_way_om_cost(self):
         """
-        With one_way transmission, it should still be possible to set an om_prod cost.
+        With one_way transmission, it should still be possible to set an flow_out cost.
         """
         m = build_model(
             {
-                "techs.test_transmission_elec.costs.monetary.om_prod": 1,
+                "techs.test_transmission_elec.costs.monetary.flow_out": 1,
                 "links.a,b.techs.test_transmission_elec.switches.one_way": True,
             },
             "simple_supply,two_hours",
@@ -607,7 +607,7 @@ class TestExportConstraints:
         assert "cost_var" in supply_export.backend.expressions
 
         m = build_model(
-            {"techs.test_supply_elec.costs.monetary.om_prod": 0.1},
+            {"techs.test_supply_elec.costs.monetary.flow_out": 0.1},
             "supply_export,two_hours,investment_costs",
         )
         m.build()
@@ -1807,13 +1807,8 @@ class TestNewBackend:
         )
 
     def test_new_build_get_parameter(self, simple_supply):
-        param = simple_supply.backend.get_parameter("flow_eff")
-        assert (
-            param.to_series()
-            .dropna()
-            .apply(lambda x: isinstance(x, pmo.parameter))
-            .all()
-        )
+        param = simple_supply.backend.get_parameter("flow_in_eff")
+        assert isinstance(param.item(), pmo.parameter)
         assert param.attrs == {
             "obj_type": "parameters",
             "is_result": 0,
@@ -1823,7 +1818,9 @@ class TestNewBackend:
         }
 
     def test_new_build_get_parameter_as_vals(self, simple_supply):
-        param = simple_supply.backend.get_parameter("flow_eff", as_backend_objs=False)
+        param = simple_supply.backend.get_parameter(
+            "flow_in_eff", as_backend_objs=False
+        )
         assert param.dtype == np.dtype("float64")
 
     def test_new_build_get_global_expression(self, simple_supply):
@@ -1954,11 +1951,11 @@ class TestNewBackend:
 
     def test_raise_error_on_preexistence_same_type(self, simple_supply):
         with pytest.raises(exceptions.BackendError) as excinfo:
-            simple_supply.backend.add_parameter("flow_eff", xr.DataArray(1))
+            simple_supply.backend.add_parameter("flow_out_eff", xr.DataArray(1))
 
         assert check_error_or_warning(
             excinfo,
-            "Trying to add already existing `flow_eff` to backend model parameters.",
+            "Trying to add already existing `flow_out_eff` to backend model parameters.",
         )
 
     def test_raise_error_on_preexistence_diff_type(self, simple_supply):
@@ -2222,7 +2219,7 @@ class TestNewBackend:
                 },
                 "variables",
             ),
-            ("flow_eff", {"nodes": "a", "techs": "test_supply_elec"}, "parameters"),
+            ("flow_out_eff", {"nodes": "a", "techs": "test_supply_elec"}, "parameters"),
             (
                 "system_balance",
                 {
@@ -2253,12 +2250,9 @@ class TestNewBackend:
         obj = simple_supply_longnames.backend.get_constraint(
             "balance_demand", as_backend_objs=False
         )
-        flow_eff_dims = ", ".join(
-            dims[i] for i in simple_supply_longnames.backend.parameters.flow_eff.dims
-        )
         assert (
             obj.sel(dims).body.item()
-            == f"parameters[flow_eff][{flow_eff_dims}]*variables[flow_in][{', '.join(dims[i] for i in obj.dims)}]"
+            == f"parameters[flow_in_eff]*variables[flow_in][{', '.join(dims[i] for i in obj.dims)}]"
         )
         assert obj.coords_in_name
 
@@ -2285,11 +2279,11 @@ class TestNewBackend:
         assert obj.coords_in_name
 
     def test_update_parameter(self, simple_supply):
-        updated_param = simple_supply.inputs.flow_eff * 1000
-        simple_supply.backend.update_parameter("flow_eff", updated_param)
+        updated_param = simple_supply.inputs.flow_out_eff * 1000
+        simple_supply.backend.update_parameter("flow_out_eff", updated_param)
 
         expected = simple_supply.backend.get_parameter(
-            "flow_eff", as_backend_objs=False
+            "flow_out_eff", as_backend_objs=False
         )
         assert expected.where(updated_param.notnull()).equals(updated_param)
 
@@ -2298,37 +2292,37 @@ class TestNewBackend:
         new_dims = {"nodes", "techs"}
         caplog.set_level(logging.DEBUG)
 
-        simple_supply.backend.update_parameter("flow_eff", updated_param)
+        simple_supply.backend.update_parameter("flow_out_eff", updated_param)
 
         assert (
             f"New values will be broadcast along the {new_dims} dimension(s)"
             in caplog.text
         )
         expected = simple_supply.backend.get_parameter(
-            "flow_eff", as_backend_objs=False
+            "flow_out_eff", as_backend_objs=False
         )
         assert (expected == updated_param).all()
 
     def test_update_parameter_replace_defaults(self, simple_supply):
-        updated_param = simple_supply.inputs.flow_eff.fillna(0.1)
+        updated_param = simple_supply.inputs.flow_out_eff.fillna(0.1)
 
-        simple_supply.backend.update_parameter("flow_eff", updated_param)
+        simple_supply.backend.update_parameter("flow_out_eff", updated_param)
 
         expected = simple_supply.backend.get_parameter(
-            "flow_eff", as_backend_objs=False
+            "flow_out_eff", as_backend_objs=False
         )
         assert expected.equals(updated_param)
 
     def test_update_parameter_add_dim(self, caplog, simple_supply):
-        """flow_eff doesn't have the time dimension in the simple model, we add it here."""
-        updated_param = simple_supply.inputs.flow_eff.where(
+        """flow_out_eff doesn't have the time dimension in the simple model, we add it here."""
+        updated_param = simple_supply.inputs.flow_out_eff.where(
             simple_supply.inputs.timesteps.notnull()
         )
 
-        refs_to_update = {"balance_demand", "balance_transmission"}
+        refs_to_update = {"balance_transmission"}
         caplog.set_level(logging.DEBUG)
 
-        simple_supply.backend.update_parameter("flow_eff", updated_param)
+        simple_supply.backend.update_parameter("flow_out_eff", updated_param)
 
         assert (
             "Defining values for a previously fully/partially undefined parameter. "
@@ -2337,18 +2331,18 @@ class TestNewBackend:
         )
 
         expected = simple_supply.backend.get_parameter(
-            "flow_eff", as_backend_objs=False
+            "flow_out_eff", as_backend_objs=False
         )
         assert "timesteps" in expected.dims
 
     def test_update_parameter_replace_undefined(self, caplog, simple_supply):
-        """parasitic_eff isn't defined in the inputs, so is a dimensionless value in the pyomo object, assigned its default value"""
-        updated_param = simple_supply.inputs.flow_eff
+        """flow_in_eff isn't defined in the inputs, so is a dimensionless value in the pyomo object, assigned its default value"""
+        updated_param = simple_supply.inputs.flow_out_eff
 
-        refs_to_update = {"flow_out_max"}
+        refs_to_update = {"balance_demand", "balance_transmission"}
         caplog.set_level(logging.DEBUG)
 
-        simple_supply.backend.update_parameter("parasitic_eff", updated_param)
+        simple_supply.backend.update_parameter("flow_in_eff", updated_param)
 
         assert (
             "Defining values for a previously fully/partially undefined parameter. "
@@ -2357,9 +2351,9 @@ class TestNewBackend:
         )
 
         expected = simple_supply.backend.get_parameter(
-            "parasitic_eff", as_backend_objs=False
+            "flow_in_eff", as_backend_objs=False
         )
-        default_val = simple_supply._model_data.defaults["parasitic_eff"]
+        default_val = simple_supply._model_data.defaults["flow_in_eff"]
         assert expected.equals(updated_param.fillna(default_val))
 
     def test_update_parameter_no_refs_to_update(self, simple_supply):

--- a/tests/test_backend_pyomo_constraints_conversion_plus.py
+++ b/tests/test_backend_pyomo_constraints_conversion_plus.py
@@ -97,7 +97,7 @@ class TestBuildConversionPlusConstraints:
         sets.loc_techs_om_cost_conversion_plus,
         """
 
-        # om_prod creates constraint and populates it with flow_out driven cost
+        # flow_out creates constraint and populates it with flow_out driven cost
         m = build_model(
             {f"techs.test_conversion_plus.costs.monetary.om_{flow}": 0.1},
             "simple_conversion_plus,two_hours,investment_costs",
@@ -226,7 +226,7 @@ class TestBuildConversionPlusConstraints:
 class TestConversionPlusConstraintResults:
     def test_carrier_ratio(self):
         m = build_model(
-            {"techs.test_conversion.costs.monetary.om_prod": 3},
+            {"techs.test_conversion.costs.monetary.flow_out": 3},
             "conversion_and_conversion_plus,one_day,investment_costs",
         )
         m.build()
@@ -259,7 +259,7 @@ class TestConversionPlusConstraintResults:
                         "carrier_in": ["gas", "coal"],
                         "primary_carrier_in": "gas",
                     },
-                    "costs.monetary": {"om_con": 2, "om_prod": -1},
+                    "costs.monetary": {"flow_in": 2, "flow_out": -1},
                 }
             },
             "conversion_and_conversion_plus,one_day,investment_costs",

--- a/tests/test_constraint_results.py
+++ b/tests/test_constraint_results.py
@@ -119,7 +119,7 @@ class TestModelSettings:
                 # Allow setting resource and flow_cap_max/equals to force infeasibility
                 "techs.test_supply_elec.constraints": {
                     "source_equals": cap_val,
-                    "flow_eff": 1,
+                    "flow_out_eff": 1,
                     "flow_cap_equals": 15,
                 },
             }

--- a/tests/test_core_model.py
+++ b/tests/test_core_model.py
@@ -232,8 +232,8 @@ class TestValidateMathDict:
         [
             ("1 == 1", "True"),
             (
-                "flow_out * flow_eff + sum(cost, over=costs) <= .inf",
-                "inheritance(supply) and flow_eff>0",
+                "flow_out * flow_out_eff + sum(cost, over=costs) <= .inf",
+                "inheritance(supply) and flow_out_eff>0",
             ),
         ],
     )

--- a/tests/test_core_preprocess.py
+++ b/tests/test_core_preprocess.py
@@ -905,10 +905,10 @@ class TestChecks:
         with pytest.raises(exceptions.ModelError):
             build_model(override_dict=override, scenario="simple_supply,one_day")
 
-        # should fail: om_prod not allowed for demand tech
+        # should fail: flow_out not allowed for demand tech
         override = AttrDict.from_yaml_string(
             """
-            techs.test_demand_elec.costs.monetary.om_prod: 10
+            techs.test_demand_elec.costs.monetary.flow_out: 10
             """
         )
         with pytest.raises(exceptions.ModelError):

--- a/tests/test_model_data.py
+++ b/tests/test_model_data.py
@@ -446,12 +446,12 @@ class TestTopLevelParams:
     def test_protected_parameter_names(self):
         with pytest.raises(KeyError) as excinfo:
             build_model(
-                {"parameters.flow_eff.data": 1},
+                {"parameters.flow_out_eff.data": 1},
                 "simple_supply,two_hours",
             )
         assert check_error_or_warning(
             excinfo,
-            "Trying to add top-level parameter with same name as a node/tech level parameter: flow_eff",
+            "Trying to add top-level parameter with same name as a node/tech level parameter: flow_out_eff",
         )
 
     @pytest.mark.parametrize("val", [1, 1.0, np.inf, "foo"])


### PR DESCRIPTION
Allow for input and output flows to have different efficiencies (mostly useful for storage techs, but also conversion).

I did try to expand this to cover capacities too (see https://github.com/calliope-project/calliope/tree/add_in_out_params), but this leads to a lot of additional verbosity and base math for what I came to realise was little additional benefit.

The beenfit generally of splitting out `in` and `out` is that in reality there are technologies that work that way (conversion technologies that have a limit on e.g., biofuel flows in as well as on heat output; storage technologies with different charge capacities to discharge capacities; transmission links with different NTCs in each direction). However, expanding everything to account for `flow_in_cap` and `flow_out_cap` is cumbersome. 

Hopefully it will be possible to at least set a different rated capacity for different carriers with the intro of #484, which would cover conversion techs. However, for storage / transmission techs (same in and out carrier), the issue still remains.

## introducing `flow_in_cap` and `flow_out_cap` in custom math

It should be possible, for storage techs, to not define `flow_cap_max` and then to define instead one's own `flow_in_cap_max` and `flow_out_cap_max` and introduce that as the constraining params for input and output flows (although `flow_cap` will still be linked to `flow_out`, requiring careful consideration when applying costs).

For transmission techs, `flow_cap` is forced to be the same in both directions so it again would be somewhat meaningless if introducing `flow_in_cap_max` and `flow_out_cap_max`. The custom math might also be hard as you need to do it per _link_, so need to write the custom math per link tech (`tech_name:remote_node`) and make sure you're getting `flow_in` (export) and `flow_out` (import) the right way around!

Summary of changes in this pull request:

* Expand `flow_eff` to `flow_in_eff` (applies to flows into the technology) and `flow_out_eff` (applies to flows out of a technology).
* Rename `om_prod` and `om_con` to `cost_flow_out` and `cost_flow_in`.
* Apply per-distance params in the base math rather than as hardcoded computation in preprocessing.

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved