### PR TITLE
Add `where` helper function to enable reproduction of fancier group constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### User-facing changes
 
+|new| `where(array, where_array)` math helper function to apply a where array _inside_ an expression, to enable extending component dimensions on-the-fly, and applying filtering to different components within the expression (#604, #679).
+
 |new| Math has been removed from `model.math`, and can now be accessed via `model.math.data` (#639).
 
 |new| (non-NaN) Default values and data types for parameters appear in math documentation (if they appear in the model definition schema) (#677).

--- a/docs/user_defined_math/syntax.md
+++ b/docs/user_defined_math/syntax.md
@@ -215,6 +215,21 @@ But if you're having trouble setting up your math, it is a useful function to ge
     Our internally defined parameters, listed in the `Parameters` section of our [pre-defined base math documentation][base-math] all have default values which propagate to the math.
     You only need to use `default_if_empty` for decision variables and global expressions, and for user-defined parameters.
 
+### where
+
+[Where strings](#where-strings) only allow you to apply conditions across the whole expression equations.
+Sometimes, it's necessary to apply specific conditions to different components _within_ the expression.
+Using `where(<math_component>, <boolean_array>)` helper function enables this,
+where `<math_component>` is a reference to a parameter, variable, or global expression and `<boolean_array>` is a reference to an array in your model inputs that contains only `True`/`1` and `False`/`0`/`NaN` values.
+`<boolean_array>` will then be applied to `<math_component>`, keeping only the values in `<math_component>` where `<boolean_array>` is `True`/`1`.
+
+This helper function can also be used to _extend_ the dimensions of a `<math_component>`.
+If the ``<boolean_array>`` has any dimensions not present in `<math_component>`, `<math_component>` will be [broadcast](https://tutorial.xarray.dev/fundamentals/02.3_aligning_data_objects.html#broadcasting-adjusting-arrays-to-the-same-shape) to include those dimensions.
+
+!!! note
+    `Where` gets referred to a lot in Calliope math.
+    It always means the same thing: applying [xarray.DataArray.where][].
+
 ## equations
 
 Equations are combinations of [expression strings](#expression-strings) and [where strings](#where-strings).

--- a/tests/test_backend_helper_functions.py
+++ b/tests/test_backend_helper_functions.py
@@ -63,6 +63,11 @@ def expression_default_if_empty(expression, parsing_kwargs):
     return expression["default_if_empty"](**parsing_kwargs)
 
 
+@pytest.fixture(scope="class")
+def expression_where(expression, parsing_kwargs):
+    return expression["where"](**parsing_kwargs)
+
+
 class TestAsArray:
     @pytest.fixture(scope="class")
     def parsing_kwargs(self, dummy_model_data):
@@ -322,6 +327,66 @@ class TestAsArray:
             result, [[1.0, 1, 1.0, 3], [np.inf, 2.0, True, 1]]
         )
 
+    def test_expression_where_techs_only(self, expression_where, dummy_model_data):
+        """Test that applying where array masks expected values without affecting the array dimensions."""
+        where_array = xr.DataArray(
+            [True, True, False, False], coords={"techs": dummy_model_data.techs}
+        )
+        result = expression_where(dummy_model_data.only_techs, where_array)
+        np.testing.assert_equal(result.values, [np.nan, 1, np.nan, np.nan])
+
+    def test_expression_where_techs_add_nodes(self, expression_where, dummy_model_data):
+        """Test that applying where array masks expected values _and_ adds to the new array dimensions with a known dim."""
+        where_array = xr.DataArray(
+            [[True, True, False, False], [False, False, True, True]],
+            coords={"nodes": dummy_model_data.nodes, "techs": dummy_model_data.techs},
+        )
+        result = expression_where(dummy_model_data.only_techs, where_array)
+        assert result.nodes.equals(dummy_model_data.nodes)
+
+        expected = xr.DataArray(
+            [[np.nan, 1, np.nan, np.nan], [np.nan, np.nan, 2, 3]],
+            coords={"nodes": dummy_model_data.nodes, "techs": dummy_model_data.techs},
+        )
+        assert result.equals(expected.transpose(*result.dims))
+
+    def test_expression_where_techs_add_new_dim(
+        self, expression_where, dummy_model_data
+    ):
+        """Test that applying where array masks expected values _and_ adds to the new array dimensions with a new dim."""
+        where_array = xr.DataArray(
+            [[True, True, False, False], [False, False, True, True]],
+            coords={"new_dim": ["a", "b"], "techs": dummy_model_data.techs},
+        )
+        result = expression_where(dummy_model_data.only_techs, where_array)
+        assert "new_dim" not in dummy_model_data.coords
+        expected = xr.DataArray(
+            [[np.nan, 1, np.nan, np.nan], [np.nan, np.nan, 2, 3]],
+            coords={"new_dim": ["a", "b"], "techs": dummy_model_data.techs},
+        )
+        assert result.equals(expected.transpose(*result.dims))
+
+    def test_expression_where_no_shared_dim(self, expression_where, dummy_model_data):
+        """Test that applying where array with no shared dims combines dims in new array."""
+        where_array = xr.DataArray([True, False], coords={"new_dim": ["a", "b"]})
+        result = expression_where(dummy_model_data.only_techs, where_array)
+
+        expected = xr.DataArray(
+            [[np.nan, 1, 2, 3], [np.nan, np.nan, np.nan, np.nan]],
+            coords={"new_dim": ["a", "b"], "techs": dummy_model_data.techs},
+        )
+        assert result.equals(expected.transpose(*result.dims))
+
+    def test_expression_where_no_initial_dim(self, expression_where, dummy_model_data):
+        """Test that applying where array adds a dim where there wasn't one before."""
+        where_array = xr.DataArray(
+            [True, False], coords={"nodes": dummy_model_data.nodes}
+        )
+        result = expression_where(dummy_model_data.no_dims, where_array)
+
+        expected = xr.DataArray([2, np.nan], coords={"nodes": dummy_model_data.nodes})
+        assert result.equals(expected.transpose(*result.dims))
+
 
 class TestAsMathString:
     @pytest.fixture(scope="class")
@@ -458,3 +523,16 @@ class TestAsMathString:
             r"\text{foo}", default=1.0
         )
         assert default_if_empty_string == r"(\text{foo}\vee{}1.0)"
+
+    def test_expression_where_no_dims(self, expression_where):
+        expression_where_string = expression_where(r"\text{foo}", r"\text{bar}")
+        assert expression_where_string == r"(\text{foo} \text{if } \text{bar} == True)"
+
+    def test_expression_where_with_dims(self, expression_where):
+        expression_where_string = expression_where(
+            r"\textbf{foo}_\text{techs}", r"\textit{bar}_\text{nodes}"
+        )
+        assert (
+            expression_where_string
+            == r"(\textbf{foo}_\text{techs} \text{if } \textit{bar}_\text{nodes} == True)"
+        )


### PR DESCRIPTION
Fixes #604 
Fixes #679

We use `where` a lot now. So, if there is another name we can give this helper function, I'm all ears!

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved