### PR TITLE
Add py.typed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ where = ["src"]
 include = ["calliope*"]
 
 [tool.setuptools.package-data]
-calliope = ["config/*", "math/*", "example_models/**/*"]
+calliope = ["config/*", "math/*", "example_models/**/*", "py.typed"]
 
 [tool.setuptools]
 license-files = ["LICENSE", "CITATION"]


### PR DESCRIPTION
Lets mypy know that calliope includes type hints, which is needed for type hints to filter through when calliope is a dependency.

Summary of changes in this pull request:

* Add `py.typed` file to source dir.
* Ensure `py.typed` is packaged on wheel building.

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved