### PR TITLE
Coerce model dimension dtypes to numeric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Both the index and the values of the timeseries (both being date strings) should
 
 |changed| `inbuilt` math -> `pre-defined` math and `custom` math -> `pre-defined` math in the documentation.
 
+|fixed| Dimensions with numeric data can be defined in tabular data _or_ YAML and will appear as numeric in the processed Calliope model input dataset.
+If all dimension data can be coerced to a numeric data type (e.g. `["10", 100, "-1"]`), then it _will_ be coerced (e.g., `[10, 100, -1]`).
+
 ## 0.7.0.dev2 (2024-01-26)
 
 v0.7 includes a major change to how Calliope internally operates.

--- a/docs/creating/data_sources.md
+++ b/docs/creating/data_sources.md
@@ -400,6 +400,11 @@ E.g.,
     data_sources:
       ...
     ```
+6. We process dimension data after loading it in according to a limited set of heuristics:
+    1. we assume any dimension with the suffix `steps` (e.g., `timesteps`, `monthsteps`) is timeseries data, and attempt to convert the data type of the dimension values accordingly.
+    2. We will attempt to convert dimension data to numeric values.
+    Therefore, dimensions with the data `[1, 2]`, `["1", "2"]`, `[1, "2"]`, and `["1.0", 2.0]` will all be converted to having a numeric data type (integer or float).
+    `["foo", "1"]` and `["foo", 1]` will _not_ be converted, as not all dimension data entries are convertible to numeric data types.
 
 ### Data you _cannot_ load in tabular format
 

--- a/src/calliope/preprocess/model_data.py
+++ b/src/calliope/preprocess/model_data.py
@@ -754,8 +754,11 @@ class ModelDataFactory:
 
     @staticmethod
     def _update_numeric_dims(ds: xr.Dataset, id_: str) -> xr.Dataset:
-        """Try coercing all dimensions to numeric.
-        Any that don't raise an error will remain as numeric.
+        """Try coercing all dimension data of the input dataset to a numeric data type.
+
+        Any dimensions where _all_ its data is potentially numeric will be returned with all data coerced to numeric.
+        All other dimensions will be returned as they were in the input dataset.
+        No changes are made to data variables in the dataset.
 
         Args:
             ds (xr.Dataset): Dataset possibly containing numeric dimensions.

--- a/tests/test_preprocess_model_data.py
+++ b/tests/test_preprocess_model_data.py
@@ -702,8 +702,7 @@ class TestModelData:
         new_param = simple_da.copy().to_dataset(name="non_ts_data")
         model_data_factory._add_to_dataset(new_param, "foo")
 
-        assert "foo | Updating" not in my_caplog.text
-        assert "datetime format" not in my_caplog.text
+        assert "dimension index values to datetime format" not in my_caplog.text
         # make sure nothing has changed in the array
         assert "non_ts_data" in model_data_factory.dataset
         assert model_data_factory.dataset["non_ts_data"].equals(simple_da)

--- a/tests/test_preprocess_model_data.py
+++ b/tests/test_preprocess_model_data.py
@@ -709,6 +709,62 @@ class TestModelData:
         assert model_data_factory.dataset["non_ts_data"].equals(simple_da)
 
     @pytest.mark.parametrize(
+        ["data", "kind"],
+        [
+            ([1, 2], "i"),
+            (["1", "2"], "i"),
+            (["1", 2], "i"),
+            ([1, "2"], "i"),
+            ([1.0, 2.0], "f"),
+            (["1.0", "2.0"], "f"),
+            ([1, "2.0"], "f"),
+            (["1", 2.0], "f"),
+        ],
+    )
+    def test_update_numeric_dims(
+        self, my_caplog, model_data_factory: ModelDataFactory, data, kind
+    ):
+        new_idx = pd.Index(data, name="bar")
+        new_param = pd.DataFrame({"my_data": [True, False]}, index=new_idx).to_xarray()
+        updated_ds = model_data_factory._update_numeric_dims(new_param, "foo")
+
+        assert (
+            "foo | Updating `bar` dimension index values to numeric type"
+            in my_caplog.text
+        )
+        assert updated_ds.coords["bar"].dtype.kind == kind
+
+    @pytest.mark.parametrize(["data", "kind"], [(["1", 2], "i"), ([1.0, "2.0"], "f")])
+    def test_update_numeric_dims_in_model_data(
+        self, my_caplog, model_data_factory: ModelDataFactory, data, kind
+    ):
+        new_idx = pd.Index(data, name="bar")
+        new_param = pd.DataFrame({"num_data": [True, False]}, index=new_idx).to_xarray()
+        model_data_factory._add_to_dataset(new_param, "foo")
+
+        assert (
+            "foo | Updating `bar` dimension index values to numeric type"
+            in my_caplog.text
+        )
+        assert model_data_factory.dataset.coords["bar"].dtype.kind == kind
+
+    @pytest.mark.parametrize(
+        "data", [["foo", 2], [1.0, "foo"], ["foo", "bar"], ["Y1", "Y2"]]
+    )
+    def test_update_numeric_dims_no_update(
+        self, my_caplog, model_data_factory: ModelDataFactory, data
+    ):
+        new_idx = pd.Index(data, name="bar")
+        new_param = pd.DataFrame({"ts_data": [True, False]}, index=new_idx).to_xarray()
+        updated_ds = model_data_factory._update_numeric_dims(new_param, "foo")
+
+        assert (
+            "foo | Updating `bar` dimension index values to numeric type"
+            not in my_caplog.text
+        )
+        assert updated_ds.coords["bar"].dtype.kind not in ["f", "i"]
+
+    @pytest.mark.parametrize(
         ["coords", "new_coords"],
         [(["foobar", "baz"], ["baz"]), (["bazfoo", "baz"], ["bazfoo", "baz"])],
     )


### PR DESCRIPTION
Fixes #567 

Summary of changes in this pull request:

* Always try to convert data dimensions to numeric and keep any successful attempts. 
* Add some tests.
* Add mention of this in the docs.

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved