### PR TITLE
Purge `time_data_path`

### DIFF
--- a/docs/creating/config.md
+++ b/docs/creating/config.md
@@ -8,7 +8,6 @@ This includes for example the choice of solver with which to actually solve the 
 config:
     init:
         name: 'My energy model'
-        time_data_path: 'timeseries_data'
         time_subset: ['2005-01-01', '2005-01-05']
     build:
         mode: plan
@@ -34,7 +33,7 @@ model.build(ensure_feasibility=True)
 model.solve(save_logs="path/to/logs/dir")
 ```
 
-None of the configuration options are _required_ as there is a default value for them all, but you will likely want to set `init.name`, `init.calliope_version`, `init.time_data_path`, `build.mode`, and `solve.solver`.
+None of the configuration options are _required_ as there is a default value for them all, but you will likely want to set `init.name`, `init.calliope_version`, `build.mode`, and `solve.solver`.
 
 To test your model pipeline, `config.init.time_subset` is a good way to limit your model size by slicing the time dimension to a smaller range.
 

--- a/src/calliope/config/config_schema.yaml
+++ b/src/calliope/config/config_schema.yaml
@@ -45,10 +45,6 @@ properties:
             type: ["null", string]
             default: null
             description: setting to cluster the timeseries, must be a path to a file where each date is linked to a representative date that also exists in the timeseries.
-          time_data_path:
-            type: string
-            default: "."
-            description: Path to time series data. If relative, it will be relative to the base model definition file.
           time_format:
             type: string
             default: "ISO8601"

--- a/src/calliope/example_models/national_scale/model.yaml
+++ b/src/calliope/example_models/national_scale/model.yaml
@@ -12,8 +12,6 @@ config:
     name: National-scale example model
     # What version of Calliope this model is intended for
     calliope_version: 0.7.0
-    # Time series data path - can either be a path relative to this file, or an absolute path
-    time_data_path: "timeseries_data"
     time_subset: ["2005-01-01", "2005-01-05"] # Subset of timesteps
 
   build:

--- a/tests/common/test_model/energy_cap_per_storage_cap.yaml
+++ b/tests/common/test_model/energy_cap_per_storage_cap.yaml
@@ -1,7 +1,6 @@
 config:
   init:
     name: Test model for energy capacity per storage capacity
-    time_data_path: "timeseries_data"
     time_subset: ["2005-01-01 00:00", "2005-01-01 01:00"]
 
   build:

--- a/tests/common/test_model/model.yaml
+++ b/tests/common/test_model/model.yaml
@@ -14,7 +14,6 @@ import:
 config:
   init:
     name: Test model
-    time_data_path: "timeseries_data"
     time_subset: ["2005-01-01", "2005-01-02"]
   build:
     mode: plan

--- a/tests/common/test_model/model_minimal.yaml
+++ b/tests/common/test_model/model_minimal.yaml
@@ -4,7 +4,6 @@ import:
 config:
   init:
     name: Minimal test model
-    time_data_path: "timeseries_data"
   build:
     mode: plan
   solve:

--- a/tests/common/test_model/weighted_obj_func.yaml
+++ b/tests/common/test_model/weighted_obj_func.yaml
@@ -1,7 +1,6 @@
 config:
   init:
     name: Cost capacity constraint test model
-    time_data_path: "timeseries_data"
     time_subset: ["2005-01-01", "2005-01-01"]
   build:
     mode: plan


### PR DESCRIPTION
Fixes existence of `config.init.time_data_path` which no longer does anything. Thanks for noticing @irm-codebase.


Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved