### PR TITLE
Update micromamba back to the latest version

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     - uses: mamba-org/setup-micromamba@v1
       with:
-        micromamba-version: '1.5.10-0'
+        micromamba-version: latest
         environment-name: ${{ github.event.repository.name }}-ubuntu-latest-312-${{ hashFiles('requirements/dev.txt') }}
         environment-file: requirements/base.txt
         create-args: >-

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -45,7 +45,7 @@ jobs:
 
     - uses: mamba-org/setup-micromamba@v1
       with:
-        micromamba-version: '1.5.10-0'
+        micromamba-version: latest
         environment-name: ${{ github.event.repository.name }}-${{ matrix.os }}-3${{ matrix.py3version }}-${{ hashFiles('requirements/dev.txt') }}
         environment-file: requirements/base.txt
         create-args: >-
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mamba-org/setup-micromamba@v1
         with:
-          micromamba-version: '1.5.10-0'
+          micromamba-version: latest
           environment-name: pipbuild
           create-args: >-
             python=3.11


### PR DESCRIPTION
Fixes #692 (hopefully). For the moment a draft, as the breakage issues have not been fixed.
https://github.com/mamba-org/mamba/issues/3503

## Summary of changes in this pull request

* Brings back micromamba to the latest version by default.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved