### PR TITLE
Fixes in docs and new data checks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Francesco Lombardi, Politecnico di Milano <francesco.lombardi@polimi.it>
 Adriaan Hilbers, Imperial College London <a.hilbers17@imperial.ac.uk>
 Jann Launer, TU Delft <j.a.c.launer@tudelft.nl>
 Ivan Ruiz Manuel, TU Delft <i.ruizmanuel@tudelft.nl>
+Stefan Strömer, AIT Austrian Institute of Technology GmbH and TU Delft <stefan.stroemer@gmail.com>

--- a/src/calliope/config/model_data_checks.yaml
+++ b/src/calliope/config/model_data_checks.yaml
@@ -29,12 +29,6 @@ fail:
   - where: storage_initial<0 OR storage_initial>1
     message: "storage_initial is a fraction, requiring values within the interval [0, 1]."
 
-  - where: flow_cap_min<0
-    message: "flow_cap_min has to be non-negative."
-
-  - where: (flow_cap_min AND flow_cap_max) AND flow_cap_max<flow_cap_min
-    message: "flow_cap_min should be less than (or equal to) flow_cap_max."
-
   - where: integer_dispatch=True AND NOT cap_method=integer
     message: Cannot use the integer `integer_dispatch` unless the technology is using an integer unit capacities (`cap_method=integer`).
 

--- a/src/calliope/config/model_data_checks.yaml
+++ b/src/calliope/config/model_data_checks.yaml
@@ -26,11 +26,8 @@ fail:
   - where: carrier_export and not any(carrier_out, over=nodes)
     message: "Export carriers must be one of the technology outflow carriers."
 
-  - where: storage_initial>1
-    message: "storage_initial is a fraction; values larger than 1 are not allowed."
-
-  - where: storage_initial<0
-    message: "storage_initial is a fraction; values smaller than 0 are not allowed."
+  - where: storage_initial<0 OR storage_initial>1
+    message: "storage_initial is a fraction, requiring values within the interval [0, 1]."
 
   - where: flow_cap_min<0
     message: "flow_cap_min has to be non-negative."

--- a/src/calliope/config/model_data_checks.yaml
+++ b/src/calliope/config/model_data_checks.yaml
@@ -29,6 +29,9 @@ fail:
   - where: storage_initial>1
     message: "storage_initial is a fraction; values larger than 1 are not allowed."
 
+  - where: storage_initial<0
+    message: "storage_initial is a fraction; values smaller than 0 are not allowed."
+
   - where: integer_dispatch=True AND NOT cap_method=integer
     message: Cannot use the integer `integer_dispatch` unless the technology is using an integer unit capacities (`cap_method=integer`).
 

--- a/src/calliope/config/model_data_checks.yaml
+++ b/src/calliope/config/model_data_checks.yaml
@@ -32,6 +32,12 @@ fail:
   - where: storage_initial<0
     message: "storage_initial is a fraction; values smaller than 0 are not allowed."
 
+  - where: flow_cap_min<0
+    message: "flow_cap_min has to be non-negative."
+
+  - where: (flow_cap_min AND flow_cap_max) AND flow_cap_max<flow_cap_min
+    message: "flow_cap_min should be less than (or equal to) flow_cap_max."
+
   - where: integer_dispatch=True AND NOT cap_method=integer
     message: Cannot use the integer `integer_dispatch` unless the technology is using an integer unit capacities (`cap_method=integer`).
 

--- a/src/calliope/config/model_def_schema.yaml
+++ b/src/calliope/config/model_def_schema.yaml
@@ -707,7 +707,7 @@ properties:
             title: Required sink use.
             description: >-
               Required amount of carrier removal from the system (e.g., electricity demand, transport distance).
-              Unit dictated by `source_unit`.
+              Unit dictated by `sink_unit`.
 
           source_unit:
             type: string

--- a/src/calliope/config/model_def_schema.yaml
+++ b/src/calliope/config/model_def_schema.yaml
@@ -697,7 +697,7 @@ properties:
             title: Maximum bound on sink.
             description: >-
               Maximum sink use to remove a carrier from the system (e.g., electricity demand, transport distance).
-              Unit dictated by `source_unit`.
+              Unit dictated by `sink_unit`.
 
           sink_use_equals:
             $ref: "#/$defs/TechParamNullNumber"

--- a/src/calliope/config/model_def_schema.yaml
+++ b/src/calliope/config/model_def_schema.yaml
@@ -687,7 +687,7 @@ properties:
             title: Minimum bound on sink.
             description: >-
               Minimum sink use to remove a carrier from the system (e.g., electricity demand, transport distance).
-              Unit dictated by `source_unit`.
+              Unit dictated by `sink_unit`.
 
           sink_use_max:
             $ref: "#/$defs/TechParamNullNumber"

--- a/src/calliope/config/model_def_schema.yaml
+++ b/src/calliope/config/model_def_schema.yaml
@@ -675,7 +675,7 @@ properties:
             x-type: str
             title: Sink unit
             description: >-
-              Sets the unit of `Sink` to either `absolute` (unit: `energy`), `per_area` (e.g. unit: `energy/area`), or `per_cap` (unit: `energy/power`).
+              Sets the unit of `Sink` to either `absolute` (unit: `energy`), `per_area` (unit: `energy/area`), or `per_cap` (unit: `energy/power`).
               `per_area` uses the `area_use` decision variable to scale the sink while `per_cap` uses the `flow_cap` decision variable.
             enum: [absolute, per_area, per_cap]
 

--- a/src/calliope/config/model_def_schema.yaml
+++ b/src/calliope/config/model_def_schema.yaml
@@ -675,7 +675,7 @@ properties:
             x-type: str
             title: Sink unit
             description: >-
-              Sets the unit of `Sink` to either `absolute` x-unit: energy), `per_area` x-unit: energy/area), or `per_cap` x-unit: energy/power).
+              Sets the unit of `Sink` to either `absolute` (e.g. kWh), `per_area` (e.g. kWh/m2), or `per_cap` (e.g. kWh/kW).
               `per_area` uses the `area_use` decision variable to scale the sink while `per_cap` uses the `flow_cap` decision variable.
             enum: [absolute, per_area, per_cap]
 

--- a/src/calliope/config/model_def_schema.yaml
+++ b/src/calliope/config/model_def_schema.yaml
@@ -675,7 +675,7 @@ properties:
             x-type: str
             title: Sink unit
             description: >-
-              Sets the unit of `Sink` to either `absolute` (e.g. kWh), `per_area` (e.g. kWh/m2), or `per_cap` (e.g. kWh/kW).
+              Sets the unit of `Sink` to either `absolute` (unit: `energy`), `per_area` (e.g. unit: `energy/area`), or `per_cap` (unit: `energy/power`).
               `per_area` uses the `area_use` decision variable to scale the sink while `per_cap` uses the `flow_cap` decision variable.
             enum: [absolute, per_area, per_cap]
 
@@ -716,7 +716,7 @@ properties:
             x-type: str
             title: Source unit
             description: >-
-              Sets the unit of `Source` to either `absolute` (e.g. kWh), `per_area` (e.g. kWh/m2), or `per_cap` (e.g. kWh/kW).
+              Sets the unit of `Source` to either `absolute` (unit: `energy`), `per_area` (unit: `energy/area`), or `per_cap` (unit: `energy/power`).
               `per_area` uses the `area_use` decision variable to scale the source while `per_cap` uses the `flow_cap` decision variable.
             enum: [absolute, per_area, per_cap]
 

--- a/tests/test_backend_pyomo.py
+++ b/tests/test_backend_pyomo.py
@@ -1605,7 +1605,9 @@ class TestModelDataChecks:
 
         with pytest.raises(exceptions.ModelError) as error:
             m.build()
-        assert check_error_or_warning(error, "values larger than 1 are not allowed")
+        assert check_error_or_warning(
+            error, "requiring values within the interval [0, 1]"
+        )
 
 
 class TestNewBackend:


### PR DESCRIPTION
Related to #643 

## Summary of changes in this pull request

* Small fixes (typos, ...) to docstrings
* Checks for valid values of ~~`flow_cap_*` and~~ `storage_initial` (d99bf9451e4d0a1a7e26cf98bef28ea19d6132fb); ~~note that I'm unsure if the check for `flow_cap_min <= flow_cap_max` is done correctly?~~

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved