### PR TITLE
Sort ref ordering within components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### User-facing changes
 
+|fixed| Backend parameter updates propagate correctly through global expressions in the order those expressions were defined (#616).
+
+|fixed| If setting `model.backend.verbose_strings()`, rebuilt model components from making backend parameter updates will automatically have verbose strings (#623)
+
 |new| Allow extracting shadow prices into results by listing constraints in `config.solve.shadow_prices`, e.g. `config.solve.shadow_prices: ["system_balance"]`  Shadow prices will be added as variables to the model results as `shadow_price_{constraintname}`, e.g. `shadow_price_system_balance`.
 
 |new| Model stores key timestamps as attributes:

--- a/src/calliope/backend/backend_model.py
+++ b/src/calliope/backend/backend_model.py
@@ -577,6 +577,7 @@ class BackendModel(BackendModelGenerator, Generic[T]):
         super().__init__(inputs, **kwargs)
         self._instance = instance
         self.shadow_prices: ShadowPrices
+        self._has_verbose_strings: bool = False
 
     @abstractmethod
     def get_parameter(self, name: str, as_backend_objs: bool = True) -> xr.DataArray:
@@ -880,11 +881,9 @@ class BackendModel(BackendModelGenerator, Generic[T]):
             "objectives",
         ]
         for component in ordered_components:
-            refs = [
-                ref
-                for ref in references
-                if self._dataset[ref].attrs["obj_type"] == component
-            ]
+            # Rebuild references in the order they are found in the backend dataset
+            # which should correspond to the order they were added to the optimisation problem.
+            refs = [k for k in getattr(self, component).data_vars if k in references]
             for ref in refs:
                 self.delete_component(ref, component)
                 getattr(self, "add_" + component.removesuffix("s"))(name=ref)

--- a/src/calliope/backend/pyomo_backend_model.py
+++ b/src/calliope/backend/pyomo_backend_model.py
@@ -341,6 +341,7 @@ class PyomoBackendModel(backend_model.BackendModel):
                 ).values():
                     self._apply_func(__renamer, da, *[da.coords[i] for i in da.dims])
                     da.attrs["coords_in_name"] = True
+        self._has_verbose_strings = True
 
     def to_lp(self, path: Union[str, Path]) -> None:
         self._instance.write(str(path), format="lp", symbolic_solver_labels=True)
@@ -428,9 +429,12 @@ class PyomoBackendModel(backend_model.BackendModel):
                 default=self.inputs.attrs["defaults"].get(name, np.nan),
             )
             self._rebuild_references(refs_to_update)
-            return None
 
-        self._apply_func(self._update_pyomo_param, parameter_da, new_values)
+            if self._has_verbose_strings:
+                self.verbose_strings()
+
+        else:
+            self._apply_func(self._update_pyomo_param, parameter_da, new_values)
 
     def update_variable_bounds(
         self,

--- a/tests/common/test_model/model.yaml
+++ b/tests/common/test_model/model.yaml
@@ -130,19 +130,16 @@ techs:
       dims: carriers
 
   test_demand_elec:
-    inherit: test_controller
     name: Demand elec tech
     carrier_in: electricity
     base_tech: demand
 
   test_demand_heat:
-    inherit: test_controller
     name: Demand heat tech
     carrier_in: heat
     base_tech: demand
 
   test_demand_coal:
-    inherit: test_controller
     name: Demand coal tech
     carrier_in: coal
     base_tech: demand


### PR DESCRIPTION
#update

Fixes #616 

## Summary of changes in this pull request

* Rebuild references in the order they appear in the backend model dataset, which is the same order they are added to it (so expressions that depend on previous expressions will be built in the correct order).
* Remove investment cost from demands in the dummy test model - this leads to a change in shadow prices which I have updated, but there's no way of knowing if the new shadow prices (or, indeed, the old ones) are correct.
* Force verbose strings on rebuilt backend model components, if verbose strings have already been triggered.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved