### PR TITLE
Fix contribution of `cost_om_annual_investment_fraction` in math

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### User-facing changes
 
+|fixed| Contribution of `cost_om_annual_investment_fraction` to total investment costs, to not apply to depreciated costs (#645).
+
 |new| Piecewise constraints added to the YAML math with its own unique syntax (#107).
 These constraints will be added to the optimisation problem using Special Ordered Sets of Type 2 (SOS2) variables.
 

--- a/src/calliope/config/model_def_schema.yaml
+++ b/src/calliope/config/model_def_schema.yaml
@@ -903,7 +903,7 @@ properties:
             x-type: float
             title: Fractional annual O&M costs.
             description: >-
-              Add an additional cost to total investment costs (except `cost_om_annual`) that is a fraction of that total.
+              Add a fraction of the sum of all investment costs except `cost_om_annual` as an additional cost, to represent fixed annual O&M costs. Warning: the sum of all investment costs includes not just those associated with `flow_cap` but also others like those associated with `area_use`!
             x-unit: fraction / total investment.
 
           cost_flow_in:

--- a/src/calliope/math/base.yaml
+++ b/src/calliope/math/base.yaml
@@ -884,13 +884,13 @@ global_expressions:
     equations:
       - expression: >
           $annualisation_weight * (
-            $depreciation_rate * (
+            ($depreciation_rate + cost_om_annual_investment_fraction) * (
               sum(default_if_empty(cost_investment_flow_cap, 0), over=carriers) +
               default_if_empty(cost_investment_storage_cap, 0) +
               default_if_empty(cost_investment_source_cap, 0) +
               default_if_empty(cost_investment_area_use, 0) +
               default_if_empty(cost_investment_purchase, 0)
-            ) * (1 + cost_om_annual_investment_fraction)
+            )
             + sum(cost_om_annual * flow_cap, over=carriers)
           )
     sub_expressions:


### PR DESCRIPTION
Partial fix for #645. Just focussing on the _bug_ raised in that issue.

@sstroemer - can you check that I've got it right?

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved