### PR TITLE
Investigating (and improving) file format handling in backends

### DIFF
--- a/src/calliope/backend/backend_model.py
+++ b/src/calliope/backend/backend_model.py
@@ -917,6 +917,16 @@ class BackendModel(BackendModelGenerator, Generic[T]):
             path (str | Path): Path to which the LP file will be written.
         """
 
+    @abstractmethod
+    def to_mps(self, path: str | Path) -> None:
+        """Write the optimisation problem to file in the Mathematical Programming System (MPS) format.
+
+        The MPS file can be used for debugging and to submit to solvers directly.
+
+        Args:
+            path (str | Path): Path to which the MPS file will be written.
+        """
+
     @property
     @abstractmethod
     def has_integer_or_binary_variables(self) -> bool:

--- a/src/calliope/backend/backend_model.py
+++ b/src/calliope/backend/backend_model.py
@@ -916,6 +916,10 @@ class BackendModel(BackendModelGenerator, Generic[T]):
         Args:
             path (str | Path): Path to which the LP file will be written.
             **kwargs: Keyword arguments that are passed to the backend's file writer.
+
+        Possible keyword arguments:
+            symbolic_solver_labels (bool, optional): If True, will use symbolic names for variables and constraints.
+                Defaults to False. _May not be supported by all backends._
         """
 
     @abstractmethod
@@ -927,6 +931,10 @@ class BackendModel(BackendModelGenerator, Generic[T]):
         Args:
             path (str | Path): Path to which the MPS file will be written.
             **kwargs: Keyword arguments that are passed to the backend's file writer.
+
+        Possible keyword arguments:
+            symbolic_solver_labels (bool, optional): If True, will use symbolic names for variables and constraints.
+                Defaults to False. _May not be supported by all backends._
         """
 
     @property

--- a/src/calliope/backend/backend_model.py
+++ b/src/calliope/backend/backend_model.py
@@ -908,23 +908,25 @@ class BackendModel(BackendModelGenerator, Generic[T]):
         """
 
     @abstractmethod
-    def to_lp(self, path: str | Path) -> None:
+    def to_lp(self, path: str | Path, **kwargs) -> None:
         """Write the optimisation problem to file in the linear programming LP format.
 
         The LP file can be used for debugging and to submit to solvers directly.
 
         Args:
             path (str | Path): Path to which the LP file will be written.
+            **kwargs: Keyword arguments that are passed to the backend's file writer.
         """
 
     @abstractmethod
-    def to_mps(self, path: str | Path) -> None:
+    def to_mps(self, path: str | Path, **kwargs) -> None:
         """Write the optimisation problem to file in the Mathematical Programming System (MPS) format.
 
         The MPS file can be used for debugging and to submit to solvers directly.
 
         Args:
             path (str | Path): Path to which the MPS file will be written.
+            **kwargs: Keyword arguments that are passed to the backend's file writer.
         """
 
     @property

--- a/src/calliope/backend/gurobi_backend_model.py
+++ b/src/calliope/backend/gurobi_backend_model.py
@@ -311,23 +311,53 @@ class GurobiBackendModel(backend_model.BackendModel):
         self._instance.update()
 
     def to_lp(self, path: str | Path, **kwargs) -> None:  # noqa: D102, override
+        kwargs_defaults = {}
+        supported_kwargs = []
+        invalid_kwargs = [key for key in kwargs if key not in supported_kwargs]
+        valid_suffixes = [".lp", ".lp.gz", ".lp.bz2", ".lp.7z"]
+
         self._instance.update()
 
-        valid_suffixes = [".lp", ".lp.gz", ".lp.bz2", ".lp.7z"]
         if "".join(Path(path).suffixes) not in valid_suffixes:
             raise ValueError(
                 "File extension must be `.lp`, or `.lp.*` with any of the accepted compression formats."
             )
+
+        if len(invalid_kwargs) > 0:
+            model_warn(
+                f"Backend 'gurobi' does not support the following kwargs: {invalid_kwargs}. They will be ignored."
+            )
+            for key in invalid_kwargs:
+                del kwargs[key]
+
+        for key, value in kwargs_defaults.items():
+            kwargs.setdefault(key, value)
+
         self._instance.write(str(path), **kwargs)
 
     def to_mps(self, path: str | Path, **kwargs) -> None:  # noqa: D102, override
+        kwargs_defaults = {}
+        supported_kwargs = []
+        invalid_kwargs = [key for key in kwargs if key not in supported_kwargs]
+        valid_suffixes = [".mps", ".mps.gz", ".mps.bz2", ".mps.7z"]
+
         self._instance.update()
 
-        valid_suffixes = [".mps", ".mps.gz", ".mps.bz2", ".mps.7z"]
         if "".join(Path(path).suffixes) not in valid_suffixes:
             raise ValueError(
                 "File extension must be `.mps`, or `.mps.*` with any of the accepted compression formats."
             )
+
+        if len(invalid_kwargs) > 0:
+            model_warn(
+                f"Backend 'gurobi' does not support the following kwargs: {invalid_kwargs}. They will be ignored."
+            )
+            for key in invalid_kwargs:
+                del kwargs[key]
+
+        for key, value in kwargs_defaults.items():
+            kwargs.setdefault(key, value)
+
         self._instance.write(str(path), **kwargs)
 
     def _create_obj_list(self, key: str, component_type: _COMPONENTS_T) -> None:

--- a/src/calliope/backend/gurobi_backend_model.py
+++ b/src/calliope/backend/gurobi_backend_model.py
@@ -308,6 +308,13 @@ class GurobiBackendModel(backend_model.BackendModel):
             raise ValueError("File extension must be `.lp`")
         self._instance.write(str(path))
 
+    def to_mps(self, path: str | Path) -> None:  # noqa: D102, override
+        self._instance.update()
+
+        if Path(path).suffix != ".mps":
+            raise ValueError("File extension must be `.mps`")
+        self._instance.write(str(path))
+
     def _create_obj_list(self, key: str, component_type: _COMPONENTS_T) -> None:
         pass
 

--- a/src/calliope/backend/gurobi_backend_model.py
+++ b/src/calliope/backend/gurobi_backend_model.py
@@ -301,19 +301,19 @@ class GurobiBackendModel(backend_model.BackendModel):
                 da.attrs["coords_in_name"] = True
         self._instance.update()
 
-    def to_lp(self, path: str | Path) -> None:  # noqa: D102, override
+    def to_lp(self, path: str | Path, **kwargs) -> None:  # noqa: D102, override
         self._instance.update()
 
         if Path(path).suffix != ".lp":
             raise ValueError("File extension must be `.lp`")
-        self._instance.write(str(path))
+        self._instance.write(str(path), **kwargs)
 
-    def to_mps(self, path: str | Path) -> None:  # noqa: D102, override
+    def to_mps(self, path: str | Path, **kwargs) -> None:  # noqa: D102, override
         self._instance.update()
 
         if Path(path).suffix != ".mps":
             raise ValueError("File extension must be `.mps`")
-        self._instance.write(str(path))
+        self._instance.write(str(path), **kwargs)
 
     def _create_obj_list(self, key: str, component_type: _COMPONENTS_T) -> None:
         pass

--- a/src/calliope/backend/gurobi_backend_model.py
+++ b/src/calliope/backend/gurobi_backend_model.py
@@ -57,8 +57,9 @@ class GurobiBackendModel(backend_model.BackendModel):
 
         self._add_all_inputs_as_parameters()
 
-        if self.inputs.attrs["config"].build.get("GRBIgnoreNames", False):
-            self._instance.Params.IgnoreNames = 1
+        for k in self.inputs.attrs["config"].build.keys():
+            if k.startswith("GRB"):
+                self._instance.setParam(k[3:], self.inputs.attrs["config"].build[k])
 
 
     def add_parameter(  # noqa: D102, override

--- a/src/calliope/backend/gurobi_backend_model.py
+++ b/src/calliope/backend/gurobi_backend_model.py
@@ -61,7 +61,6 @@ class GurobiBackendModel(backend_model.BackendModel):
             if k.startswith("GRB"):
                 self._instance.setParam(k[3:], self.inputs.attrs["config"].build[k])
 
-
     def add_parameter(  # noqa: D102, override
         self, parameter_name: str, parameter_values: xr.DataArray, default: Any = np.nan
     ) -> None:
@@ -282,7 +281,11 @@ class GurobiBackendModel(backend_model.BackendModel):
         def __renamer(val, *idx, name: str, attr: str):
             if pd.notnull(val):
                 # see: https://stackoverflow.com/a/27086669
-                new_obj_name = f"{name}[{'_'.join(idx)}]".replace(" ", r"_").replace(":", r"_").replace("-", r"_")
+                new_obj_name = (
+                    f"{name}[{'_'.join(idx)}]".replace(" ", r"_")
+                    .replace(":", r"_")
+                    .replace("-", r"_")
+                )
                 setattr(val, attr, new_obj_name)
 
         self._instance.update()
@@ -310,15 +313,21 @@ class GurobiBackendModel(backend_model.BackendModel):
     def to_lp(self, path: str | Path, **kwargs) -> None:  # noqa: D102, override
         self._instance.update()
 
-        if "".join(Path(path).suffixes) not in [".lp", ".lp.gz", ".lp.bz2", ".lp.7z"]:
-            raise ValueError("File extension must be `.lp`, or `.lp.*` with any of the accepted compression formats.")
+        valid_suffixes = [".lp", ".lp.gz", ".lp.bz2", ".lp.7z"]
+        if "".join(Path(path).suffixes) not in valid_suffixes:
+            raise ValueError(
+                "File extension must be `.lp`, or `.lp.*` with any of the accepted compression formats."
+            )
         self._instance.write(str(path), **kwargs)
 
     def to_mps(self, path: str | Path, **kwargs) -> None:  # noqa: D102, override
         self._instance.update()
 
-        if "".join(Path(path).suffixes) not in [".mps", ".mps.gz", ".mps.bz2", ".mps.7z"]:
-            raise ValueError("File extension must be `.mps`, or `.mps.*` with any of the accepted compression formats.")
+        valid_suffixes = [".mps", ".mps.gz", ".mps.bz2", ".mps.7z"]
+        if "".join(Path(path).suffixes) not in valid_suffixes:
+            raise ValueError(
+                "File extension must be `.mps`, or `.mps.*` with any of the accepted compression formats."
+            )
         self._instance.write(str(path), **kwargs)
 
     def _create_obj_list(self, key: str, component_type: _COMPONENTS_T) -> None:

--- a/src/calliope/backend/gurobi_backend_model.py
+++ b/src/calliope/backend/gurobi_backend_model.py
@@ -57,6 +57,10 @@ class GurobiBackendModel(backend_model.BackendModel):
 
         self._add_all_inputs_as_parameters()
 
+        if self.inputs.attrs["config"].build.get("GRBIgnoreNames", False):
+            self._instance.Params.IgnoreNames = 1
+
+
     def add_parameter(  # noqa: D102, override
         self, parameter_name: str, parameter_values: xr.DataArray, default: Any = np.nan
     ) -> None:
@@ -276,7 +280,7 @@ class GurobiBackendModel(backend_model.BackendModel):
     def verbose_strings(self) -> None:  # noqa: D102, override
         def __renamer(val, *idx, name: str, attr: str):
             if pd.notnull(val):
-                new_obj_name = f"{name}[{', '.join(idx)}]"
+                new_obj_name = f"{name}[{','.join(idx)}]"
                 setattr(val, attr, new_obj_name)
 
         self._instance.update()

--- a/src/calliope/backend/gurobi_backend_model.py
+++ b/src/calliope/backend/gurobi_backend_model.py
@@ -280,7 +280,8 @@ class GurobiBackendModel(backend_model.BackendModel):
     def verbose_strings(self) -> None:  # noqa: D102, override
         def __renamer(val, *idx, name: str, attr: str):
             if pd.notnull(val):
-                new_obj_name = f"{name}[{','.join(idx)}]"
+                # see: https://stackoverflow.com/a/27086669
+                new_obj_name = f"{name}[{'_'.join(idx)}]".replace(" ", r"_").replace(":", r"_").replace("-", r"_")
                 setattr(val, attr, new_obj_name)
 
         self._instance.update()

--- a/src/calliope/backend/gurobi_backend_model.py
+++ b/src/calliope/backend/gurobi_backend_model.py
@@ -282,7 +282,7 @@ class GurobiBackendModel(backend_model.BackendModel):
             if pd.notnull(val):
                 # see: https://stackoverflow.com/a/27086669
                 new_obj_name = (
-                    f"{name}[{'_'.join(idx)}]".replace(" ", r"_")
+                    f"{name}[{'__'.join(idx)}]".replace(" ", r"_")
                     .replace(":", r"_")
                     .replace("-", r"_")
                 )

--- a/src/calliope/backend/gurobi_backend_model.py
+++ b/src/calliope/backend/gurobi_backend_model.py
@@ -310,15 +310,15 @@ class GurobiBackendModel(backend_model.BackendModel):
     def to_lp(self, path: str | Path, **kwargs) -> None:  # noqa: D102, override
         self._instance.update()
 
-        if Path(path).suffix != ".lp":
-            raise ValueError("File extension must be `.lp`")
+        if "".join(Path(path).suffixes) not in [".lp", ".lp.gz", ".lp.bz2", ".lp.7z"]:
+            raise ValueError("File extension must be `.lp`, or `.lp.*` with any of the accepted compression formats.")
         self._instance.write(str(path), **kwargs)
 
     def to_mps(self, path: str | Path, **kwargs) -> None:  # noqa: D102, override
         self._instance.update()
 
-        if Path(path).suffix != ".mps":
-            raise ValueError("File extension must be `.mps`")
+        if "".join(Path(path).suffixes) not in [".mps", ".mps.gz", ".mps.bz2", ".mps.7z"]:
+            raise ValueError("File extension must be `.mps`, or `.mps.*` with any of the accepted compression formats.")
         self._instance.write(str(path), **kwargs)
 
     def _create_obj_list(self, key: str, component_type: _COMPONENTS_T) -> None:

--- a/src/calliope/backend/pyomo_backend_model.py
+++ b/src/calliope/backend/pyomo_backend_model.py
@@ -375,15 +375,46 @@ class PyomoBackendModel(backend_model.BackendModel):
         self._has_verbose_strings = True
 
     def to_lp(self, path: str | Path, **kwargs) -> None:  # noqa: D102, override
+        kwargs_defaults = {"symbolic_solver_labels": True}
+        supported_kwargs = ["symbolic_solver_labels"]
+        invalid_kwargs = [key for key in kwargs if key not in supported_kwargs]
+
         if Path(path).suffix != ".lp":
             raise ValueError("File extension must be `.lp`")
-        kwargs.setdefault("symbolic_solver_labels", True)
+
+        if len(invalid_kwargs) > 0:
+            model_warn(
+                f"Backend 'pyomo' does not support the following kwargs: {invalid_kwargs}. They will be ignored."
+            )
+            for key in invalid_kwargs:
+                del kwargs[key]
+
+        for key, value in kwargs_defaults.items():
+            kwargs.setdefault(key, value)
+
+        if any(key not in supported_kwargs for key in kwargs.keys()):
+            model_warn("Backend 'pyomo' does not support")
+
         self._instance.write(str(path), format="lp", **kwargs)
 
     def to_mps(self, path: str | Path, **kwargs) -> None:  # noqa: D102, override
+        kwargs_defaults = {"symbolic_solver_labels": True}
+        supported_kwargs = ["symbolic_solver_labels"]
+        invalid_kwargs = [key for key in kwargs if key not in supported_kwargs]
+
         if Path(path).suffix != ".mps":
             raise ValueError("File extension must be `.mps`")
-        kwargs.setdefault("symbolic_solver_labels", True)
+
+        if len(invalid_kwargs) > 0:
+            model_warn(
+                f"Backend 'pyomo' does not support the following kwargs: {invalid_kwargs}. They will be ignored."
+            )
+            for key in invalid_kwargs:
+                del kwargs[key]
+
+        for key, value in kwargs_defaults.items():
+            kwargs.setdefault(key, value)
+
         self._instance.write(str(path), format="mps", **kwargs)
 
     def _create_obj_list(self, key: str, component_type: _COMPONENTS_T) -> None:

--- a/src/calliope/backend/pyomo_backend_model.py
+++ b/src/calliope/backend/pyomo_backend_model.py
@@ -349,15 +349,15 @@ class PyomoBackendModel(backend_model.BackendModel):
                     da.attrs["coords_in_name"] = True
         self._has_verbose_strings = True
 
-    def to_lp(self, path: str | Path) -> None:  # noqa: D102, override
+    def to_lp(self, path: str | Path, **kwargs) -> None:  # noqa: D102, override
         if Path(path).suffix != ".lp":
             raise ValueError("File extension must be `.lp`")
-        self._instance.write(str(path), format="lp", symbolic_solver_labels=True)
+        self._instance.write(str(path), format="lp", **kwargs)
 
-    def to_mps(self, path: str | Path) -> None:  # noqa: D102, override
+    def to_mps(self, path: str | Path, **kwargs) -> None:  # noqa: D102, override
         if Path(path).suffix != ".mps":
             raise ValueError("File extension must be `.mps`")
-        self._instance.write(str(path), format="mps", symbolic_solver_labels=True)
+        self._instance.write(str(path), format="mps", **kwargs)
 
     def _create_obj_list(self, key: str, component_type: _COMPONENTS_T) -> None:
         """Attach an empty pyomo kernel list object to the pyomo model object.

--- a/src/calliope/backend/pyomo_backend_model.py
+++ b/src/calliope/backend/pyomo_backend_model.py
@@ -352,11 +352,13 @@ class PyomoBackendModel(backend_model.BackendModel):
     def to_lp(self, path: str | Path, **kwargs) -> None:  # noqa: D102, override
         if Path(path).suffix != ".lp":
             raise ValueError("File extension must be `.lp`")
+        kwargs.setdefault("symbolic_solver_labels", True)
         self._instance.write(str(path), format="lp", **kwargs)
 
     def to_mps(self, path: str | Path, **kwargs) -> None:  # noqa: D102, override
         if Path(path).suffix != ".mps":
             raise ValueError("File extension must be `.mps`")
+        kwargs.setdefault("symbolic_solver_labels", True)
         self._instance.write(str(path), format="mps", **kwargs)
 
     def _create_obj_list(self, key: str, component_type: _COMPONENTS_T) -> None:

--- a/src/calliope/backend/pyomo_backend_model.py
+++ b/src/calliope/backend/pyomo_backend_model.py
@@ -312,8 +312,12 @@ class PyomoBackendModel(backend_model.BackendModel):
         termination = results.solver[0].termination_condition
 
         if pe.TerminationCondition.to_solver_status(termination) == pe.SolverStatus.ok:
-            self._instance.load_solution(results.solution[0])
-            results = self.load_results()
+            if len(results.solution) == 0:
+                model_warn("Solver status OK, but solver did not return a solution.", _class=BackendWarning)
+                results = xr.Dataset()
+            else:
+                self._instance.load_solution(results.solution[0])
+                results = self.load_results()
         else:
             self._solve_logger.critical("Problem status:")
             for line in str(results.problem[0]).split("\n"):

--- a/src/calliope/backend/pyomo_backend_model.py
+++ b/src/calliope/backend/pyomo_backend_model.py
@@ -352,6 +352,9 @@ class PyomoBackendModel(backend_model.BackendModel):
     def to_lp(self, path: str | Path) -> None:  # noqa: D102, override
         self._instance.write(str(path), format="lp", symbolic_solver_labels=True)
 
+    def to_mps(self, path: str | Path) -> None:  # noqa: D102, override
+        self._instance.write(str(path), format="mps", symbolic_solver_labels=True)
+
     def _create_obj_list(self, key: str, component_type: _COMPONENTS_T) -> None:
         """Attach an empty pyomo kernel list object to the pyomo model object.
 

--- a/src/calliope/backend/pyomo_backend_model.py
+++ b/src/calliope/backend/pyomo_backend_model.py
@@ -24,8 +24,8 @@ from pyomo.core.kernel.piecewise_library.transforms import (
     piecewise_sos2,
 )
 from pyomo.opt import SolverFactory  # type: ignore
-from pyomo.util.model_size import build_model_size_report  # type: ignore
 from pyomo.opt.base import ProblemFormat  # type: ignore
+from pyomo.util.model_size import build_model_size_report  # type: ignore
 
 from calliope.backend import backend_model, parsing
 from calliope.exceptions import BackendError, BackendWarning
@@ -285,7 +285,11 @@ class PyomoBackendModel(backend_model.BackendModel):
             self.shadow_prices.deactivate()
         opt = SolverFactory(solver, solver_io=solver_io)
 
-        solve_kwargs = {"symbolic_solver_labels": False, "keepfiles": False, "tee": True}
+        solve_kwargs = {
+            "symbolic_solver_labels": False,
+            "keepfiles": False,
+            "tee": True,
+        }
         valid_solve_kwargs = ["symbolic_solver_labels", "keepfiles"]
 
         if solver_options:
@@ -297,7 +301,9 @@ class PyomoBackendModel(backend_model.BackendModel):
                     elif k in valid_solve_kwargs:
                         solve_kwargs[k] = v
                     else:
-                        model_warn(f"Solver option {k} is not a valid Pyomo option and will be ignored.")
+                        model_warn(
+                            f"Solver option {k} is not a valid Pyomo option and will be ignored."
+                        )
                 else:
                     opt.options[k] = v
 
@@ -325,7 +331,10 @@ class PyomoBackendModel(backend_model.BackendModel):
 
         if pe.TerminationCondition.to_solver_status(termination) == pe.SolverStatus.ok:
             if len(results.solution) == 0:
-                model_warn("Solver status OK, but solver did not return a solution.", _class=BackendWarning)
+                model_warn(
+                    "Solver status OK, but solver did not return a solution.",
+                    _class=BackendWarning,
+                )
                 results = xr.Dataset()
             else:
                 self._instance.load_solution(results.solution[0])

--- a/src/calliope/backend/pyomo_backend_model.py
+++ b/src/calliope/backend/pyomo_backend_model.py
@@ -350,9 +350,13 @@ class PyomoBackendModel(backend_model.BackendModel):
         self._has_verbose_strings = True
 
     def to_lp(self, path: str | Path) -> None:  # noqa: D102, override
+        if Path(path).suffix != ".lp":
+            raise ValueError("File extension must be `.lp`")
         self._instance.write(str(path), format="lp", symbolic_solver_labels=True)
 
     def to_mps(self, path: str | Path) -> None:  # noqa: D102, override
+        if Path(path).suffix != ".mps":
+            raise ValueError("File extension must be `.mps`")
         self._instance.write(str(path), format="mps", symbolic_solver_labels=True)
 
     def _create_obj_list(self, key: str, component_type: _COMPONENTS_T) -> None:


### PR DESCRIPTION
Fixes: _nothing_

This is a (pre-vacation) draft of some local changes that I needed, with a few open questions, some findings, and maybe a few interesting updates.

## Summary of changes in this pull request

The content below explains the changes, and I will add upcoming changes to this list. Benchmarks and insights, as well as open questions are given after that.

### Step-by-step of new functionality

- 5725dd6f01c72f5545e3fe28d0852ec69f01a652: Allow writing MPS files, by implementing `to_mps(...)` based on `to_lp(...)`.
- 37a476eb4d0aded53b1f94696a08e7b970f902d1: Implement the file extension (suffix) check in the Pyomo backend to be consistent with the Gurobi backend.
- 782a268e573130b2e35965f049666134b020ef66: Add `kwargs` to both `to_lp(...)` and `to_mps(...)`, to allow passing keyword arguments to the file writers. This, e.g., allows setting `symbolic_solver_labels` explicitly (previously it was active by default in the Pyomo backend).
- LP file writing with the Gurobi backend does not work, because the object names contain special characters and spaces. Refer to the [Gurobi documentation](https://docs.gurobi.com/projects/optimizer/en/current/reference/python/model.html#Model.addVar) stating: _"Note also that names that contain spaces are strongly discouraged, because they can’t be written to LP format files."_
    - b5d78607743b891397b439b2f97d013271f89974: Remove spaces.
    - 293177b92256c0faa45f2139976565190514f2a6: Replace other internally used special characters. This does not catch errors due to "wrong" user configurations.
- 6e3529bbd70a9675a03b05d2ceac1659ae88b39c: In 782a268e573130b2e35965f049666134b020ef66 the default `symbolic_solver_labels = True` was lost. To not break the expected default functionality, this internally enforces the default again.
- 977a521322f670c736d88c3df9dcf4c0d8e381aa: This allows passing Gurobi parameters (in a hacky way) to the backend, before any actual model building happens. This is important for setting `IgnoreNames`, which only affects objects added after it was set. This does not do anything write now, but was done while trying to prepare for "proper" names in the Gurobi backend.
- 26e10c5f5da9a5ee253ce463eafe9ad74a93685a changes two things:
    - It sets explicit default values for `solve_kwargs`. This was previously initialized as empty dictionary, and then updating if logs are to be kept with `{"symbolic_solver_labels": True, "keepfiles": True}`. This indicates that, e.g., `symbolic_solver_labels = False` is the assumed default, which may change without anyone immediately noticing it (Pyomo release notes can be long...). While doing that it also moves where `tee = True` is set, to allow overwriting it.
    - While most options can be set via `opt.options`, some settings are done either via direct functions or using keyword arguments directly to the `solve(...)` function. To allow setting those, this now allows passing entries to `solver_options` that start with `pyomo_`. Those are caught and handled accordingly. Currently this allows: Manually modifying `solve_kwargs` (e.g., setting `keepfiles` without having to activate `save_logs`), and most importantly setting the `ProblemFormat` that Pyomo should use (which allows forcing, e.g., `cpxlp` or `mps` formats) when passing models as file to a solver.
- 1af275982231e11c6ffbe86d89c00428e936e95c: When using the Gurobi backend to write model files, one may be interested in using the automated compression feature that Gurobi support [[docs1](https://www.gurobi.com/documentation/current/refman/py_model_write.html#pythonmethod:Model.write), [docs2](https://www.gurobi.com/documentation/current/refman/model_file_formats.html#sec:FileFormats)].
- 5b56de82de30f9fba7d5a950353fb8dab0457db5: I've missed that the Pyomo backend uses double underscores to join stuff, which I should have since the Gurobi backend had a two-char join with `, ` too; this is fixed now.
- c64c089970468b99a8f5691ae7893041c27f49e8: Contains a draft for a way to circumvent the `kwarg` problem pointed out by Bryn.

### Fixes

b68d2f3472c0ead84b79bdbf8178e51aa75df092 fixes an error that occurs when a solver returns an "okay" status code (at least one that is interpreted as such) but does not return any solutions, which can happen, e.g., for a time limit abort with Gurobi. This lead the to the following error, that is now caught, including a warning for the user.

```console
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/user/calliope/src/calliope/model.py", line 441, in solve
    results = self.backend._solve(warmstart=warmstart, **solver_config)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/calliope/src/calliope/backend/pyomo_backend_model.py", line 315, in _solve
    self._instance.load_solution(results.solution[0])
                                 ~~~~~~~~~~~~~~~~^^^
  File "/home/user/miniconda3/envs/calliope/lib/python3.12/site-packages/pyomo/opt/results/container.py", line 174, in __getitem__
    return self._list[i]
           ~~~~~~~~~~^^^
IndexError: list index out of range
```

As indicated above, without b5d78607743b891397b439b2f97d013271f89974 and 293177b92256c0faa45f2139976565190514f2a6 errors like the following occur when writing LPs with Gurobi:

```console
Warning: variable name "flow_cap[N1, N1_to_X2, heat]" has a space
Warning: constraint name "area_use_per_flow_capacity[X1, pv, electricity]" has a space
Warning: to let Gurobi read it back, use rlp format
```

## Benchmarks

> If you see something that sounds weird, please point out - I did not have any time to really check the benchmarks in detail.

- Benchmarks are done with the `urban_scale` model, using a _half year_ (`"config.init.time_subset": ["2005-01-01", "2005-06-30"]`) or _full year_ (`"config.init.time_subset": ["2005-01-01", "2005-12-31"]`) override.
- Timings are measured from the "outside", capturing the full function calls of `urban_scale` (_parse_), `build` (_build_), `to_**` (_write_), and `solve` (_pass_).
- Timings are mean out of 15 runs (half year) or 5 runs (full year).
- Passing the model to the solver is measured by setting `TimeLimit = 0` (for Gurobi) or `-seconds 0` (for Cbc, command line).
- `ssl` indicates `symbolic_solver_labels`.
- Cbc was also used from the command line, like `cbc model.lp -sec 0 solve`.

### Summary

> **Current summary:** No need for MPS files if not explicitly needed.

- For Pyomo, MPS files are approx. 30% slower for `write` and `pass` than LP files.
- For Gurobi, MPS files are ~25% faster than LP files (for writing, since passing is almost instant since `gurobipy` is used).
- Gurobi file writing is >6x faster than Pyomo.
- Loading the MPS file with Cbc (command line) is ~15% faster than for the equivalent LP file (note: Cbc cannot read the Gurobi LP file by default, a manual replacement from `-infinity` to `-inf` has to be done). The Gurobi written LP and MPS files are slightly faster to read, with slightly below 10% (but I did not in-depth benchmark this).

#### Compression

For compressed files from Gurobi, reading them is almost identical to reading the uncompressed files. Rough stats for the different compression formats, based on "full year":

| format | write [s] | size [MB] |
|:---:|:---:|:---:|
| `.lp.7z` | 14.4 | 1.4 |
| `.lp.bz2` | 3.9 | 3.9 |
| `.lp.gz` | 2.35 | 6.9 |
| | | |
| `.mps.7z` | 23.6 | 2.4 |
| `.mps.bz2` | 4.2 | 6.7 |
| `.mps.gz` | 1.6 | 11.7 |

> Uncompressed files are 29.4 MB for LP and 133.2 MB for MPS.

Summary:

- `7z` for best file size, but slow
- `bz2` for good file sizes, and good time spent
- `gz` for basic compression, but fast

### Results

#### "half year"

| backend   | format    | parse    | build    | write    | pass     | comment |
|:---------:|:---------:|:--------:|:--------:|:--------:|:--------:|:-------:|
| pyomo     | lp        | 3.00e+00 | 2.29e+01 | 1.16e+01 | 1.35e+01 | with-ssl |
| pyomo     | mps       | 2.96e+00 | 2.44e+01 | 1.58e+01 | 1.75e+01 | with-ssl |
| pyomo     | lp        | 2.95e+00 | 2.33e+01 | 8.26e+00 | 9.91e+00 | no-ssl |
| pyomo     | mps       | 3.06e+00 | 2.53e+01 | 1.22e+01 | 1.39e+01 | no-ssl |
| gurobi    | lp        | 2.97e+00 | 2.45e+01 | 1.40e+00 | 2.73e-01 | - |
| gurobi    | mps       | 2.92e+00 | 2.56e+01 | 1.08e+00 | 3.28e-01 | - |
| pyomo     | lp        | 2.60e+00 | 1.97e+01 | 1.03e+01 | - | with-ssl |
| pyomo     | lp        | 2.35e+00 | 1.78e+01 | 6.59e+00 | - | no-ssl |

#### "full year"

| backend   | format    | parse    | build    | write    | pass     | comment |
|:---------:|:---------:|:--------:|:--------:|:--------:|:--------:|:-------:|
| pyomo     | lp        | 0.00e+00 | 0.00e+00 | 0.00e+00 | 1.79e+01 | no-ssl |
| pyomo     | mps       | 0.00e+00 | 0.00e+00 | 0.00e+00 | 2.36e+01 | no-ssl |


## Questions

> **[01]** I would like to allow for more complex default names of variables and constraints when using the Gurobi backend. Currently, when adding `name=name` to the various `add_***` functions the names do not include an increasing number (as the Pyomo backend uses). Variables are then just named, e.g., `flow_cap`, which obviously prevents writing the model to a file. I fixed the verbose names, but those could be too verbose for certain use cases where `variable(flow_cap)(0)`, or something similar could be sufficient. Since I don't really understand the important internals right now:

- [ ] **What would be the best way to achieve this?** Getting a variable count from Gurobi? Maintaining one internally? Using some internal that is already there?

> **[02]** I encountered an upstream bug in Pyomo ([#3336](https://github.com/Pyomo/pyomo/issues/3336)), which has already been fixed and merged ([#3337](https://github.com/Pyomo/pyomo/pull/3337)) into `main`. 

- [ ] **What is the current reason to limit `pyomo < 6.7.2`?** Changes to `gurobi_direct` and the new "manual" IIS calculation could be interesting to include.

## Reviewer checklist

For myself:

- [x] `pre-commit` checked (ruff and black should probably fail) - done in 294ce40e75dc1e054cbd4211a1fe0d04b0d9892b
- [ ] tests checked
- [ ] new tests for `mps`, and ???

Original:

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved