### PR TITLE
Fix sync issues in model math / config / defaults attributes

### DIFF
--- a/src/calliope/postprocess/postprocess.py
+++ b/src/calliope/postprocess/postprocess.py
@@ -169,7 +169,7 @@ def clean_results(results, zero_threshold):
         comment = "Postprocessing: All values < {} set to 0 in {}".format(
             zero_threshold, ", ".join(threshold_applied)
         )
-        LOGGER.warn(comment)
+        LOGGER.warning(comment)
     else:
         comment = "Postprocessing: zero threshold of {} not required".format(
             zero_threshold

--- a/tests/test_core_model.py
+++ b/tests/test_core_model.py
@@ -29,40 +29,6 @@ class TestModel:
     def test_info_simple_model(self, simple_supply):
         simple_supply.info()
 
-    def test_update_observed_dict(self, national_scale_example):
-        national_scale_example.config.build["backend"] = "foo"
-        assert national_scale_example._model_data.attrs["config"].build.backend == "foo"
-
-    def test_add_observed_dict_from_model_data(
-        self, national_scale_example, dict_to_add
-    ):
-        national_scale_example._model_data.attrs["foo"] = dict_to_add
-        national_scale_example._add_observed_dict("foo")
-        assert national_scale_example.foo == dict_to_add
-        assert national_scale_example._model_data.attrs["foo"] == dict_to_add
-
-    def test_add_observed_dict_from_dict(self, national_scale_example, dict_to_add):
-        national_scale_example._add_observed_dict("bar", dict_to_add)
-        assert national_scale_example.bar == dict_to_add
-        assert national_scale_example._model_data.attrs["bar"] == dict_to_add
-
-    def test_add_observed_dict_not_available(self, national_scale_example):
-        with pytest.raises(calliope.exceptions.ModelError) as excinfo:
-            national_scale_example._add_observed_dict("baz")
-        assert check_error_or_warning(
-            excinfo,
-            "Expected the model property `baz` to be a dictionary attribute of the model dataset",
-        )
-        assert not hasattr(national_scale_example, "baz")
-
-    def test_add_observed_dict_not_dict(self, national_scale_example):
-        with pytest.raises(TypeError) as excinfo:
-            national_scale_example._add_observed_dict("baz", "bar")
-        assert check_error_or_warning(
-            excinfo,
-            "Attempted to add dictionary property `baz` to model, but received argument of type `str`",
-        )
-
 
 class TestAddMath:
     @pytest.fixture

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -174,18 +174,23 @@ class TestIO:
             with pytest.warns(exceptions.ModelWarning):
                 model.to_csv(out_path, dropna=False)
 
-    @pytest.mark.parametrize("attr", ["config", "math"])
+    @pytest.mark.parametrize("attr", ["config", "math", "defaults"])
     def test_dicts_as_model_attrs_and_property(self, model_from_file, attr):
-        assert attr in model_from_file._model_data.attrs.keys()
-        assert hasattr(model_from_file, attr)
-
-    def test_defaults_as_model_attrs_not_property(self, model_from_file):
-        assert "defaults" in model_from_file._model_data.attrs.keys()
-        assert not hasattr(model_from_file, "defaults")
+        assert (
+            hasattr(model_from_file, attr)
+            and attr in model_from_file._model_data.attrs.keys()
+        )
 
     @pytest.mark.parametrize("attr", ["results", "inputs"])
     def test_filtered_dataset_as_property(self, model_from_file, attr):
         assert hasattr(model_from_file, attr)
+
+    @pytest.mark.parametrize(
+        "attr", ["config", "math", "defaults", "results", "inputs"]
+    )
+    def test_protected_attrs(self, model_from_file, attr):
+        with pytest.raises(AttributeError):
+            setattr(model_from_file, attr, "foo")
 
     def test_save_read_solve_save_netcdf(self, model, tmpdir_factory):
         out_path = tmpdir_factory.mktemp("model_dir").join("model.nc")


### PR DESCRIPTION
Fixes #608 (and is a prerequisite for #606).

This PR is meant to fix potential issues due to duplication of model data at the model.attribute level and at the model._model_data.attrs level.

Instead of copying stuff, class @properties are used to call and modify specific things (math, config, defaults).
model.attributes should be used for data we want to lose between runs (instance-specific timestamps, temp flags, etc).

By drawing this distinction, the code should become easier to maintain down the line.

## Summary of changes in this pull request

* Turned `model.math`, `model.config` and `model.defaults` into properties that refer to `model._model_data.attrs` directly to avoid double instancing and potential desyncs
* Removed depreciated methods to sync `model.math` and `model.config` with values in `model._model_data`.
* Updated some tests.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved