### PR TITLE
PR improvements: math components in CalliopeMath, small fixes

### DIFF
--- a/src/calliope/backend/backend_model.py
+++ b/src/calliope/backend/backend_model.py
@@ -31,7 +31,7 @@ from calliope.attrdict import AttrDict
 from calliope.backend import helper_functions, parsing
 from calliope.exceptions import warn as model_warn
 from calliope.io import load_config
-from calliope.preprocess import CalliopeMath
+from calliope.preprocess.model_math import ORDERED_COMPONENTS_T, CalliopeMath
 from calliope.util.schema import (
     MODEL_SCHEMA,
     extract_from_schema,
@@ -44,13 +44,6 @@ if TYPE_CHECKING:
 from calliope.exceptions import BackendError
 
 T = TypeVar("T")
-ORDERED_COMPONENTS_T = Literal[
-    "variables",
-    "global_expressions",
-    "constraints",
-    "piecewise_constraints",
-    "objectives",
-]
 ALL_COMPONENTS_T = Literal["parameters", ORDERED_COMPONENTS_T]
 
 
@@ -539,7 +532,7 @@ class BackendModelGenerator(ABC):
 
         Args:
             key (str): Backend object name
-            obj_type (Literal["variables", "constraints", "objectives", "parameters", "expressions"]): Object type.
+            obj_type (ALL_COMPONENTS_T): Object type.
 
         Raises:
             BackendError: if `key` already exists in the backend model

--- a/src/calliope/backend/parsing.py
+++ b/src/calliope/backend/parsing.py
@@ -850,12 +850,13 @@ class ParsedBackendComponent(ParsedBackendEquation):
         return where
 
     def raise_caught_errors(self):
-        """If there are any parsing errors, pipe them to the ModelError bullet point list generator."""
+        """Pipe parsing errors to the ModelError bullet point list generator."""
         if not self._is_valid:
             exceptions.print_warnings_and_raise_errors(
                 errors={f"{self.name}": self._errors},
                 during=(
-                    "math string parsing (marker indicates where parsing stopped, but may not point to the root cause of the issue)"
+                    "math string parsing (marker indicates where parsing stopped, "
+                    "but may not point to the root cause of the issue)"
                 ),
                 bullet=self._ERR_BULLET,
             )

--- a/src/calliope/preprocess/model_math.py
+++ b/src/calliope/preprocess/model_math.py
@@ -2,6 +2,7 @@
 
 import importlib.resources
 import logging
+import typing
 from copy import deepcopy
 from pathlib import Path
 
@@ -11,6 +12,13 @@ from calliope.util.schema import MATH_SCHEMA, validate_dict
 from calliope.util.tools import relative_path
 
 LOGGER = logging.getLogger(__name__)
+ORDERED_COMPONENTS_T = typing.Literal[
+    "variables",
+    "global_expressions",
+    "constraints",
+    "piecewise_constraints",
+    "objectives",
+]
 
 
 class CalliopeMath:
@@ -33,13 +41,7 @@ class CalliopeMath:
         """
         self.history: list[str] = []
         self.data: AttrDict = AttrDict(
-            {
-                "variables": {},
-                "global_expressions": {},
-                "constraints": {},
-                "piecewise_constraints": {},
-                "objectives": {},
-            }
+            {name: {} for name in typing.get_args(ORDERED_COMPONENTS_T)}
         )
 
         for math in math_to_add:
@@ -61,12 +63,13 @@ class CalliopeMath:
 
     def __repr__(self) -> str:
         """Custom string representation of class."""
-        return f"""Calliope math definition dictionary with:
-    {len(self.data["variables"])} decision variable(s)
-    {len(self.data["global_expressions"])} global expression(s)
-    {len(self.data["constraints"])} constraint(s)
-    {len(self.data["piecewise_constraints"])} piecewise constraint(s)
-    {len(self.data["objectives"])} objective(s)
+        return f"""
+        Calliope math definition dictionary with:
+        {len(self.data["variables"])} decision variable(s)
+        {len(self.data["global_expressions"])} global expression(s)
+        {len(self.data["constraints"])} constraint(s)
+        {len(self.data["piecewise_constraints"])} piecewise constraint(s)
+        {len(self.data["objectives"])} objective(s)
         """
 
     def add(self, math: AttrDict):
@@ -127,7 +130,7 @@ class CalliopeMath:
             self._add_file(f / f"{filename}.yaml", filename)
 
     def _add_user_defined_file(
-        self, relative_filepath: str | Path, model_def_path: str | Path
+        self, relative_filepath: str | Path, model_def_path: str | Path | None
     ) -> None:
         """Add user-defined Calliope math, relative to the model definition path.
 

--- a/src/calliope/preprocess/model_math.py
+++ b/src/calliope/preprocess/model_math.py
@@ -63,13 +63,12 @@ class CalliopeMath:
 
     def __repr__(self) -> str:
         """Custom string representation of class."""
-        return f"""
-        Calliope math definition dictionary with:
-        {len(self.data["variables"])} decision variable(s)
-        {len(self.data["global_expressions"])} global expression(s)
-        {len(self.data["constraints"])} constraint(s)
-        {len(self.data["piecewise_constraints"])} piecewise constraint(s)
-        {len(self.data["objectives"])} objective(s)
+        return f"""Calliope math definition dictionary with:
+    {len(self.data["variables"])} decision variable(s)
+    {len(self.data["global_expressions"])} global expression(s)
+    {len(self.data["constraints"])} constraint(s)
+    {len(self.data["piecewise_constraints"])} piecewise constraint(s)
+    {len(self.data["objectives"])} objective(s)
         """
 
     def add(self, math: AttrDict):


### PR DESCRIPTION
## Summary of changes in this pull request

* Ordered math components (except for parameters) now live in `CalliopeMath`. Code now refers to them.
* Small comment fixes.

## Reviewer checklist

- [x] Test(s) added to cover contribution
- [ ] Documentation updated (not needed)
- [ ] Changelog updated (not needed)
- [ ] Coverage maintained or improved (same as target PR)