### PR TITLE
Update CI action versions

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -23,7 +23,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: mamba-org/setup-micromamba@v1
       with:
@@ -53,6 +53,6 @@ jobs:
 
     - name: upload coverage report to Codecov
       if: github.ref == 'refs/heads/main'
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       env:
         directory: "./reports/coverage/"

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -13,6 +13,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: markdown-link-check
         uses: gaurav-nelson/github-action-markdown-link-check@1.0.15

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: mamba-org/setup-micromamba@v1
       with:
@@ -81,11 +81,13 @@ jobs:
       run: pytest
 
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       if: matrix.os == 'ubuntu-latest' && matrix.py3version == '12'
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
         directory: "./reports/coverage/"
+        verbose: true
 
   pre-release-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
     - name: Download built package from another workflow
-      uses: dawidd6/action-download-artifact@v2
+      uses: dawidd6/action-download-artifact@v3
       with:
         name: ${{ env.PACKAGENAME }}
         workflow: pr-ci.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ output = "reports/coverage/coverage.xml"
 
 [tool.black]
 line-length = 88
-skip_magic_trailing_comma = true
+skip-magic-trailing-comma = true
 target-version = ['py310', 'py311', 'py312']
 include = '\.pyi?$'
 exclude = '''


### PR DESCRIPTION
Codecov has been acting up so I think it's time to use their latest github action version and bite the bullet and add the CODECOV token to the repository secrets (they said it wasn't necessary for open source projects but uploads sometimes fail for lack of it).

Also updated a pyproject.toml setting that was wrong. Thanks @irm-codebase for picking up on that.


Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved