### PR TITLE
Add pyupgrade to ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,13 @@ line-length = 88
 
 [tool.ruff.format]
 exclude = [".*.egg-info", "requirements/**"]
+skip-magic-trailing-comma = true
+
+[tool.ruff.isort]
+split-on-trailing-comma = false
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "Q", "W", "D", "PT"]
+select = ["E", "F", "I", "Q", "W", "D", "PT", "UP"]
 # line too long; Black will handle these
 ignore = ["E501"]
 

--- a/src/calliope/attrdict.py
+++ b/src/calliope/attrdict.py
@@ -6,7 +6,6 @@ import copy
 import io
 import logging
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 import ruamel.yaml as ruamel_yaml
@@ -17,7 +16,7 @@ from calliope.util.tools import relative_path
 logger = logging.getLogger(__name__)
 
 
-class __Missing(object):
+class __Missing:
     def __nonzero__(self):
         return False
 
@@ -41,10 +40,10 @@ def _yaml_load(src):
     try:
         result = yaml.load(src)
         if not isinstance(result, dict):
-            raise ValueError("Could not parse {} as YAML".format(src_name))
+            raise ValueError(f"Could not parse {src_name} as YAML")
         return result
     except ruamel_yaml.YAMLError:
-        logger.error("Parser error when reading YAML " "from {}.".format(src_name))
+        logger.error(f"Parser error when reading YAML from {src_name}.")
         raise
 
 
@@ -113,7 +112,7 @@ class AttrDict(dict):
         cls,
         loaded: Self,
         resolve_imports: bool | str,
-        base_path: Optional[str | Path] = None,
+        base_path: str | Path | None = None,
     ) -> Self:
         if (
             isinstance(resolve_imports, bool)
@@ -405,7 +404,7 @@ class AttrDict(dict):
             wipe_keys = []
         for k in override_keys:
             if not allow_override and k in self_keys:
-                raise KeyError("Key defined twice: {}".format(k))
+                raise KeyError(f"Key defined twice: {k}")
             else:
                 other_value = other.get_key(k)
                 # If other value is None, and would overwrite an entire subdict,

--- a/src/calliope/backend/backend_model.py
+++ b/src/calliope/backend/backend_model.py
@@ -9,20 +9,10 @@ import logging
 import time
 import typing
 from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterable
 from copy import deepcopy
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Generic,
-    Iterable,
-    Literal,
-    Optional,
-    SupportsFloat,
-    TypeVar,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Generic, Literal, SupportsFloat, TypeVar
 
 import numpy as np
 import xarray as xr
@@ -246,13 +236,13 @@ class BackendModelGenerator(ABC):
     def _add_component(
         self,
         name: str,
-        component_dict: Optional[Tp],
+        component_dict: Tp | None,
         component_setter: Callable,
         component_type: Literal[
             "variables", "global_expressions", "constraints", "objectives"
         ],
         break_early: bool = True,
-    ) -> Optional[parsing.ParsedBackendComponent]:
+    ) -> parsing.ParsedBackendComponent | None:
         """Generalised function to add a optimisation problem component array to the model.
 
         Args:
@@ -409,8 +399,8 @@ class BackendModelGenerator(ABC):
         name: str,
         da: xr.DataArray,
         obj_type: _COMPONENTS_T,
-        unparsed_dict: Union[parsing.UNPARSED_DICTS, dict],
-        references: Optional[set] = None,
+        unparsed_dict: parsing.UNPARSED_DICTS | dict,
+        references: set | None = None,
     ):
         """Add array of backend objects to backend dataset in-place.
 
@@ -593,7 +583,7 @@ class BackendModel(BackendModelGenerator, Generic[T]):
     @abstractmethod
     def get_constraint(
         self, name: str, as_backend_objs: bool = True, eval_body: bool = False
-    ) -> Union[xr.DataArray, xr.Dataset]:
+    ) -> xr.DataArray | xr.Dataset:
         """Get constraint data from the backend for debugging.
 
         Dat can be returned as  a table of details or as an array of backend interface objects
@@ -673,7 +663,7 @@ class BackendModel(BackendModelGenerator, Generic[T]):
 
     @abstractmethod
     def update_parameter(
-        self, name: str, new_values: Union[xr.DataArray, SupportsFloat]
+        self, name: str, new_values: xr.DataArray | SupportsFloat
     ) -> None:
         """Update parameter elements using an array of new values.
 
@@ -695,8 +685,8 @@ class BackendModel(BackendModelGenerator, Generic[T]):
         self,
         name: str,
         *,
-        min: Optional[Union[xr.DataArray, SupportsFloat]] = None,
-        max: Optional[Union[xr.DataArray, SupportsFloat]] = None,
+        min: xr.DataArray | SupportsFloat | None = None,
+        max: xr.DataArray | SupportsFloat | None = None,
     ) -> None:
         """Update the bounds on a decision variable.
 
@@ -714,7 +704,7 @@ class BackendModel(BackendModelGenerator, Generic[T]):
         """
 
     @abstractmethod
-    def fix_variable(self, name: str, where: Optional[xr.DataArray] = None) -> None:
+    def fix_variable(self, name: str, where: xr.DataArray | None = None) -> None:
         """Fix the variable value to the value quantified on the most recent call to `solve`.
 
         Fixed variables will be treated as parameters in the optimisation.
@@ -728,7 +718,7 @@ class BackendModel(BackendModelGenerator, Generic[T]):
         """
 
     @abstractmethod
-    def unfix_variable(self, name: str, where: Optional[xr.DataArray] = None) -> None:
+    def unfix_variable(self, name: str, where: xr.DataArray | None = None) -> None:
         """Unfix the variable so that it is treated as a decision variable in the next call to `solve`.
 
         Args:
@@ -755,7 +745,7 @@ class BackendModel(BackendModelGenerator, Generic[T]):
         """
 
     @abstractmethod
-    def to_lp(self, path: Union[str, Path]) -> None:
+    def to_lp(self, path: str | Path) -> None:
         """Write the optimisation problem to file in the linear programming LP format.
 
         The LP file can be used for debugging and to submit to solvers directly.

--- a/src/calliope/backend/latex_backend_model.py
+++ b/src/calliope/backend/latex_backend_model.py
@@ -7,7 +7,7 @@ import re
 import textwrap
 import typing
 from pathlib import Path
-from typing import Any, Literal, Optional, Union, overload
+from typing import Any, Literal, overload
 
 import jinja2
 import numpy as np
@@ -65,7 +65,7 @@ class MathDocumentation:
         self,
         filename: Literal[None] = None,
         mkdocs_tabbed: bool = False,
-        format: Optional[_ALLOWED_MATH_FILE_FORMATS] = None,
+        format: _ALLOWED_MATH_FILE_FORMATS | None = None,
     ) -> str: ...
 
     # Expecting None (and format arg is not needed) if giving filename.
@@ -74,10 +74,10 @@ class MathDocumentation:
 
     def write(
         self,
-        filename: Optional[Union[str, Path]] = None,
+        filename: str | Path | None = None,
         mkdocs_tabbed: bool = False,
-        format: Optional[_ALLOWED_MATH_FILE_FORMATS] = None,
-    ) -> Optional[str]:
+        format: _ALLOWED_MATH_FILE_FORMATS | None = None,
+    ) -> str | None:
         """Write model documentation.
 
         `build` must be run beforehand.
@@ -382,9 +382,7 @@ class LatexBackendModel(backend_model.BackendModelGenerator):
         self._add_to_dataset(parameter_name, parameter_values, "parameters", attrs)
 
     def add_constraint(  # noqa: D102, override
-        self,
-        name: str,
-        constraint_dict: Optional[parsing.UnparsedConstraintDict] = None,
+        self, name: str, constraint_dict: parsing.UnparsedConstraintDict | None = None
     ) -> None:
         equation_strings: list = []
 
@@ -403,9 +401,7 @@ class LatexBackendModel(backend_model.BackendModelGenerator):
         )
 
     def add_global_expression(  # noqa: D102, override
-        self,
-        name: str,
-        expression_dict: Optional[parsing.UnparsedExpressionDict] = None,
+        self, name: str, expression_dict: parsing.UnparsedExpressionDict | None = None
     ) -> None:
         equation_strings: list = []
 
@@ -428,7 +424,7 @@ class LatexBackendModel(backend_model.BackendModelGenerator):
         )
 
     def add_variable(  # noqa: D102, override
-        self, name: str, variable_dict: Optional[parsing.UnparsedVariableDict] = None
+        self, name: str, variable_dict: parsing.UnparsedVariableDict | None = None
     ) -> None:
         domain_dict = {"real": r"\mathbb{R}\;", "integer": r"\mathbb{Z}\;"}
 
@@ -451,7 +447,7 @@ class LatexBackendModel(backend_model.BackendModelGenerator):
         )
 
     def add_objective(  # noqa: D102, override
-        self, name: str, objective_dict: Optional[parsing.UnparsedObjectiveDict] = None
+        self, name: str, objective_dict: parsing.UnparsedObjectiveDict | None = None
     ) -> None:
         sense_dict = {
             "minimize": r"\min{}",
@@ -560,12 +556,12 @@ class LatexBackendModel(backend_model.BackendModelGenerator):
 
     def _generate_math_string(
         self,
-        parsed_component: Optional[parsing.ParsedBackendComponent],
+        parsed_component: parsing.ParsedBackendComponent | None,
         where_array: xr.DataArray,
-        equations: Optional[list[dict[str, str]]] = None,
-        sense: Optional[str] = None,
-        where: Optional[str] = None,
-        sets: Optional[list[str]] = None,
+        equations: list[dict[str, str]] | None = None,
+        sense: str | None = None,
+        where: str | None = None,
+        sets: list[str] | None = None,
     ) -> None:
         if parsed_component is not None:
             where = parsed_component.evaluate_where(self, return_type="math_string")

--- a/src/calliope/backend/parsing.py
+++ b/src/calliope/backend/parsing.py
@@ -8,16 +8,8 @@ import functools
 import itertools
 import logging
 import operator
-from typing import (
-    TYPE_CHECKING,
-    Callable,
-    Iterable,
-    Literal,
-    Optional,
-    TypeVar,
-    Union,
-    overload,
-)
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, Literal, TypeVar, overload
 
 import pyparsing as pp
 import xarray as xr
@@ -88,12 +80,13 @@ class UnparsedObjectiveDict(TypedDict):
     sense: str
 
 
-UNPARSED_DICTS = Union[
-    UnparsedConstraintDict,
-    UnparsedVariableDict,
-    UnparsedExpressionDict,
-    UnparsedObjectiveDict,
-]
+UNPARSED_DICTS = (
+    UnparsedConstraintDict
+    | UnparsedVariableDict
+    | UnparsedExpressionDict
+    | UnparsedObjectiveDict,
+)
+
 T = TypeVar("T", bound=UNPARSED_DICTS)
 
 LOGGER = logging.getLogger(__name__)
@@ -108,8 +101,8 @@ class ParsedBackendEquation:
         sets: list[str],
         expression: pp.ParseResults,
         where_list: list[pp.ParseResults],
-        sub_expressions: Optional[dict[str, pp.ParseResults]] = None,
-        slices: Optional[dict[str, pp.ParseResults]] = None,
+        sub_expressions: dict[str, pp.ParseResults] | None = None,
+        slices: dict[str, pp.ParseResults] | None = None,
     ) -> None:
         """For parsing equation expressions and corresponding "where" strings.
 
@@ -205,7 +198,7 @@ class ParsedBackendEquation:
             if isinstance(parser_element, to_find):
                 items.append(parser_element.name)
 
-            elif isinstance(parser_element, (pp.ParseResults, list)):
+            elif isinstance(parser_element, pp.ParseResults | list):
                 items.extend(recursive_func(parser_elements=parser_element))
 
             elif isinstance(parser_element, valid_eval_classes):
@@ -258,7 +251,7 @@ class ParsedBackendEquation:
         backend_interface: backend_model.BackendModelGenerator,
         *,
         return_type: Literal["array"] = "array",
-        references: Optional[set] = None,
+        references: set | None = None,
         initial_where: xr.DataArray = TRUE_ARRAY,
     ) -> xr.DataArray: ...
 
@@ -269,7 +262,7 @@ class ParsedBackendEquation:
         backend_interface: backend_model.BackendModelGenerator,
         *,
         return_type: Literal["math_string"],
-        references: Optional[set] = None,
+        references: set | None = None,
     ) -> str: ...
 
     def evaluate_where(
@@ -279,7 +272,7 @@ class ParsedBackendEquation:
         return_type: str = "array",
         references: set | None = None,
         initial_where: xr.DataArray = TRUE_ARRAY,
-    ) -> Union[xr.DataArray, str]:
+    ) -> xr.DataArray | str:
         """Evaluate parsed backend object dictionary `where` string.
 
         Args:
@@ -342,7 +335,7 @@ class ParsedBackendEquation:
         backend_interface: backend_model.BackendModel,
         *,
         return_type: Literal["array"] = "array",
-        references: Optional[set] = None,
+        references: set | None = None,
         where: xr.DataArray = TRUE_ARRAY,
     ) -> xr.DataArray: ...
 
@@ -353,7 +346,7 @@ class ParsedBackendEquation:
         backend_interface: backend_model.BackendModel,
         *,
         return_type: Literal["math_string"],
-        references: Optional[set] = None,
+        references: set | None = None,
     ) -> str: ...
 
     def evaluate_expression(
@@ -361,9 +354,9 @@ class ParsedBackendEquation:
         backend_interface: backend_model.BackendModel,
         *,
         return_type: Literal["array", "math_string"] = "array",
-        references: Optional[set] = None,
+        references: set | None = None,
         where: xr.DataArray = TRUE_ARRAY,
-    ) -> Union[xr.DataArray, str]:
+    ) -> xr.DataArray | str:
         """Evaluate a math string to produce an array backend objects or a LaTex math string.
 
         Args:

--- a/src/calliope/backend/where_parser.py
+++ b/src/calliope/backend/where_parser.py
@@ -5,7 +5,8 @@
 from __future__ import annotations
 
 import operator
-from typing import TYPE_CHECKING, Callable, Union
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pyparsing as pp
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
 
 pp.ParserElement.enablePackrat()
 
-BOOLEANTYPE = Union[np.bool_, np.typing.NDArray[np.bool_]]
+BOOLEANTYPE = np.bool_ | np.typing.NDArray[np.bool_]
 
 
 class EvalAttrs(TypedDict):
@@ -121,7 +122,7 @@ class ConfigOptionParser(EvalWhere):
             self.eval_attrs["input_data"].attrs["config"].build[self.config_option]
         )
 
-        if not isinstance(config_val, (int, float, str, bool, np.bool_)):
+        if not isinstance(config_val, int | float | str | bool | np.bool_):
             raise BackendError(
                 f"(where, {self.instring}): Configuration option resolves to invalid "
                 f"type `{type(config_val).__name__}`, expected a number, string, or boolean."

--- a/src/calliope/cli.py
+++ b/src/calliope/cli.py
@@ -79,7 +79,7 @@ def format_exceptions(
             profile.disable()
             if profile_filename:
                 dump_path = os.path.expanduser(profile_filename)
-                click.secho("\nSaving cProfile output to: {}".format(dump_path))
+                click.secho(f"\nSaving cProfile output to: {dump_path}")
                 profile.dump_stats(dump_path)
             else:
                 click.secho("\n\n----PROFILE OUTPUT----\n\n")
@@ -97,7 +97,7 @@ def format_exceptions(
             stack = traceback.extract_tb(e.__traceback__)
             # Get last stack trace entry still in Calliope
             last = [i for i in stack if "calliope" in i[0]][-1]
-            err_string = "\nError in {}, {}:{}".format(last[2], last[0], last[1])
+            err_string = f"\nError in {last[2]}, {last[0]}:{last[1]}"
             click.secho(err_string, fg="red")
             click.secho(str(e), fg="red")
             if start_time:
@@ -111,14 +111,12 @@ def print_end_time(start_time, msg="complete"):
     secs = round((end_time - start_time).total_seconds(), 1)
     tend = end_time.strftime(_time_format)
     click.secho(
-        "\nCalliope run {}. " "Elapsed: {} seconds (time at exit: {})".format(
-            msg, secs, tend
-        )
+        f"\nCalliope run {msg}. " f"Elapsed: {secs} seconds (time at exit: {tend})"
     )
 
 
 def _get_version():
-    return "Version {}".format(__version__)
+    return f"Version {__version__}"
 
 
 def _cli_start(debug, quiet):
@@ -176,7 +174,7 @@ def new(path, template, debug):
         if template is None:
             template = "national_scale"
         source_path = examples._EXAMPLE_MODEL_DIR / template
-        click.echo("Copying {} template to target directory: {}".format(template, path))
+        click.echo(f"Copying {template} template to target directory: {path}")
         shutil.copytree(source_path, path)
 
 
@@ -194,8 +192,8 @@ def _run_setup_model(model_file, scenario, model_format, override_dict):
         else:
             raise ValueError(
                 "Cannot determine model file format based on file "
-                'extension for "{}". Set format explicitly with '
-                "--model_format.".format(model_file)
+                f'extension for "{model_file}". Set format explicitly with '
+                "--model_format."
             )
 
     if model_format == "yaml":
@@ -208,7 +206,7 @@ def _run_setup_model(model_file, scenario, model_format, override_dict):
             )
         model = read_netcdf(model_file)
     else:
-        raise ValueError("Invalid model format: {}".format(model_format))
+        raise ValueError(f"Invalid model format: {model_format}")
 
     return model
 
@@ -257,9 +255,7 @@ def run(
     """
     start_time = _cli_start(debug, quiet)
     click.secho(
-        "Calliope {} starting at {}\n".format(
-            __version__, start_time.strftime(_time_format)
-        )
+        f"Calliope {__version__} starting at {start_time.strftime(_time_format)}\n"
     )
 
     with format_exceptions(debug, pdb, profile, profile_filename, start_time):
@@ -309,10 +305,10 @@ def run(
             )
 
             if save_csv:
-                click.secho("Saving CSV results to directory: {}".format(save_csv))
+                click.secho(f"Saving CSV results to directory: {save_csv}")
                 model.to_csv(save_csv)
             if save_netcdf:
-                click.secho("Saving NetCDF results to file: {}".format(save_netcdf))
+                click.secho(f"Saving NetCDF results to file: {save_netcdf}")
                 model.to_netcdf(save_netcdf)
 
             print_end_time(start_time)

--- a/src/calliope/exceptions.py
+++ b/src/calliope/exceptions.py
@@ -4,7 +4,6 @@
 
 import textwrap
 import warnings
-from typing import Optional, Union
 
 
 class ModelError(Exception):
@@ -41,8 +40,8 @@ def warn(message: str, _class: type[Warning] = ModelWarning):
 
 
 def print_warnings_and_raise_errors(
-    warnings: Optional[Union[list[str], dict[str, list[str]]]] = None,
-    errors: Optional[Union[list[str], dict[str, list[str]]]] = None,
+    warnings: list[str] | dict[str, list[str]] | None = None,
+    errors: list[str] | dict[str, list[str]] | None = None,
     during: str = "model processing",
     bullet: str = " * ",
 ) -> None:
@@ -92,7 +91,7 @@ def print_warnings_and_raise_errors(
     def _predicate(string_: str) -> bool:
         return not string_.startswith((bullet, spacer))
 
-    def _indenter(strings: Union[list[str], dict[str, list[str]]]) -> str:
+    def _indenter(strings: list[str] | dict[str, list[str]]) -> str:
         if isinstance(strings, dict):
             sorted_strings = []
             for k, v in strings.items():

--- a/src/calliope/io.py
+++ b/src/calliope/io.py
@@ -4,7 +4,6 @@
 
 import importlib.resources
 from pathlib import Path
-from typing import Union
 
 # We import netCDF4 before xarray to mitigate a numpy warning:
 # https://github.com/pydata/xarray/issues/7259
@@ -40,8 +39,8 @@ def read_netcdf(path):
 
 
 def _pop_serialised_list(
-    attrs: dict, serialised_items: Union[str, list]
-) -> Union[list, np.ndarray]:
+    attrs: dict, serialised_items: str | list
+) -> list | np.ndarray:
     """Pop a list of serialised attributes from the attribute dictionary."""
     serialised_ = attrs.pop(serialised_items, [])
     return listify(serialised_)

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -5,8 +5,9 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, TypeVar
 
 import pandas as pd
 import xarray as xr
@@ -35,7 +36,7 @@ from calliope.util.tools import relative_path
 
 LOGGER = logging.getLogger(__name__)
 
-T = TypeVar("T", bound=Union[PyomoBackendModel, LatexBackendModel])
+T = TypeVar("T", bound=PyomoBackendModel | LatexBackendModel)
 if TYPE_CHECKING:
     from calliope.backend.backend_model import BackendModel
 
@@ -46,7 +47,7 @@ def read_netcdf(path):
     return Model(model_definition=model_data)
 
 
-class Model(object):
+class Model:
     """A Calliope Model."""
 
     _BACKENDS: dict[str, Callable] = {"pyomo": PyomoBackendModel}
@@ -55,9 +56,9 @@ class Model(object):
     def __init__(
         self,
         model_definition: str | Path | dict | xr.Dataset,
-        scenario: Optional[str] = None,
-        override_dict: Optional[dict] = None,
-        data_source_dfs: Optional[dict[str, pd.DataFrame]] = None,
+        scenario: str | None = None,
+        override_dict: dict | None = None,
+        data_source_dfs: dict[str, pd.DataFrame] | None = None,
         **kwargs,
     ):
         """Returns a new Model from YAML model configuration files or a fully specified dictionary.
@@ -82,7 +83,7 @@ class Model(object):
         self.config: AttrDict
         self.defaults: AttrDict
         self.math: AttrDict
-        self._model_def_path: Optional[Path]
+        self._model_def_path: Path | None
         self.backend: BackendModel
         self.math_documentation = MathDocumentation()
         self._is_built: bool = False
@@ -145,8 +146,8 @@ class Model(object):
         self,
         model_definition: calliope.AttrDict,
         applied_overrides: str,
-        scenario: Optional[str],
-        data_source_dfs: Optional[dict[str, pd.DataFrame]],
+        scenario: str | None,
+        data_source_dfs: dict[str, pd.DataFrame] | None,
     ) -> None:
         """Initialise the model using pre-processed YAML files and optional dataframes/dicts.
 
@@ -265,7 +266,7 @@ class Model(object):
         self._add_observed_dict("config")
         self._add_observed_dict("math")
 
-    def _add_observed_dict(self, name: str, dict_to_add: Optional[dict] = None) -> None:
+    def _add_observed_dict(self, name: str, dict_to_add: dict | None = None) -> None:
         """Add the same dictionary as property of model object and an attribute of the model xarray dataset.
 
         Args:

--- a/src/calliope/postprocess/postprocess.py
+++ b/src/calliope/postprocess/postprocess.py
@@ -157,9 +157,7 @@ def clean_results(results, zero_threshold):
         )
         LOGGER.warn(comment)
     else:
-        comment = "Postprocessing: zero threshold of {} not required".format(
-            zero_threshold
-        )
+        comment = f"Postprocessing: zero threshold of {zero_threshold} not required"
         LOGGER.info(comment)
 
     # Combine unused_supply and unmet_demand into one variable

--- a/src/calliope/preprocess/data_sources.py
+++ b/src/calliope/preprocess/data_sources.py
@@ -3,8 +3,8 @@
 """Preprocessing functionality."""
 
 import logging
+from collections.abc import Hashable
 from pathlib import Path
-from typing import Hashable, Optional
 
 import numpy as np
 import pandas as pd
@@ -50,8 +50,8 @@ class DataSource:
         model_config: dict,
         source_name: str,
         data_source: DataSourceDict,
-        data_source_dfs: Optional[dict[str, pd.DataFrame]] = None,
-        model_definition_path: Optional[Path] = None,
+        data_source_dfs: dict[str, pd.DataFrame] | None = None,
+        model_definition_path: Path | None = None,
     ):
         """Load and format a data source from file / in-memory object.
 
@@ -372,7 +372,7 @@ class DataSource:
             self.MESSAGE_TEMPLATE.format(name=self.name, message=message)
         )
 
-    def _listify_if_defined(self, key: str) -> Optional[list]:
+    def _listify_if_defined(self, key: str) -> list | None:
         """If `key` is in data source definition dictionary, return values as a list.
 
         If values are not yet an iterable, they will be coerced to an iterable of length 1.

--- a/src/calliope/preprocess/load.py
+++ b/src/calliope/preprocess/load.py
@@ -4,7 +4,6 @@
 
 import logging
 from pathlib import Path
-from typing import Optional
 
 from calliope import exceptions
 from calliope.attrdict import AttrDict
@@ -15,10 +14,10 @@ LOGGER = logging.getLogger(__name__)
 
 def load_model_definition(
     model_definition: str | Path | dict,
-    scenario: Optional[str] = None,
-    override_dict: Optional[dict] = None,
+    scenario: str | None = None,
+    override_dict: dict | None = None,
     **kwargs,
-) -> tuple[AttrDict, Optional[Path], str]:
+) -> tuple[AttrDict, Path | None, str]:
     """Load model definition from file / dictionary and apply user-defined overrides.
 
     Args:
@@ -66,17 +65,12 @@ def _combine_overrides(overrides: AttrDict, scenario_overrides: list):
             yaml_string = overrides[override].to_yaml()
             override_with_imports = AttrDict.from_yaml_string(yaml_string)
         except KeyError:
-            raise exceptions.ModelError(
-                "Override `{}` is not defined.".format(override)
-            )
+            raise exceptions.ModelError(f"Override `{override}` is not defined.")
         try:
             combined_override_dict.union(override_with_imports, allow_override=False)
         except KeyError as e:
             raise exceptions.ModelError(
-                str(e)[1:-1]
-                + ". Already specified but defined again in " "override `{}`.".format(
-                    override
-                )
+                f"{str(e)[1:-1]}. Already specified but defined again in override `{override}`."
             )
 
     return combined_override_dict
@@ -84,8 +78,8 @@ def _combine_overrides(overrides: AttrDict, scenario_overrides: list):
 
 def _apply_overrides(
     model_def: AttrDict,
-    scenario: Optional[str] = None,
-    override_dict: Optional[str | dict] = None,
+    scenario: str | None = None,
+    override_dict: str | dict | None = None,
 ) -> tuple[AttrDict, list[str]]:
     """Generate processed Model configuration, applying any scenario overrides.
 
@@ -159,7 +153,7 @@ def _load_overrides_from_scenario(
     model_def: AttrDict, scenario: str, overrides: dict, scenarios: dict
 ) -> list[str]:
     if scenario in scenarios.keys():
-        LOGGER.info("Loading overrides from scenario: {} ".format(scenario))
+        LOGGER.info(f"Loading overrides from scenario: {scenario} ")
         scenario_list = listify(scenarios[scenario])
     else:
         scenario_list = scenario.split(",")

--- a/src/calliope/preprocess/model_data.py
+++ b/src/calliope/preprocess/model_data.py
@@ -5,7 +5,7 @@
 import itertools
 import logging
 from copy import deepcopy
-from typing import Literal, Optional
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -21,7 +21,7 @@ from calliope.util.tools import listify
 
 LOGGER = logging.getLogger(__name__)
 
-DATA_T = Optional[float | int | bool | str] | list[Optional[float | int | bool | str]]
+DATA_T = float | int | bool | str | None | list[float | int | bool | str | None]
 
 
 class Param(TypedDict):
@@ -505,7 +505,7 @@ class ModelDataFactory:
     def _inherit_defs(
         self,
         dim_name: Literal["nodes", "techs"],
-        dim_dict: Optional[AttrDict] = None,
+        dim_dict: AttrDict | None = None,
         **connected_dims: str,
     ) -> AttrDict:
         """For a set of node/tech definitions, climb the inheritance tree to build a final definition dictionary.
@@ -582,8 +582,8 @@ class ModelDataFactory:
         dim_item_dict: AttrDict,
         dim_name: Literal["nodes", "techs"],
         item_name: str,
-        inheritance: Optional[list] = None,
-    ) -> tuple[AttrDict, Optional[list]]:
+        inheritance: list | None = None,
+    ) -> tuple[AttrDict, list | None]:
         """Follow the `inherit` references from `nodes` to `node_groups` / from `techs` to `tech_groups`.
 
         Abstract group definitions (those in `node_groups`/`tech_groups`) can inherit each other, but `nodes`/`techs` cannot.

--- a/src/calliope/preprocess/time.py
+++ b/src/calliope/preprocess/time.py
@@ -219,8 +219,8 @@ def _check_time_subset(ts_index: pd.Index, time_subset: list[str]):
     except ValueError as e:
         raise exceptions.ModelError(
             "Timeseries subset must be in ISO format (anything up to the  "
-            "detail of `%Y-%m-%d %H:%M:%S`).\n User time subset: {}\n "
-            "Error caused: {}".format(time_subset, e)
+            f"detail of `%Y-%m-%d %H:%M:%S`).\n User time subset: {time_subset}\n "
+            f"Error caused: {e}"
         )
 
     df_start_time = ts_index[0]

--- a/src/calliope/util/generate_runs.py
+++ b/src/calliope/util/generate_runs.py
@@ -53,10 +53,10 @@ def generate_runs(model_file, scenarios=None, additional_args=None, override_dic
         ).strip()
 
         if override_dict:
-            cmd = cmd + ' --override_dict="{}"'.format(override_dict)
+            cmd = f'{cmd} --override_dict="{override_dict}"'
 
         if additional_args:
-            cmd = cmd + " " + additional_args
+            cmd = f"{cmd} {additional_args}"
 
         commands.append(cmd)
 
@@ -83,7 +83,7 @@ def generate_bash_script(
         "",
         "if [[ $# -eq 0 ]] ; then",
         "    echo No parameter given, running all runs sequentially...",
-        "    for i in $(seq 1 {}); do process_case $i; done".format(len(commands)),
+        f"    for i in $(seq 1 {len(commands)}); do process_case $i; done",
         "else",
         "    echo Running run $1",
         "    process_case $1",
@@ -126,10 +126,10 @@ def generate_bsub_script(
 
     lines = [
         "#!/bin/sh",
-        "#BSUB -J calliope[1-{}]".format(len(commands)),
-        "#BSUB -n {}".format(cluster_threads),
-        '#BSUB -R "rusage[mem={}]"'.format(cluster_mem),
-        "#BSUB -W {}".format(cluster_time),
+        f"#BSUB -J calliope[1-{len(commands)}]",
+        f"#BSUB -n {cluster_threads}",
+        f'#BSUB -R "rusage[mem={cluster_mem}]"',
+        f"#BSUB -W {cluster_time}",
         "#BSUB -r",  # Automatically restart failed jobs
         "#BSUB -o log_%I.log",
         "",
@@ -169,12 +169,10 @@ def generate_sbatch_script(
     lines = [
         "#!/bin/bash",
         "#SBATCH -J calliope",  # Name of the job
-        "#SBATCH --array=1-{}".format(len(commands)),  # How many jobs there are
-        "#SBATCH --ntasks={}".format(cluster_threads),
-        "#SBATCH --mem={}".format(cluster_mem),
-        "#SBATCH --time={}".format(
-            cluster_time
-        ),  # How much wallclock time will be required
+        f"#SBATCH --array=1-{len(commands)}",  # How many jobs there are
+        f"#SBATCH --ntasks={cluster_threads}",
+        f"#SBATCH --mem={cluster_mem}",
+        f"#SBATCH --time={cluster_time}",  # How much wallclock time will be required
         "#SBATCH -o log_%a.log",
         "",
         "#! Optional add-ins for SBATCH (uncomment and add info as necessary):",

--- a/src/calliope/util/logging.py
+++ b/src/calliope/util/logging.py
@@ -6,7 +6,6 @@
 import datetime
 import logging
 import sys
-from typing import Optional
 
 _time_format = "%Y-%m-%d %H:%M:%S"
 
@@ -98,7 +97,7 @@ def log_time(
     logger: logging.Logger,
     timings: dict,
     identifier: str,
-    comment: Optional[str] = None,
+    comment: str | None = None,
     level: str = "info",
     time_since_solve_start: bool = False,
 ) -> float:

--- a/src/calliope/util/schema.py
+++ b/src/calliope/util/schema.py
@@ -6,7 +6,7 @@ import importlib
 import re
 import sys
 from copy import deepcopy
-from typing import Literal, Optional
+from typing import Literal
 
 import jsonschema
 
@@ -134,7 +134,7 @@ def validate_dict(to_validate: dict, schema: dict, dict_descriptor: str) -> None
 def extract_from_schema(
     schema: dict,
     keyword: str,
-    subset_top_level: Optional[Literal["nodes", "techs", "parameters"]] = None,
+    subset_top_level: Literal["nodes", "techs", "parameters"] | None = None,
 ) -> dict:
     """Extract a keyword for each leaf property in the schema.
 
@@ -182,7 +182,6 @@ def _extend_with_keyword(
                     continue
                 instance.setdefault(".".join(new_key.groups()), val)
 
-        for error in validate_properties(validator, properties, instance, schema):
-            yield error
+        yield from validate_properties(validator, properties, instance, schema)
 
     return jsonschema.validators.extend(validator_class, {"properties": set_defaults})

--- a/tests/common/util.py
+++ b/tests/common/util.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Literal, Optional, Union
+from typing import Literal
 
 import calliope
 import xarray as xr
@@ -29,7 +29,7 @@ def check_error_or_warning(error_warning, test_string_or_strings):
         )
     elif hasattr(error_warning, "value"):
         output = str(error_warning.value)
-    elif isinstance(error_warning, (list, set)):
+    elif isinstance(error_warning, list | set):
         output = ",".join(error_warning)
 
     if isinstance(test_string_or_strings, list):
@@ -41,7 +41,7 @@ def check_error_or_warning(error_warning, test_string_or_strings):
 
 
 def check_variable_exists(
-    expr_or_constr: Optional[xr.DataArray], variable: str, slices: Optional[dict] = None
+    expr_or_constr: xr.DataArray | None, variable: str, slices: dict | None = None
 ) -> bool:
     """
     Search for existence of a decision variable in a Pyomo constraint.
@@ -77,8 +77,8 @@ def check_variable_exists(
 
 def build_lp(
     model: calliope.Model,
-    outfile: Union[str, Path],
-    math: Optional[dict[Union[dict, list]]] = None,
+    outfile: str | Path,
+    math: dict[dict | list] | None = None,
     backend: Literal["pyomo"] = "pyomo",
 ) -> None:
     """

--- a/tests/test_backend_pyomo.py
+++ b/tests/test_backend_pyomo.py
@@ -496,8 +496,7 @@ class TestCostConstraints:
     def test_loc_techs_cost_var_constraint(self, tech, scenario, cost):
         """I for i in sets.loc_techs_om_cost if i not in sets.loc_techs_conversion_plus + sets.loc_techs_conversion"""
         m = build_model(
-            {"techs.{}.costs.monetary.{}".format(tech, cost): 1},
-            "{},two_hours".format(scenario),
+            {f"techs.{tech}.costs.monetary.{cost}": 1}, f"{scenario},two_hours"
         )
         m.build()
         assert "cost_var" in m.backend.expressions
@@ -646,7 +645,7 @@ class TestCapacityConstraints:
         m.build()
         assert hasattr(
             m._backend_model,
-            "flow_capacity_per_storage_capacity_{}_constraint".format(override),
+            f"flow_capacity_per_storage_capacity_{override}_constraint",
         )
 
     @pytest.mark.filterwarnings("ignore:(?s).*Integer:calliope.exceptions.ModelWarning")
@@ -673,9 +672,7 @@ class TestCapacityConstraints:
         m.build()
         assert not any(
             [
-                hasattr(
-                    m._backend_model, "flow_capacity_storage_{}_constraint".format(i)
-                )
+                hasattr(m._backend_model, f"flow_capacity_storage_{i}_constraint")
                 for i in ["max", "min"]
             ]
         )
@@ -700,11 +697,7 @@ class TestCapacityConstraints:
 
         else:
             m = build_model(
-                {
-                    "techs.test_supply_plus.constraints.resource_cap_{}".format(
-                        override
-                    ): 10
-                },
+                {f"techs.test_supply_plus.constraints.resource_cap_{override}": 10},
                 "simple_supply_and_supply_plus,two_hours,investment_costs",
             )
             m.build()
@@ -1801,7 +1794,7 @@ class TestNewBackend:
             "cost", as_backend_objs=False, eval_body=True
         )
         assert (
-            expr.to_series().dropna().apply(lambda x: isinstance(x, (float, int))).all()
+            expr.to_series().dropna().apply(lambda x: isinstance(x, float | int)).all()
         )
 
     def test_new_build_get_constraint(self, simple_supply):
@@ -1847,7 +1840,7 @@ class TestNewBackend:
             constr["body"]
             .to_series()
             .dropna()
-            .apply(lambda x: isinstance(x, (float, int)))
+            .apply(lambda x: isinstance(x, float | int))
             .all()
         )
 

--- a/tests/test_core_attrdict.py
+++ b/tests/test_core_attrdict.py
@@ -308,7 +308,7 @@ class TestAttrDict:
             out_file = os.path.join(tempdir, "test.yaml")
             d.to_yaml(out_file)
 
-            with open(out_file, "r") as f:
+            with open(out_file) as f:
                 result = f.read()
 
             assert "some_int: 10" in result
@@ -347,16 +347,16 @@ class TestAttrDict:
             with open(imported_file, "w") as f:
                 f.write(imported_yaml)
 
-            yaml_string = """
+            yaml_string = f"""
                 foobar:
                     import:
-                        - {}
+                        - {imported_file}
                 foo:
                     bar: 1
                     baz: 2
                     3:
                         4: 5
-            """.format(imported_file)
+            """
 
             d = AttrDict.from_yaml_string(yaml_string, resolve_imports="foobar")
 

--- a/tests/test_core_preprocess.py
+++ b/tests/test_core_preprocess.py
@@ -148,9 +148,7 @@ class TestModelRun:
         """
 
         def override(param):
-            return AttrDict.from_yaml_string(
-                "config.init.time_subset: {}".format(param)
-            )
+            return AttrDict.from_yaml_string(f"config.init.time_subset: {param}")
 
         # should fail: one string in list
         with pytest.raises(exceptions.ModelError):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -142,7 +142,7 @@ class TestIO:
         "file_name",
         sorted(
             [
-                "inputs_{}.csv".format(i)
+                f"inputs_{i}.csv"
                 for i in calliope.examples.national_scale().inputs.data_vars.keys()
             ]
         ),
@@ -152,7 +152,7 @@ class TestIO:
 
     def test_csv_contents(self, model_csv_dir):
         with open(
-            os.path.join(model_csv_dir, "inputs_flow_cap_max_systemwide.csv"), "r"
+            os.path.join(model_csv_dir, "inputs_flow_cap_max_systemwide.csv")
         ) as f:
             assert "demand_power" not in f.read()
 
@@ -162,7 +162,7 @@ class TestIO:
             model.to_csv(out_path, dropna=False)
 
             with open(
-                os.path.join(out_path, "inputs_flow_cap_max_systemwide.csv"), "r"
+                os.path.join(out_path, "inputs_flow_cap_max_systemwide.csv")
             ) as f:
                 assert "demand_power" in f.read()
 
@@ -215,7 +215,7 @@ class TestIO:
             out_path = os.path.join(tempdir, "model.lp")
             model.backend.to_lp(out_path)
 
-            with open(out_path, "r") as f:
+            with open(out_path) as f:
                 assert "variables(flow_cap)" in f.read()
 
     @pytest.mark.skip(

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -1,7 +1,6 @@
 import importlib
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 import pytest
@@ -184,8 +183,8 @@ class CustomMathExamples(ABC):
         def _build_and_compare(
             filename: str,
             scenario: str,
-            overrides: Optional[dict] = None,
-            components: Optional[dict[list[str]]] = None,
+            overrides: dict | None = None,
+            components: dict[list[str]] | None = None,
         ):
             if components is not None:
                 for component_group, component_list in components.items():


### PR DESCRIPTION
Fixes all our outdated Python syntax.

Thanks to @irm-codebase for pointing to [pyupgrade](https://docs.astral.sh/ruff/rules/#pyupgrade-up). I think it's worth having it in our core config as it will keep our code cleaner and easier to review/maintain. 

## Summary of changes in this pull request

* Added `UP` to ruff config.
* Applied `pre-commit`, cleaning up any unresolved fixes.
* Reintroduce `skip-trailing-comma` and add the relevant `isort` config to make it work. I much prefer the result, even if it leads to more line changes per commit, on average.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved