### PR TITLE
Pin to non-broken mkdocs-jupyter

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,7 +2,7 @@ glpk == 5.0
 jsonschema2md >= 1, < 2
 mkdocs >= 1.5, < 1.6
 mkdocs-click >= 0.6, < 0.7
-mkdocs-jupyter >= 0.24, < 0.25
+mkdocs-jupyter >= 0.24, < 0.24.7
 mkdocs-macros-plugin >= 1.0, < 2
 mkdocs-material >= 9.5, < 10
 mkdocstrings-python >= 1.7, < 2


### PR DESCRIPTION
Fixes issue _not_ fixed in #591. There is curretnly a broken conda forge build on `mkdocs-jupyter`. See this [feedstock PR comment](https://github.com/conda-forge/mkdocs-jupyter-feedstock/pull/30#issuecomment-2088298861).

## Summary of changes in this pull request

* Pin mkdocs-jupyter to < 0.24.7

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved