### PR TITLE
Allowing complete math overrides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ exclude = '''
 
 [tool.ruff]
 line-length = 88
-select = ["E", "F", "I", "Q", "W"]
+select = ["E", "F", "I", "Q", "W", "PT"]
 # line too long; Black will handle these
 ignore = ["E501"]
 

--- a/src/calliope/backend/backend_model.py
+++ b/src/calliope/backend/backend_model.py
@@ -7,7 +7,6 @@ Methods to interface with the optimisation problem
 
 from __future__ import annotations
 
-import importlib
 import logging
 import time
 import typing
@@ -36,11 +35,9 @@ from calliope.backend import helper_functions, parsing
 from calliope.exceptions import warn as model_warn
 from calliope.io import load_config
 from calliope.util.schema import (
-    MATH_SCHEMA,
     MODEL_SCHEMA,
     extract_from_schema,
     update_then_validate_config,
-    validate_dict,
 )
 
 if TYPE_CHECKING:
@@ -211,7 +208,6 @@ class BackendModelGenerator(ABC):
         )
 
     def _build(self) -> None:
-        self._add_run_mode_math()
         # The order of adding components matters!
         # 1. Variables, 2. Global Expressions, 3. Constraints, 4. Objectives
         for components in [
@@ -229,27 +225,6 @@ class BackendModelGenerator(ABC):
                     f"Optimisation Model | {components}:{name} | Built in {end:.4f}s"
                 )
             LOGGER.info(f"Optimisation Model | {components} | Generated.")
-
-    def _add_run_mode_math(self) -> None:
-        """If not given in the add_math list, override model math with run mode math"""
-
-        # FIXME: available modes should not be hardcoded here. They should come from a YAML schema.
-        mode = self.inputs.attrs["config"].build.mode
-        add_math = self.inputs.attrs["applied_additional_math"]
-        not_run_mode = {"plan", "operate", "spores"}.difference([mode])
-        run_mode_mismatch = not_run_mode.intersection(add_math)
-        if run_mode_mismatch:
-            exceptions.warn(
-                f"Running in {mode} mode, but run mode(s) {run_mode_mismatch} "
-                "math being loaded from file via the model configuration"
-            )
-
-        if mode != "plan" and mode not in add_math:
-            LOGGER.debug(f"Updating math formulation with {mode} mode math.")
-            filepath = importlib.resources.files("calliope") / "math" / f"{mode}.yaml"
-            self.inputs.math.union(AttrDict.from_yaml(filepath), allow_override=True)
-
-        validate_dict(self.inputs.math, MATH_SCHEMA, "math")
 
     def _add_component(
         self,

--- a/src/calliope/config/config_schema.yaml
+++ b/src/calliope/config/config_schema.yaml
@@ -56,8 +56,8 @@ properties:
             default: true
             description: >-
               Whether or not to use the base Calliope math and schema when building models.
-              If "true", the model will use the base Calliope math. Values in "add_math" and "add_schema" will be appended to these.
-              If "false", users must fully define the model math and schema via "add_math" and "add_schema". Use with caution!
+              If "true", the model will use the base Calliope math. Values in "add_math" will be merged into it.
+              If "false", users must fully define the model math via "add_math". Use with caution!
           add_math:
             type: array
             default: []

--- a/src/calliope/config/config_schema.yaml
+++ b/src/calliope/config/config_schema.yaml
@@ -69,16 +69,6 @@ properties:
                 If referring to an pre-defined Calliope math file (see documentation for available files), do not append the reference with ".yaml".
                 If referring to your own math file, ensure the file type is given as a suffix (".yaml" or ".yml").
                 Relative paths will be assumed to be relative to the model definition file given when creating a calliope Model (`calliope.Model(model_definition=...)`)
-          add_schema:
-            type: array
-            default: []
-            description: List of references to files which contain schema definitions for model parameters, including their default value.
-            uniqueItems: true
-            items:
-              type: string
-              description: >
-                Ensure the file type is given as a suffix (".yaml" or ".yml").
-                Relative paths will be assumed to be relative to the model definition file given when creating a calliope Model (`calliope.Model(model_definition=...)`)
           distance_unit:
             type: string
             default: km

--- a/src/calliope/config/config_schema.yaml
+++ b/src/calliope/config/config_schema.yaml
@@ -51,6 +51,13 @@ properties:
             type: string
             default: "ISO8601"
             description: Timestamp format of all time series data when read from file. "ISO8601" means "%Y-%m-%d %H:%M:%S".
+          base_math:
+            type: boolean
+            default: true
+            description: >-
+              Whether or not to use the base Calliope math and schema when building models.
+              If "true", the model will use the base Calliope math. Values in "add_math" and "add_schema" will be appended to these.
+              If "false", users must fully define the model math and schema via "add_math" and "add_schema". Use with caution!
           add_math:
             type: array
             default: []
@@ -61,6 +68,16 @@ properties:
               description: >
                 If referring to an pre-defined Calliope math file (see documentation for available files), do not append the reference with ".yaml".
                 If referring to your own math file, ensure the file type is given as a suffix (".yaml" or ".yml").
+                Relative paths will be assumed to be relative to the model definition file given when creating a calliope Model (`calliope.Model(model_definition=...)`)
+          add_schema:
+            type: array
+            default: []
+            description: List of references to files which contain schema definitions for model parameters, including their default value.
+            uniqueItems: true
+            items:
+              type: string
+              description: >
+                Ensure the file type is given as a suffix (".yaml" or ".yml").
                 Relative paths will be assumed to be relative to the model definition file given when creating a calliope Model (`calliope.Model(model_definition=...)`)
           distance_unit:
             type: string


### PR DESCRIPTION
Fixes #606 

## Summary of changes in this pull request

* Introduces a new parameter (`config.init.base_math`) that will tell the model to skip base math if set to `False`.
* Run mode math updates have been moved from the backend to the main model file.
* Math is now always validated when modified (either in `init` or `build`). This is to prevent unexpected surprises if users save an initialized model without building it.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved