### PR TITLE
Add simplistic mypy configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,10 @@ count = ''
 quiet-level = 3
 ignore-words-list = "socio-economic"  # British english spelling that isn't covered by the inbuilt dictionary
 
+[tool.mypy]
+ignore_missing_imports = true
+files = "src/"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["calliope*"]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,6 +6,7 @@ mkdocs-jupyter >= 0.24, < 0.24.7
 mkdocs-macros-plugin >= 1.0, < 2
 mkdocs-material >= 9.5, < 10
 mkdocstrings-python >= 1.7, < 2
+mypy >= 1.13.0, < 2
 pandas-stubs
 plotly >= 5, < 6
 pre-commit < 4


### PR DESCRIPTION
This PR attempts to bring a bit more standardisation on the way we use mypy.

I've noticed that our current usage of the tool is varied, and may result in back and forth on some changes.
This attempts to reduce redundant changes by using a simplistic 'hands-off' mypy configuration.

Notably, I do not add any CI testing for it, as it would fail. Instead, this attempts to help us clean up the code over time.

## Summary of changes in this pull request

* Added mypy to the `dev.txt` dependencies, using the newest version available.
* Added minimalistic configuration for the tool in `pyproject.toml`.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved