### PR TITLE
Pin micromamba version in CI

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     - uses: mamba-org/setup-micromamba@v1
       with:
-        micromamba-version: latest
+        micromamba-version: "1.5.10"
         environment-name: ${{ github.event.repository.name }}-ubuntu-latest-312-${{ hashFiles('requirements/dev.txt') }}
         environment-file: requirements/base.txt
         create-args: >-

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     - uses: mamba-org/setup-micromamba@v1
       with:
-        micromamba-version: "1.5.10"
+        micromamba-version: '1.5.10-0'
         environment-name: ${{ github.event.repository.name }}-ubuntu-latest-312-${{ hashFiles('requirements/dev.txt') }}
         environment-file: requirements/base.txt
         create-args: >-

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -45,7 +45,7 @@ jobs:
 
     - uses: mamba-org/setup-micromamba@v1
       with:
-        micromamba-version: latest
+        micromamba-version: "1.5.10"
         environment-name: ${{ github.event.repository.name }}-${{ matrix.os }}-3${{ matrix.py3version }}-${{ hashFiles('requirements/dev.txt') }}
         environment-file: requirements/base.txt
         create-args: >-
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mamba-org/setup-micromamba@v1
         with:
-          micromamba-version: latest
+          micromamba-version: "1.5.10"
           environment-file: .github/workflows/pr-ci-pipbuild-environment.yml
           post-cleanup: all
           cache-environment: true

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -45,7 +45,7 @@ jobs:
 
     - uses: mamba-org/setup-micromamba@v1
       with:
-        micromamba-version: "1.5.10"
+        micromamba-version: '1.5.10-0'
         environment-name: ${{ github.event.repository.name }}-${{ matrix.os }}-3${{ matrix.py3version }}-${{ hashFiles('requirements/dev.txt') }}
         environment-file: requirements/base.txt
         create-args: >-
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mamba-org/setup-micromamba@v1
         with:
-          micromamba-version: "1.5.10"
+          micromamba-version: '1.5.10-0'
           environment-file: .github/workflows/pr-ci-pipbuild-environment.yml
           post-cleanup: all
           cache-environment: true


### PR DESCRIPTION
Fixes failing tests seen in #690 

This is caused by latest micromamba updating to v2.0 and lots of issues arising. This one seems to have been flagged by someone else [here](https://github.com/mamba-org/micromamba-releases/issues/58)

## Summary of changes in this pull request

* Pin to most recent v1 micromamba

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved