### PR TITLE
Add distance unit config item & default to km

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This enables un-indexed parameters to be defined, as well as those indexed over 
 |new| parameter dimensions at the `tech` or `node` level can be enhanced using the new `parameter` definition syntax.
 For instance, `flow_cap` can be defined per `carrier`.
 
+|changed| Automatically derived transmission link distances default to kilometres, with the configuration option (`config.init.distance_unit`) to switch to the old default of distances in metres.
+
 |changed| |backwards-incompatible| Costs must be defined using the new `parameter` definition syntax.
 
 |changed| `flow_cap` (formerly `energy_cap`) is indexed over `carriers` as well as `nodes` and `techs`.

--- a/src/calliope/config/config_schema.yaml
+++ b/src/calliope/config/config_schema.yaml
@@ -62,6 +62,13 @@ properties:
                 If referring to an in-built Calliope custom math file (see documentation for available files), do not append the reference with ".yaml".
                 If referring to your own custom math file, ensure the file type is given as a suffix (".yaml" or ".yml").
                 Relative paths will be assumed to be relative to the model definition file given when creating a calliope Model (`calliope.Model(model_definition=...)`)
+          distance_unit:
+            type: string
+            default: km
+            description: >-
+              Unit of transmission link `distance` (m - metres, km - kilometres).
+              Automatically derived distances from lat/lon coordinates will be given in this unit.
+            enum: [m, km]
 
       build:
         type: object

--- a/src/calliope/config/model_def_schema.yaml
+++ b/src/calliope/config/model_def_schema.yaml
@@ -728,7 +728,8 @@ properties:
             default: .nan
             title: Distance spanned by link.
             description: >-
-              Used for per_distance constraints. If not defined, it will be automatically inferred from latitude/longitude of nodes in a link if not given here.
+              Used for `..._per_distance` constraints.
+              If not defined, it will be automatically derived from latitude/longitude of nodes in a link.
 
           flow_in_eff_per_distance:
             $ref: "#/$defs/TechParamNullNumberVariable"

--- a/src/calliope/preprocess/model_data.py
+++ b/src/calliope/preprocess/model_data.py
@@ -298,6 +298,8 @@ class ModelDataFactory:
                     self.model_data.longitude.sel(nodes=node2).item(),
                 )["s12"]
             distance_array = pd.Series(distances).rename_axis(index="techs").to_xarray()
+            if self.config["distance_unit"] == "km":
+                distance_array /= 1000
         else:
             LOGGER.debug(
                 "Link distances will not be computed automatically since lat/lon coordinates are not defined."

--- a/tests/test_model_data.py
+++ b/tests/test_model_data.py
@@ -172,7 +172,7 @@ class TestModelData:
         assert model_data_factory.model_data["definition_matrix"].dtype.kind == "b"
 
     @pytest.mark.parametrize(
-        ["existing_distance", "expected_distance"], [(np.nan, 343834), (1, 1)]
+        ["existing_distance", "expected_distance"], [(np.nan, 343.834), (1, 1)]
     )
     def test_add_link_distances_missing_distance(
         self,
@@ -204,9 +204,12 @@ class TestModelData:
             techs="test_link_a_b_elec"
         ).item() == pytest.approx(expected_distance)
 
+    @pytest.mark.parametrize(["unit", "expected"], [("m", 343834), ("km", 343.834)])
     def test_add_link_distances_no_da(
-        self, my_caplog, model_data_factory_w_params: ModelDataFactory
+        self, my_caplog, model_data_factory_w_params: ModelDataFactory, unit, expected
     ):
+        _default_distance_unit = model_data_factory_w_params.config["distance_unit"]
+        model_data_factory_w_params.config["distance_unit"] = unit
         model_data_factory_w_params.clean_data_from_undefined_members()
         model_data_factory_w_params.model_data["latitude"] = (
             pd.Series({"A": 51.507222, "B": 48.8567})
@@ -221,10 +224,11 @@ class TestModelData:
         del model_data_factory_w_params.model_data["distance"]
 
         model_data_factory_w_params.add_link_distances()
+        model_data_factory_w_params.config["distance_unit"] = _default_distance_unit
         assert "Link distance matrix automatically computed" in my_caplog.text
         assert (
             model_data_factory_w_params.model_data["distance"].dropna("techs")
-            == pytest.approx(343834)
+            == pytest.approx(expected)
         ).all()
 
     def test_add_link_distances_no_latlon(


### PR DESCRIPTION
Fixes #209 

Summary of changes in this pull request:

* `config.init.distance_unit` option available to define whether distances should be derived in metres or kilometres

Reviewer checklist:

- [x] Test(s) added to cover contribution
- [ ] Documentation updated
- [x] Changelog updated
- [x] Coverage maintained or improved