### PR TITLE
Fix references between built backend components

### DIFF
--- a/src/calliope/backend/latex_backend_model.py
+++ b/src/calliope/backend/latex_backend_model.py
@@ -335,7 +335,7 @@ class LatexBackendModel(backend_model.BackendModelGenerator):
     ) -> None:
         domain_dict = {"real": r"\mathbb{R}\;", "integer": r"\mathbb{Z}\;"}
 
-        def _variable_setter(where: xr.DataArray) -> xr.DataArray:
+        def _variable_setter(where: xr.DataArray, references: set) -> xr.DataArray:
             return where.where(where)
 
         if variable_dict is None:


### PR DESCRIPTION
Fixes issue found while implementing gurobi backend related to how updates to parameters filter through the rest of the backend model.
It now goes into variables and updates those if needs and it then implements the updates in order (parameters->variables->exprs->constrs->objective)

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved