### PR TITLE
Purge spurious debug parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 * `timestamp_solve_started`: at the start of `Model.solve()`
 * `timestamp_solve_complete`: at the end of `Model.solve()`
 
+### Internal changes
+
+|fixed| Removed unused debug parameter in `Model.__init__()`
+
 ## 0.7.0.dev3 (2024-02-14)
 
 ### User-facing changes

--- a/src/calliope/io.py
+++ b/src/calliope/io.py
@@ -125,8 +125,6 @@ def save_netcdf(model_data, path, model=None):
     if model is not None and hasattr(model, "_model_def_dict"):
         # Attach initial model definition to _model_data
         model_data_attrs["_model_def_dict"] = model._model_def_dict.to_yaml()
-        if hasattr(model, "_debug_data"):
-            model_data_attrs["_debug_data"] = model._debug_data.to_yaml()
 
     _serialise(model_data_attrs)
     for var in model_data.data_vars.values():

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -247,12 +247,6 @@ class Model(object):
             )
             del model_data.attrs["_model_def_dict"]
 
-        if "_debug_data" in model_data.attrs:
-            self._debug_data = AttrDict.from_yaml_string(
-                model_data.attrs["_debug_data"]
-            )
-            del model_data.attrs["_debug_data"]
-
         self._model_data = model_data
         self._add_model_data_methods()
 

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -64,7 +64,6 @@ class Model(object):
     def __init__(
         self,
         model_definition: str | Path | dict | xr.Dataset,
-        debug: bool = False,
         scenario: Optional[str] = None,
         override_dict: Optional[dict] = None,
         data_source_dfs: Optional[dict[str, pd.DataFrame]] = None,
@@ -79,9 +78,6 @@ class Model(object):
                 If str or Path, must be the path to a model configuration file.
                 If dict or AttrDict, must fully specify the model.
                 If an xarray dataset, must be a valid calliope model.
-            debug (bool, optional):
-                If True, additional debug data will be included in the built model.
-                Defaults to False.
             scenario (str):
                 Comma delimited string of pre-defined `scenarios` to apply to the model,
             override_dict (dict):
@@ -116,7 +112,7 @@ class Model(object):
                 )
             )
             self._init_from_model_def_dict(
-                model_def, applied_overrides, scenario, debug, data_source_dfs
+                model_def, applied_overrides, scenario, data_source_dfs
             )
 
         self._model_data.attrs["timestamp_model_creation"] = timestamp_model_creation
@@ -155,15 +151,15 @@ class Model(object):
         model_definition: calliope.AttrDict,
         applied_overrides: str,
         scenario: Optional[str],
-        debug: bool,
         data_source_dfs: Optional[dict[str, pd.DataFrame]],
     ) -> None:
-        """Initialise the model using a `model_run` dictionary, which may have been loaded from YAML.
+        """Initialise the model using pre-processed YAML files and optional dataframes/dicts.
 
         Args:
-            model_run (calliope.AttrDict): Preprocessed model configuration.
-            debug_data (calliope.AttrDict): Additional data from processing the input configuration.
-            debug (bool): If True, `debug_data` will be attached to the Model object as the attribute `calliope.Model._debug_data`.
+            model_definition (calliope.AttrDict): preprocessed model configuration
+            applied_overrides (str): overrides specified by users
+            scenario (Optional[str]): scenario specified by users
+            data_source_dfs (Optional[dict[str, pd.DataFrame]]): optional files with additional model information
         """
         # First pass to check top-level keys are all good
         validate_dict(model_definition, CONFIG_SCHEMA, "Model definition")


### PR DESCRIPTION
Fixes #607

## Summary of changes in this pull request

Just removed a parameter that is no longer used from the Calliope `__init__` function.
Also updated the docstring from v0.6 to 0.7

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved