### PR TITLE
Shadow price configuration in YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.0.dev4 (development)
+
+### User-facing changes
+
+|new| Allow extracting shadow prices into results by listing constraints in `config.solve.shadow_prices`, e.g. `config.solve.shadow_prices: ["system_balance"]`  Shadow prices will be added as variables to the model results as `shadow_price_{constraintname}`, e.g. `shadow_price_system_balance`.
+
 ## 0.7.0.dev3 (2024-02-14)
 
 ### User-facing changes

--- a/docs/advanced/shadow_prices.md
+++ b/docs/advanced/shadow_prices.md
@@ -3,7 +3,7 @@
 In a linear problem, you can obtain the [shadow prices](https://en.wikipedia.org/wiki/Shadow_price) (dual variables) for each constraint from the Pyomo backend.
 This can prove particularly useful if you are linking Calliope with other models or want to dig deeper into the economic impacts of your designed energy system.
 
-You can access shadow prices by specifying a list of constraints for which shadow prices should be returned in the results, in your `solve` configuration:
+You can access shadow prices by specifying a list of [constraints][base-math] for which shadow prices should be returned in the results, in your `solve` configuration:
 
 ```yaml
 config:
@@ -22,7 +22,10 @@ config:
 
 ## Shadow prices when running in Python
 
-When running in Python, you can turn on shadow price tracking by running `model.backend.shadow_prices.activate()` after `model.build()`. Then, you can access shadow prices for any constraint once you have an optimal solution by running `model.backend.shadow_prices.get("constraint_name")`, which returns an [xarray.DataArray][].
+When running in Python, you can additionally turn on shadow price tracking by running `model.backend.shadow_prices.activate()` after `model.build()`.
+By doing that, or by having added at least one valid constraint in `config.solve.shadow_prices` (see above), shadow price tracking will be enabled.
+
+Then, you can access shadow prices for any constraint once you have an optimal solution by running `model.backend.shadow_prices.get("constraint_name")`, which returns an [xarray.DataArray][].
 
 !!! example
 

--- a/docs/advanced/shadow_prices.md
+++ b/docs/advanced/shadow_prices.md
@@ -55,7 +55,7 @@ As with [running in the command-line tool](#shadow-prices-when-using-the-command
     ```python
     model = calliope.examples.national_scale()
     model.build()
-    model.solve(shadow_prices="system_balance")
+    model.solve(shadow_prices=["system_balance"])
 
     balance_price = model.results.shadow_price_system_balance.to_series()
     ```

--- a/docs/advanced/shadow_prices.md
+++ b/docs/advanced/shadow_prices.md
@@ -3,7 +3,26 @@
 In a linear problem, you can obtain the [shadow prices](https://en.wikipedia.org/wiki/Shadow_price) (dual variables) for each constraint from the Pyomo backend.
 This can prove particularly useful if you are linking Calliope with other models or want to dig deeper into the economic impacts of your designed energy system.
 
-You can access shadow prices for any constraint by running once you have an optimal solution by running `model.backend.shadow_prices.get("constraint_name")`, which returns an [xarray.DataArray][].
+You can access shadow prices by specifying a list of constraints for which shadow prices should be returned in the results, in your `solve` configuration:
+
+```yaml
+config:
+    solve:
+        shadow_prices: ["system_balance", ...]
+```
+
+!!! note
+
+    * Not all solvers provide access to shadow prices.
+    For instance, we know that it is possible with Gurobi and GLPK, but not with CBC.
+    Since we cannot test all Pyomo-compatible solvers, you may run into issues depending on the solver you use.
+    * You cannot access shadow prices if you have integer/binary variables in your model.
+    If you try to do so, you will receive a warning, and shadow price tracking will remain disabled.
+    * You can check the status of shadow price tracking with `model.backend.shadow_prices.is_active`.
+
+## Shadow prices when running in Python
+
+When running in Python, you can turn on shadow price tracking by running `model.backend.shadow_prices.activate()` after `model.build()`. Then, you can access shadow prices for any constraint once you have an optimal solution by running `model.backend.shadow_prices.get("constraint_name")`, which returns an [xarray.DataArray][].
 
 !!! example
 
@@ -17,13 +36,4 @@ You can access shadow prices for any constraint by running once you have an opti
     ```
 
     1. With the Pyomo backend interface, tracking shadow prices can be memory-intensive.
-    Therefore, you must actively activate tracking before solving your model.
-
-!!! note
-
-    * Not all solvers provide an API to access duals.
-    For instance, we know it is not possible with the CBC solver.
-    * You cannot access shadow prices if you have integer/binary variables in your model.
-    If you try to do so, you will receive a None/NaN-filled array.
-    * You can check the status of shadow price tracking with `model.backend.shadow_prices.is_active`.
-    * Currently, the only way to access shadow prices is by running Calliope in Python, and not through the command-line interface.
+    Therefore, you must manually activate tracking before solving your model.

--- a/docs/advanced/shadow_prices.md
+++ b/docs/advanced/shadow_prices.md
@@ -3,13 +3,16 @@
 In a linear problem, you can obtain the [shadow prices](https://en.wikipedia.org/wiki/Shadow_price) (dual variables) for each constraint from the Pyomo backend.
 This can prove particularly useful if you are linking Calliope with other models or want to dig deeper into the economic impacts of your designed energy system.
 
-You can access shadow prices by specifying a list of [constraints][base-math] for which shadow prices should be returned in the results, in your `solve` configuration:
+You can access shadow prices by specifying a list of constraints for which shadow prices should be returned in the results, in your `solve` configuration:
 
 ```yaml
 config:
     solve:
         shadow_prices: ["system_balance", ...]
 ```
+
+A list of the available constraint names can be found under "Subject to" in [our base math documentation page][base-math].
+If you [define any of your own math constraints](../user_defined_math/components.md#constraints), you can also reference those by name in the list.
 
 !!! note
 
@@ -20,12 +23,18 @@ config:
     If you try to do so, you will receive a warning, and shadow price tracking will remain disabled.
     * You can check the status of shadow price tracking with `model.backend.shadow_prices.is_active`.
 
+## Shadow prices when using the command-line tool
+
+By specifying constraints in the YAML configuration (see above), shadow price tracking will be activated and the shadow prices of those constraints you have listed will be available in the results dataset, prefixed with `shadow_price_`.
+For instance, listing `system_balance` in the configuration will lead to `shadow_price_system_balance` being available in the optimisation results that are saved to file on calling [`calliope run ...`](../running.md#running-with-the-command-line-tool).
+
 ## Shadow prices when running in Python
 
 When running in Python, you can additionally turn on shadow price tracking by running `model.backend.shadow_prices.activate()` after `model.build()`.
 By doing that, or by having added at least one valid constraint in `config.solve.shadow_prices` (see above), shadow price tracking will be enabled.
 
 Then, you can access shadow prices for any constraint once you have an optimal solution by running `model.backend.shadow_prices.get("constraint_name")`, which returns an [xarray.DataArray][].
+As with [running in the command-line tool](#shadow-prices-when-using-the-command-line-tool), having a list of shadow prices to track in the solve configuration will lead to shadow prices being available automatically in the model [results dataset][calliope.Model.results].
 
 !!! example
 
@@ -40,3 +49,13 @@ Then, you can access shadow prices for any constraint once you have an optimal s
 
     1. With the Pyomo backend interface, tracking shadow prices can be memory-intensive.
     Therefore, you must manually activate tracking before solving your model.
+
+    Or:
+
+    ```python
+    model = calliope.examples.national_scale()
+    model.build()
+    model.solve(shadow_prices="system_balance")
+
+    balance_price = model.results.shadow_price_system_balance.to_series()
+    ```

--- a/src/calliope/backend/backend_model.py
+++ b/src/calliope/backend/backend_model.py
@@ -19,6 +19,7 @@ from typing import (
     Any,
     Callable,
     Generic,
+    Iterable,
     Literal,
     Optional,
     SupportsFloat,
@@ -759,6 +760,18 @@ class BackendModel(BackendModelGenerator, Generic[T]):
             path (Union[str, Path]): Path to which the LP file will be written.
         """
 
+    @property
+    @abstractmethod
+    def has_integer_or_binary_variables(self) -> bool:
+        """Confirm whether or not the built model has binary or integer decision variables.
+
+        This can be used to understand how long the optimisation may take (MILP problems are harder to solve than LP ones),
+        and to verify whether shadow prices can be tracked (they cannot be tracked in MILP problems).
+
+        Returns:
+            bool: If True, the built model has binary or integer decision variables. If False, all decision variables are continuous.
+        """
+
     @abstractmethod
     def _solve(
         self,
@@ -797,21 +810,6 @@ class BackendModel(BackendModelGenerator, Generic[T]):
                 otherwise an empty dataset.
         """
 
-    def _activate_shadow_prices_if_needed(self, solve_config: dict) -> list:
-        shadow_prices = set(solve_config.get("shadow_prices", []))
-        invalid_constraints = shadow_prices.difference(self.constraints.data_vars)
-        valid_constraints = shadow_prices.intersection(self.constraints.data_vars)
-        if invalid_constraints:
-            model_warn(
-                f"Invalid constraints {invalid_constraints} in `config.solve.shadow_prices`.  "
-                "Their shadow prices will not be tracked."
-            )
-        # Only actually activate shadow price tracking if at least one valid
-        # constraint remains in the list after filtering out invalid ones
-        if valid_constraints:
-            self.shadow_prices.activate()
-        self.tracked_shadow_prices = valid_constraints
-
     def load_results(self) -> xr.Dataset:
         """
         Evaluate backend decision variables, global expressions, parameters (if not in
@@ -840,12 +838,9 @@ class BackendModel(BackendModelGenerator, Generic[T]):
             if expr.notnull().any()
         }
 
-        shadow_prices = (
-            self.tracked_shadow_prices if hasattr(self, "tracked_shadow_prices") else []
-        )
         all_shadow_prices = {
             f"shadow_price_{constraint}": self.shadow_prices.get(constraint)
-            for constraint in shadow_prices
+            for constraint in self.shadow_prices.tracked
         }
 
         results = xr.Dataset(
@@ -901,6 +896,8 @@ class ShadowPrices:
     To keep memory overhead low. Shadow price tracking is deactivated by default.
     """
 
+    _tracked: set = set()
+
     @abstractmethod
     def get(self, name) -> xr.DataArray:
         """Extract shadow prices (a.k.a. duals) from a constraint.
@@ -924,3 +921,36 @@ class ShadowPrices:
     @abstractmethod
     def is_active(self) -> bool:
         "Check whether shadow price tracking is active or not"
+
+    @property
+    @abstractmethod
+    def available_constraints(self) -> Iterable:
+        "Iterable of constraints that are available to provide shadow prices on"
+
+    @property
+    def tracked(self) -> set:
+        "Constraints being tracked for automatic addition to the results dataset"
+        return self._tracked
+
+    def track_constraints(self, constraints_to_track: list):
+        """Track constraints if they are available in the built backend model.
+
+        If there is at least one available constraint to track,
+        `self.tracked` will be updated and shadow price tracking will be activated.
+
+        Args:
+            constraints_to_track (list): Constraint names to track
+        """
+        shadow_prices = set(constraints_to_track)
+        invalid_constraints = shadow_prices.difference(self.available_constraints)
+        valid_constraints = shadow_prices.intersection(self.available_constraints)
+        if invalid_constraints:
+            model_warn(
+                f"Invalid constraints {invalid_constraints} in `config.solve.shadow_prices`. "
+                "Their shadow prices will not be tracked."
+            )
+        # Only actually activate shadow price tracking if at least one valid
+        # constraint remains in the list after filtering out invalid ones
+        if valid_constraints:
+            self.activate()
+        self._tracked = valid_constraints

--- a/src/calliope/backend/backend_model.py
+++ b/src/calliope/backend/backend_model.py
@@ -797,7 +797,7 @@ class BackendModel(BackendModelGenerator, Generic[T]):
                 otherwise an empty dataset.
         """
 
-    def _activate_shadow_prices_if_needed(self, solve_config: dict) -> None:
+    def _activate_shadow_prices_if_needed(self, solve_config: dict) -> list:
         shadow_prices = solve_config.get("shadow_prices", None)
         if shadow_prices:
             for constraint_name in shadow_prices:
@@ -812,6 +812,7 @@ class BackendModel(BackendModelGenerator, Generic[T]):
             # constraint remains in the list after filtering out invalid ones
             if shadow_prices:
                 self.shadow_prices.activate()
+        return shadow_prices
 
     def load_results(self) -> xr.Dataset:
         """

--- a/src/calliope/backend/pyomo_backend_model.py
+++ b/src/calliope/backend/pyomo_backend_model.py
@@ -488,6 +488,14 @@ class PyomoBackendModel(backend_model.BackendModel):
             variable_da = variable_da.where(where.fillna(0))
         self._apply_func(self._unfix_pyomo_variable, variable_da)
 
+    @property
+    def has_integer_or_binary_variables(self) -> bool:
+        model_report = build_model_size_report(self._instance)
+        binaries = model_report["activated"]["binary_variables"]
+        integers = model_report["activated"]["integer_variables"]
+        number_of_binary_and_integer_vars = binaries + integers
+        return number_of_binary_and_integer_vars > 0
+
     def _get_capacity_bound(
         self, bound: Any, name: str, references: set
     ) -> xr.DataArray:
@@ -821,16 +829,6 @@ class PyomoBackendModel(backend_model.BackendModel):
                     pd.to_datetime, data.coords[name_], keep_attrs=True
                 )
 
-    def _has_integer_or_binary_variables(self) -> bool:
-        model_report = build_model_size_report(self._instance)
-        binaries = model_report["activated"]["binary_variables"]
-        integers = model_report["activated"]["integer_variables"]
-        number_of_binary_and_integer_vars = binaries + integers
-        if number_of_binary_and_integer_vars:
-            return True
-        else:
-            return False
-
 
 class CoordObj(ABC):
     """Class with methods to update the `name` property of inheriting classes"""
@@ -928,7 +926,7 @@ class PyomoShadowPrices(backend_model.ShadowPrices):
         )
 
     def activate(self):
-        if self._backend_obj._has_integer_or_binary_variables():
+        if self._backend_obj.has_integer_or_binary_variables:
             warning_text = "Shadow price tracking on a model with binary or integer variables is not possible. Proceeding without activating shadow price tracking."
             model_warn(warning_text, _class=BackendWarning)
         else:
@@ -940,6 +938,10 @@ class PyomoShadowPrices(backend_model.ShadowPrices):
     @property
     def is_active(self) -> bool:
         return self._dual_obj.active
+
+    @property
+    def available_constraints(self) -> Iterable:
+        return self._backend_obj.constraints.data_vars
 
     @staticmethod
     def _duals_from_pyomo_constraint(

--- a/src/calliope/config/config_schema.yaml
+++ b/src/calliope/config/config_schema.yaml
@@ -161,6 +161,14 @@ properties:
             type: number
             default: 1e-10
             description: On postprocessing the optimisation results, values smaller than this threshold will be considered as optimisation artefacts and will be set to zero.
+          shadow_prices:
+            type: array
+            uniqueItems: true
+            items:
+              type: string
+              description: Names of model constraints.
+            default: []
+            description: List of constraints for which to extract shadow prices. Shadow prices will be added as variables to the model results as `shadow_price_{constraintname}`.
 
   parameters:
     type: [object, "null"]

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -448,9 +448,7 @@ class Model(object):
 
         solver_config = update_then_validate_config("solve", self.config, **kwargs)
 
-        updated_shadow_prices = self.backend._activate_shadow_prices_if_needed(
-            solver_config
-        )
+        self.backend._activate_shadow_prices_if_needed(solver_config)
 
         if run_mode == "operate":
             if not self._model_data.attrs["allow_operate_mode"]:
@@ -473,7 +471,7 @@ class Model(object):
         # Add additional post-processed result variables to results
         if results.attrs["termination_condition"] in ["optimal", "feasible"]:
             results = postprocess_results.postprocess_model_results(
-                self.backend, results, self._model_data, updated_shadow_prices
+                results, self._model_data
             )
 
         log_time(

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -448,7 +448,8 @@ class Model(object):
 
         solver_config = update_then_validate_config("solve", self.config, **kwargs)
 
-        self.backend._activate_shadow_prices_if_needed(solver_config)
+        shadow_prices = solver_config.get("shadow_prices", [])
+        self.backend.shadow_prices.track_constraints(shadow_prices)
 
         if run_mode == "operate":
             if not self._model_data.attrs["allow_operate_mode"]:

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -439,6 +439,23 @@ class Model(object):
 
         solver_config = update_then_validate_config("solve", self.config, **kwargs)
 
+        shadow_prices = solver_config["shadow_prices"]
+
+        if shadow_prices:
+            for constraint_name in shadow_prices:
+                if constraint_name not in self.math.constraints.keys():
+                    shadow_prices.remove(constraint_name)
+                    exceptions.warn(
+                        f"{constraint_name} was listed in `config.solve.shadow_prices`"
+                        "but is not a valid constraint. Shadow prices for this"
+                        "constraint will not be tracked.",
+                        exceptions.ModelWarning,
+                    )
+            # Only actually activate shadow price tracking if at least one valid
+            # constraint remains in the list after filtering out invalid ones
+            if shadow_prices:
+                self.backend.shadow_prices.activate()
+
         if run_mode == "operate":
             if not self._model_data.attrs["allow_operate_mode"]:
                 raise exceptions.ModelError(
@@ -462,6 +479,13 @@ class Model(object):
             results = postprocess_results.postprocess_model_results(
                 results, self._model_data, self._timings
             )
+
+        # Add shadow prices to results
+        if shadow_prices:
+            for constraint in shadow_prices:
+                var_name = f"shadow_price_{constraint}"
+                self._model_data[var_name] = self.backend.shadow_prices.get(constraint)
+                self._model_data[var_name].attrs["is_result"] = 1
 
         self._model_data = self._model_data.drop_vars(to_drop)
 

--- a/src/calliope/postprocess/postprocess.py
+++ b/src/calliope/postprocess/postprocess.py
@@ -14,16 +14,11 @@ import logging
 import numpy as np
 import xarray as xr
 
-from calliope.backend.backend_model import BackendModel
-
 LOGGER = logging.getLogger(__name__)
 
 
 def postprocess_model_results(
-    backend: BackendModel,
-    results: xr.Dataset,
-    model_data: xr.Dataset,
-    shadow_prices: list,
+    results: xr.Dataset, model_data: xr.Dataset
 ) -> xr.Dataset:
     """
     Adds additional post-processed result variables to
@@ -52,12 +47,6 @@ def postprocess_model_results(
     results["total_levelised_cost"] = systemwide_levelised_cost(
         results, model_data, total=True
     )
-
-    # Add shadow prices to results
-    if shadow_prices:
-        for constraint in shadow_prices:
-            var_name = f"shadow_price_{constraint}"
-            results[var_name] = backend.shadow_prices.get(constraint)
 
     results = clean_results(results, zero_threshold)
 

--- a/src/calliope/postprocess/postprocess.py
+++ b/src/calliope/postprocess/postprocess.py
@@ -14,11 +14,16 @@ import logging
 import numpy as np
 import xarray as xr
 
+from calliope.backend.backend_model import BackendModel
+
 LOGGER = logging.getLogger(__name__)
 
 
 def postprocess_model_results(
-    results: xr.Dataset, model_data: xr.Dataset
+    backend: BackendModel,
+    results: xr.Dataset,
+    model_data: xr.Dataset,
+    shadow_prices: list,
 ) -> xr.Dataset:
     """
     Adds additional post-processed result variables to
@@ -47,6 +52,13 @@ def postprocess_model_results(
     results["total_levelised_cost"] = systemwide_levelised_cost(
         results, model_data, total=True
     )
+
+    # Add shadow prices to results
+    if shadow_prices:
+        for constraint in shadow_prices:
+            var_name = f"shadow_price_{constraint}"
+            results[var_name] = backend.shadow_prices.get(constraint)
+
     results = clean_results(results, zero_threshold)
 
     for var_data in results.data_vars.values():

--- a/tests/common/test_model/scenarios.yaml
+++ b/tests/common/test_model/scenarios.yaml
@@ -444,3 +444,9 @@ overrides:
       demand_elec:
         add_dimensions:
           parameters: sink_use_max
+
+  shadow_prices:
+    config.solve.shadow_prices: ["system_balance", "balance_demand"]
+
+  shadow_prices_invalid_constraint:
+    config.solve.shadow_prices: ["flow_cap_max_foobar"]

--- a/tests/test_backend_pyomo.py
+++ b/tests/test_backend_pyomo.py
@@ -2575,6 +2575,8 @@ class TestShadowPrices:
         m = simple_supply_yaml_invalid
         with pytest.warns(exceptions.ModelWarning) as warning:
             m.solve()
-        assert check_error_or_warning(warning, "flow_cap_max_foobar was listed")
+        assert check_error_or_warning(
+            warning, "Invalid constraints {'flow_cap_max_foobar'}"
+        )
         # Since we listed only one (invalid) constraint, tracking should not be active
         assert not m.backend.shadow_prices.is_active

--- a/tests/test_backend_pyomo.py
+++ b/tests/test_backend_pyomo.py
@@ -2526,7 +2526,7 @@ class TestShadowPrices:
         assert simple_supply.backend.shadow_prices.is_active
 
     def test_activate_milp_model(self, supply_milp):
-        with pytest.warns(exceptions.BackendWarning) as warning:
+        with pytest.warns(exceptions.BackendWarning):
             supply_milp.backend.shadow_prices.activate()
         assert not supply_milp.backend.shadow_prices.is_active
 


### PR DESCRIPTION
Fixes #581

Summary of changes in this pull request:

* Allow enabling shadow price tracking in YAML `config.solve`
* Only activate shadow price tracking if model is continuous and warn if it is not
* Improved tests for shadow price tracking

Reviewer checklist:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved