### PR TITLE
Fix: Update commit-ci codecov step

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -54,5 +54,8 @@ jobs:
     - name: upload coverage report to Codecov
       if: github.ref == 'refs/heads/main'
       uses: codecov/codecov-action@v4
-      env:
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
         directory: "./reports/coverage/"
+        verbose: true


### PR DESCRIPTION
Fixes codecov not uploading successfully on `main` and its failure being silent. This is why we have failing coverage reports in all our PRs.

## Summary of changes in this pull request

* Copy over codecov config from pr-ci to commit-ci.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved