### PR TITLE
Release v0.7.0.dev2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.0.dev2 (dev)
+## 0.7.0.dev2 (2024-01-26)
 
 v0.7 includes a major change to how Calliope internally operates.
 Along with this, there are multiple changes to how Calliope models are defined and configured.

--- a/src/calliope/_version.py
+++ b/src/calliope/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.0-dev"
+__version__ = "0.7.0.dev2"


### PR DESCRIPTION
Let's try again!

Reviewer checklist:

- [x] Version updated
- [ ] Documentation updated
- [x] Changelog updated
- [x] Test-PyPI run succeeds (and installing locally works: `pip install -i https://test.pypi.org/simple/ --extra-index-ur
l https://pypi.org/simple calliope==0.7.0.dev2`)