### PR TITLE
Pin mkdocs to < 1.6 to get docs building again

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 glpk == 5.0
 jsonschema2md >= 1, < 2
-mkdocs >= 1.5, < 2
+mkdocs >= 1.5, < 1.6
 mkdocs-click >= 0.6, < 0.7
 mkdocs-jupyter >= 0.24, < 0.25
 mkdocs-macros-plugin >= 1.0, < 2


### PR DESCRIPTION
It seems the [mkdocs 1.6](https://www.mkdocs.org/about/release-notes/#version-160-2024-04-20) breaks the builds.

## Summary of changes in this pull request

* Pin mkdocs to < 1.6 to get docs building again


## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved