### PR TITLE
Make release checklist clickable

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -6,14 +6,14 @@ on:
       - "main"
     paths-ignore:
       - README.md
-      - changelog.rst
+      - CHANGELOG.md
       - LICENSE
       - CITATION
       - AUTHORS
-      - doc/**
       - docs/**
       - .readthedocs.yml
       - .pre-commit-config.yaml
+      - mkdocs.yml
 
 defaults:
   run:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,7 +86,8 @@ markdown_extensions:
       alternate_style: true
   - pymdownx.snippets
   - pymdownx.details
-
+  - pymdownx.tasklist:
+      clickable_checkbox: true
 
 nav:
   - Home: index.md


### PR DESCRIPTION
Fixes the release checklist so it's clickable. I find this useful for going through the checklist even if the checkboxes dont persist on refresh.

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved