### PR TITLE
Update data source dtype coercion

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -20,12 +20,18 @@ defaults:
     shell: bash -l {0}
 
 env:
-  LANG: "en_GB.UTF-8"
+  LANG: "en_GB"
+  LC_ALL: "en_GB.UTF-8"
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+
+    - name: Update locale
+      run: |
+        sudo locale-gen en_GB en_GB.UTF-8
+
     - uses: actions/checkout@v3
 
     - uses: mamba-org/setup-micromamba@v1

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -21,7 +21,6 @@ defaults:
 
 env:
   LANG: "en_GB"
-  LC_ALL: "en_GB.UTF-8"
 
 jobs:
   test:
@@ -29,8 +28,7 @@ jobs:
     steps:
 
     - name: Update locale
-      run: |
-        sudo locale-gen en_GB en_GB.UTF-8
+      run: sudo locale-gen en_GB en_GB.UTF-8
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -19,6 +19,9 @@ defaults:
   run:
     shell: bash -l {0}
 
+env:
+  LANG: "en_GB.UTF-8"
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -28,7 +28,6 @@ concurrency:
 
 env:
   LANG: "en_GB.UTF-8"
-  LC_ALL: "en_GB.UTF-8"
 
 jobs:
   test:
@@ -45,6 +44,11 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
+
+    - name: Update locale
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo locale-gen en_GB en_GB.UTF-8
+
     - uses: actions/checkout@v3
 
     - uses: mamba-org/setup-micromamba@v1

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  LANG: "en_GB.UTF-8"
+
 jobs:
   test:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -28,6 +28,7 @@ concurrency:
 
 env:
   LANG: "en_GB.UTF-8"
+  LC_ALL: "en_GB.UTF-8"
 
 jobs:
   test:

--- a/src/calliope/preprocess/data_sources.py
+++ b/src/calliope/preprocess/data_sources.py
@@ -29,6 +29,8 @@ LOGGER = logging.getLogger(__name__)
 
 locale.setlocale(locale.LC_ALL, "")
 
+exceptions.warn(f"Locale: {locale.getlocale()}")
+
 
 class DataSourceDict(TypedDict):
     rows: NotRequired[str | list[str]]

--- a/src/calliope/preprocess/data_sources.py
+++ b/src/calliope/preprocess/data_sources.py
@@ -27,7 +27,7 @@ from calliope.util.tools import listify, relative_path
 
 LOGGER = logging.getLogger(__name__)
 
-locale.setlocale(locale.LC_ALL, "en_GB.utf-8")
+locale.setlocale(locale.LC_ALL, "")
 
 
 class DataSourceDict(TypedDict):

--- a/src/calliope/preprocess/data_sources.py
+++ b/src/calliope/preprocess/data_sources.py
@@ -27,7 +27,7 @@ from calliope.util.tools import listify, relative_path
 
 LOGGER = logging.getLogger(__name__)
 
-locale.setlocale(locale.LC_ALL, "en_GB")
+locale.setlocale(locale.LC_ALL, "en_GB.utf-8")
 
 
 class DataSourceDict(TypedDict):

--- a/src/calliope/preprocess/data_sources.py
+++ b/src/calliope/preprocess/data_sources.py
@@ -27,7 +27,7 @@ from calliope.util.tools import listify, relative_path
 
 LOGGER = logging.getLogger(__name__)
 
-locale.setlocale(locale.LC_ALL, "")
+locale.setlocale(locale.LC_ALL, "en_GB")
 
 
 class DataSourceDict(TypedDict):

--- a/src/calliope/preprocess/data_sources.py
+++ b/src/calliope/preprocess/data_sources.py
@@ -412,7 +412,7 @@ class DataSource:
             self._log(
                 f"Updating non-NaN values of parameter `{tdf_group.name}` to {dtype} type"
             )
-            if dtype == "float" and not is_numeric_dtype(tdf_group):
+            if dtype in ["float", int] and not is_numeric_dtype(tdf_group):
                 tdf_group = tdf_group.apply(
                     lambda x: atof(x) if not is_numeric_dtype(type(x)) else x
                 )

--- a/src/calliope/preprocess/time.py
+++ b/src/calliope/preprocess/time.py
@@ -157,7 +157,7 @@ def cluster(data: xr.Dataset, clustering_file: str | Path, time_format: str):
     """
     clustering_timeseries = pd.read_csv(clustering_file, index_col=0).squeeze()
     clustering_timeseries.index = _datetime_index(
-        clustering_timeseries.index + " 00:00:00", time_format
+        clustering_timeseries.index, time_format
     )
     representative_days = pd.to_datetime(clustering_timeseries.dropna()).dt.date
     grouper = representative_days.to_frame("clusters").groupby("clusters")
@@ -182,17 +182,12 @@ def cluster(data: xr.Dataset, clustering_file: str | Path, time_format: str):
 
 def _datetime_index(index: pd.Index, format: str) -> pd.Index:
     try:
-        if format == "ISO8601":
-            dt = pd.to_datetime(index, format=format)
-        else:
-            dt = pd.to_datetime(index, format=format, exact=False)
+        return pd.to_datetime(index, format=format)
     except ValueError as e:
         raise exceptions.ModelError(
             f"Error in parsing dates in timeseries data from using datetime format `{format}`. "
             f"Full error: {e}"
         )
-    else:
-        return dt
 
 
 def _check_time_subset(ts_index: pd.Index, time_subset: list[str]):


### PR DESCRIPTION
Fixes issue where data sources contain numeric data with separators.

E.g., `25,000` would be loaded by stored in CSV as "25,000" and pandas can't natively coerce that to a numeric dtype. 

Summary of changes in this pull request:

* Data that should be numeric but is stored in the array as a string due to a separator will be coerced to a numeric value according to the "locale" of the user's machine. I believe this defaults to `,` being the thousand separator and `.` the decimal point. It would probably be feasible for a user to change the locale manually (
`locale.setlocale(..)`) if they had data using other separators.

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved