### PR TITLE
Fix multi carrier costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### User-facing changes
 
+|fixed| Math for multi-carrier variable export costs (#663).
+
 |new| Piecewise constraints added to the YAML math with its own unique syntax (#107).
 These constraints will be added to the optimisation problem using Special Ordered Sets of Type 2 (SOS2) variables.
 

--- a/src/calliope/backend/pyomo_backend_model.py
+++ b/src/calliope/backend/pyomo_backend_model.py
@@ -210,7 +210,7 @@ class PyomoBackendModel(backend_model.BackendModel):
         )
         orig_dtype = parameter.original_dtype
         self.log("parameters", name, f"Converting Pyomo object to {orig_dtype} dtype.")
-        return param_as_vals.astype(orig_dtype)
+        return param_as_vals.astype(orig_dtype).where(param_as_vals.notnull())
 
     @overload
     def get_constraint(  # noqa: D102, override
@@ -687,7 +687,7 @@ class PyomoBackendModel(backend_model.BackendModel):
                 expr = expr_da.astype(str)
         else:
             expr = expr_da.astype(str)
-        return expr.where(expr.notnull())
+        return expr.where(expr_da.notnull())
 
     @staticmethod
     def _from_pyomo_param(val: ObjParameter | ObjVariable | float) -> Any:

--- a/src/calliope/math/base.yaml
+++ b/src/calliope/math/base.yaml
@@ -800,9 +800,9 @@ global_expressions:
       - expression: timestep_weights * ($cost_export + $cost_flow_out + $cost_flow_in)
     sub_expressions:
       cost_export:
-        - where: flow_export
+        - where: any(carrier_export, over=carriers) AND any(cost_export, over=carriers)
           expression: sum(cost_export * flow_export, over=carriers)
-        - where: NOT flow_export
+        - where: NOT (any(carrier_export, over=carriers) AND any(cost_export, over=carriers))
           expression: "0"
       cost_flow_in:
         - where: "base_tech=supply"

--- a/tests/common/lp_files/cost_var.lp
+++ b/tests/common/lp_files/cost_var.lp
@@ -1,0 +1,43 @@
+\* Source Pyomo model name=None *\
+
+min
+objectives(foo)(0):
++0.1 variables(flow_out)(a__test_conversion__heat__2005_01_01_00_00)
++0.1 variables(flow_out)(a__test_conversion__heat__2005_01_01_01_00)
++1.0 variables(flow_out)(a__test_conversion_plus__electricity__2005_01_01_00_00)
++2.0 variables(flow_out)(a__test_conversion_plus__heat__2005_01_01_00_00)
++4.0 variables(flow_in)(a__test_conversion_plus__gas__2005_01_01_00_00)
++1.0 variables(flow_out)(a__test_conversion_plus__electricity__2005_01_01_01_00)
++2.0 variables(flow_out)(a__test_conversion_plus__heat__2005_01_01_01_00)
++4.0 variables(flow_in)(a__test_conversion_plus__gas__2005_01_01_01_00)
++0.1 variables(flow_out)(a__test_supply_coal__coal__2005_01_01_00_00)
++0.1 variables(flow_out)(a__test_supply_coal__coal__2005_01_01_01_00)
++0.1 variables(flow_out)(a__test_supply_elec__electricity__2005_01_01_00_00)
++0.1 variables(flow_out)(a__test_supply_elec__electricity__2005_01_01_01_00)
++0.1 variables(flow_out)(a__test_supply_gas__gas__2005_01_01_00_00)
++0.1 variables(flow_out)(a__test_supply_gas__gas__2005_01_01_01_00)
+
+s.t.
+
+c_e_ONE_VAR_CONSTANT:
++1 ONE_VAR_CONSTANT
+= 1
+
+bounds
+   1 <= ONE_VAR_CONSTANT <= 1
+   0 <= variables(flow_out)(a__test_conversion__heat__2005_01_01_00_00) <= +inf
+   0 <= variables(flow_out)(a__test_conversion__heat__2005_01_01_01_00) <= +inf
+   0 <= variables(flow_out)(a__test_conversion_plus__electricity__2005_01_01_00_00) <= +inf
+   0 <= variables(flow_out)(a__test_conversion_plus__heat__2005_01_01_00_00) <= +inf
+   0 <= variables(flow_in)(a__test_conversion_plus__gas__2005_01_01_00_00) <= +inf
+   0 <= variables(flow_out)(a__test_conversion_plus__electricity__2005_01_01_01_00) <= +inf
+   0 <= variables(flow_out)(a__test_conversion_plus__heat__2005_01_01_01_00) <= +inf
+   0 <= variables(flow_in)(a__test_conversion_plus__gas__2005_01_01_01_00) <= +inf
+   0 <= variables(flow_out)(a__test_supply_coal__coal__2005_01_01_00_00) <= +inf
+   0 <= variables(flow_out)(a__test_supply_coal__coal__2005_01_01_01_00) <= +inf
+   0 <= variables(flow_out)(a__test_supply_elec__electricity__2005_01_01_00_00) <= +inf
+   0 <= variables(flow_out)(a__test_supply_elec__electricity__2005_01_01_01_00) <= +inf
+   0 <= variables(flow_out)(a__test_supply_gas__gas__2005_01_01_00_00) <= +inf
+   0 <= variables(flow_out)(a__test_supply_gas__gas__2005_01_01_01_00) <= +inf
+end
+

--- a/tests/common/lp_files/cost_var_with_export.lp
+++ b/tests/common/lp_files/cost_var_with_export.lp
@@ -1,0 +1,51 @@
+\* Source Pyomo model name=None *\
+
+min
+objectives(foo)(0):
++0.1 variables(flow_out)(a__test_conversion__heat__2005_01_01_00_00)
++0.1 variables(flow_out)(a__test_conversion__heat__2005_01_01_01_00)
++1.0 variables(flow_out)(a__test_conversion_plus__electricity__2005_01_01_00_00)
++2.0 variables(flow_out)(a__test_conversion_plus__heat__2005_01_01_00_00)
++3.0 variables(flow_export)(a__test_conversion_plus__heat__2005_01_01_00_00)
++4.0 variables(flow_in)(a__test_conversion_plus__gas__2005_01_01_00_00)
++1.0 variables(flow_out)(a__test_conversion_plus__electricity__2005_01_01_01_00)
++2.0 variables(flow_out)(a__test_conversion_plus__heat__2005_01_01_01_00)
++3.0 variables(flow_export)(a__test_conversion_plus__heat__2005_01_01_01_00)
++4.0 variables(flow_in)(a__test_conversion_plus__gas__2005_01_01_01_00)
++0.1 variables(flow_out)(a__test_supply_coal__coal__2005_01_01_00_00)
++0.1 variables(flow_out)(a__test_supply_coal__coal__2005_01_01_01_00)
++5.0 variables(flow_export)(a__test_supply_elec__electricity__2005_01_01_00_00)
++0.1 variables(flow_out)(a__test_supply_elec__electricity__2005_01_01_00_00)
++5.0 variables(flow_export)(a__test_supply_elec__electricity__2005_01_01_01_00)
++0.1 variables(flow_out)(a__test_supply_elec__electricity__2005_01_01_01_00)
++0.1 variables(flow_out)(a__test_supply_gas__gas__2005_01_01_00_00)
++0.1 variables(flow_out)(a__test_supply_gas__gas__2005_01_01_01_00)
+
+s.t.
+
+c_e_ONE_VAR_CONSTANT:
++1 ONE_VAR_CONSTANT
+= 1
+
+bounds
+   1 <= ONE_VAR_CONSTANT <= 1
+   0 <= variables(flow_out)(a__test_conversion__heat__2005_01_01_00_00) <= +inf
+   0 <= variables(flow_out)(a__test_conversion__heat__2005_01_01_01_00) <= +inf
+   0 <= variables(flow_out)(a__test_conversion_plus__electricity__2005_01_01_00_00) <= +inf
+   0 <= variables(flow_out)(a__test_conversion_plus__heat__2005_01_01_00_00) <= +inf
+   0 <= variables(flow_export)(a__test_conversion_plus__heat__2005_01_01_00_00) <= +inf
+   0 <= variables(flow_in)(a__test_conversion_plus__gas__2005_01_01_00_00) <= +inf
+   0 <= variables(flow_out)(a__test_conversion_plus__electricity__2005_01_01_01_00) <= +inf
+   0 <= variables(flow_out)(a__test_conversion_plus__heat__2005_01_01_01_00) <= +inf
+   0 <= variables(flow_export)(a__test_conversion_plus__heat__2005_01_01_01_00) <= +inf
+   0 <= variables(flow_in)(a__test_conversion_plus__gas__2005_01_01_01_00) <= +inf
+   0 <= variables(flow_out)(a__test_supply_coal__coal__2005_01_01_00_00) <= +inf
+   0 <= variables(flow_out)(a__test_supply_coal__coal__2005_01_01_01_00) <= +inf
+   0 <= variables(flow_export)(a__test_supply_elec__electricity__2005_01_01_00_00) <= +inf
+   0 <= variables(flow_out)(a__test_supply_elec__electricity__2005_01_01_00_00) <= +inf
+   0 <= variables(flow_export)(a__test_supply_elec__electricity__2005_01_01_01_00) <= +inf
+   0 <= variables(flow_out)(a__test_supply_elec__electricity__2005_01_01_01_00) <= +inf
+   0 <= variables(flow_out)(a__test_supply_gas__gas__2005_01_01_00_00) <= +inf
+   0 <= variables(flow_out)(a__test_supply_gas__gas__2005_01_01_01_00) <= +inf
+end
+

--- a/tests/common/util.py
+++ b/tests/common/util.py
@@ -81,7 +81,7 @@ def build_lp(
     outfile: str | Path,
     math: dict[str, dict | list] | None = None,
     backend_name: Literal["pyomo"] = "pyomo",
-) -> None:
+) -> "backend.BackendModel":
     """
     Write a barebones LP file with which to compare in tests.
     All model parameters and variables will be loaded automatically, as well as a dummy objective if one isn't provided as part of `math`.
@@ -94,6 +94,7 @@ def build_lp(
         backend_name (Literal["pyomo"], optional): Backend to use to create the LP file. Defaults to "pyomo".
     """
     backend_instance = backend.get_model_backend(backend_name, model._model_data)
+
     for name, dict_ in model.math["variables"].items():
         backend_instance.add_variable(name, dict_)
     for name, dict_ in model.math["global_expressions"].items():

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -149,6 +149,62 @@ class TestBaseMath:
         }
         compare_lps(model, custom_math, "balance_storage")
 
+    @pytest.mark.parametrize("with_export", [True, False])
+    def test_cost_var_with_export(self, compare_lps, with_export):
+        """Test variable costs in the objective."""
+        self.TEST_REGISTER.add("global_expressions.cost_var")
+        override = {
+            "techs.test_conversion_plus.cost_flow_out": {
+                "data": [1, 2],
+                "index": [["electricity", "monetary"], ["heat", "monetary"]],
+                "dims": ["carriers", "costs"],
+            },
+            "techs.test_conversion_plus.cost_flow_in": {
+                "data": 4,
+                "index": "monetary",
+                "dims": "costs",
+            },
+        }
+        if with_export:
+            override.update(
+                {
+                    "techs.test_conversion_plus": {
+                        "carrier_export": "heat",
+                        "cost_export": {
+                            "data": 3,
+                            "index": [["heat", "monetary"]],
+                            "dims": ["carriers", "costs"],
+                        },
+                    },
+                    "techs.test_supply_elec": {
+                        "carrier_export": "electricity",
+                        "cost_export": {
+                            "data": 5,
+                            "index": "monetary",
+                            "dims": "costs",
+                        },
+                    },
+                }
+            )
+        model = build_test_model(
+            override, "conversion_and_conversion_plus,var_costs,two_hours"
+        )
+        custom_math = {
+            # need the expression defined in a constraint/objective for it to appear in the LP file bounds
+            "objectives": {
+                "foo": {
+                    "equations": [
+                        {
+                            "expression": "sum(cost_var, over=[nodes, techs, costs, timesteps])"
+                        }
+                    ],
+                    "sense": "minimise",
+                }
+            }
+        }
+        suffix = "_with_export" if with_export else ""
+        compare_lps(model, custom_math, f"cost_var{suffix}")
+
     @pytest.mark.xfail(reason="not all base math is in the test config dict yet")
     def test_all_math_registered(self, base_math):
         """After running all the previous tests in the class, the base_math dict should be empty, i.e. all math has been tested"""


### PR DESCRIPTION
Fixes #663 

## Summary of changes in this pull request

* Checking for definition of `carrier_export` across all carriers
* Added LP comparison for the cost_var global expression
* Minor fixes to dtypes of backend components when checking their string implementation

## Reviewer checklist

- [x] Test(s) added to cover contribution
- [ ] Documentation updated
- [x] Changelog updated
- [x] Coverage maintained or improved