### PR TITLE
Introduce SPORES in v0.7.0 as a generalisable mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### User-facing changes
 
+|changed| Single data entries defined in YAML indexed parameters will not be automatically broadcast along indexed dimensions.
+To achieve the same functionality as in `<v0.7.dev4`, the user must set the new `init` configuration option `broadcast_param_data` to True (#615).
+
 |changed| Helper functions are now documented on their own page within the "Defining your own math" section of the documentation (#698).
 
 |new| `where(array, condition)` math helper function to apply a where array _inside_ an expression, to enable extending component dimensions on-the-fly, and applying filtering to different components within the expression (#604, #679).

--- a/docs/creating/config.md
+++ b/docs/creating/config.md
@@ -41,6 +41,10 @@ To test your model pipeline, `config.init.time_subset` is a good way to limit yo
     Various capabilities are available to adjust the temporal resolution of a model on-the-fly, both by resampling or using externally-provided clustering.
     See our [time adjustment page](../advanced/time.md) for more details.
 
+!!! info "See also"
+    The full set of available configuration options is documented in the [configuration schema][model-configuration-schema].
+    This provides you with a description of each configuration option and the default which will be used if you do not provide a value.
+
 ## Deep-dive into some key configuration options
 
 ### `config.build.backend`

--- a/docs/creating/parameters.md
+++ b/docs/creating/parameters.md
@@ -53,3 +53,29 @@ Which will add the new dimension `my_new_dim` to your model: `model.inputs.my_ne
 
 !!! warning
     The `parameter` section should not be used for large datasets (e.g., indexing over the time dimension) as it will have a high memory overhead on loading the data.
+
+## Broadcasting data along indexed dimensions
+
+If you want to set the same data for all index items, you can set the `init` [configuration option](config.md) `broadcast_param_data` to True and then use a single value in `data`:
+
+=== "Without broadcasting"
+
+    ```yaml
+    my_indexed_param:
+      data: [1, 1, 1, 1]
+      index: [my_index_val1, my_index_val2, my_index_val3, my_index_val4]
+      dims: my_new_dim
+    ```
+
+=== "With broadcasting"
+
+    ```yaml
+    my_indexed_param:
+      data: 1  # All index items will take on this value
+      index: [my_index_val1, my_index_val2, my_index_val3, my_index_val4]
+      dims: my_new_dim
+    ```
+
+!!! warning
+    The danger of broadcasting is that you maybe update `index` as a scenario override without realising that the data will be broadcast over this new index.
+    E.g., if you start with `!#yaml {data: 1, index: monetary, dims: costs}` and update it with `!#yaml {index: [monetary, emissions]}` then the `data` value of `1` will be set for both `monetary` and `emissions` index values.

--- a/docs/examples/national_scale/index.md
+++ b/docs/examples/national_scale/index.md
@@ -1,3 +1,10 @@
+---
+costs:
+    file: "src/calliope/example_models/national_scale/data_tables/costs.csv"
+    header: [0, 1]
+    index_col: 0
+---
+
 # National Scale Example Model
 
 This example consists of two possible power supply technologies,
@@ -24,6 +31,29 @@ It does not contain much data, but the scaffolding with which to construct and r
 ```
 
 ## Model definition
+
+### Referencing tabular data
+
+As of Calliope v0.7.0 it is possible to load tabular data completely separately from the YAML model definition.
+To do this we reference data tables under the `data_tables` key:
+
+```yaml
+--8<-- "src/calliope/example_models/national_scale/model.yaml:data-tables"
+```
+
+In the Calliope national scale example model, we load both timeseries and cost data from file.
+As an example, the data in the cost CSV file looks like this:
+
+{{ read_csv(page.meta.costs.file, header=page.meta.costs.header, index_col=page.meta.costs.index_col) }}
+
+You'll notice that in each row there is reference to a technology, and in each column to a cost parameter and a comment on the units being used.
+Therefore, we reference `techs` in our data table _rows_, and `parameters` and `comment` in our data table _columns_.
+The `comment` information is metadata that we don't need in our Calliope model object, so we _drop_ it on loading the table.
+Since all the data refers to the one cost class `monetary`, we don't add that information in the CSV file, but instead add it on as a dimension when loading the file.
+Where there is no data for that combination of technology and cost parameter, the value is Not-a-Number (NaN) and this combination will be ignored on loading the table.
+
+!!! info
+    You can read more about loading data from file in [our dedicated tutorial][loading-tabular-data].
 
 ### Indexed parameters
 
@@ -110,23 +140,6 @@ The costs are more numerous as well, and include monetary costs for all relevant
 * carrier conversion capacity
 * variable operational and maintenance costs
 
-### Interlude: inheriting from templates
-
-You will notice that the above technologies _inherit_ `cost_dim_setter`.
-Templates allow us to avoid excessive repetition in our model definition.
-In this case, `cost_dim_setter` defines the dimension and index of costs, allowing us to keep our definition of technology costs to only defining `data`.
-By defining `data`, the technologies override the `null` setting applied by `cost_dim_setter`.
-We also use it to set the `interest_rate` for all technologies, which will be used to annualise any investment costs each technology defines.
-
-Technologies and nodes can inherit from anything defined in `templates`.
-items in `templates` can also inherit from each other, so you can create inheritance chains.
-
-`cost_dim_setter` looks like this:
-
-```yaml
---8<-- "src/calliope/example_models/national_scale/model_config/techs.yaml:cost-dim-setter"
-```
-
 ### Storage technologies
 
 The second location allows a limited amount of battery storage to be deployed to better balance the system.
@@ -184,8 +197,16 @@ Transmission technologies look different to other technologies, as they link the
 `free_transmission` allows local power transmission from any of the csp facilities to the nearest location.
 As the name suggests, it applies no cost or efficiency losses to this transmission.
 
+### Interlude: inheriting from templates
+
 We can see that those technologies which rely on `free_transmission` inherit a lot of this information from elsewhere in the model definition.
 `free_transmission` is defined in `templates`, which makes it inheritable.
+[Templates](../../creating/templates.md) allow us to avoid excessive repetition in our model definition.
+
+Technologies and nodes can inherit from anything defined in `templates`.
+items in `templates` can also inherit from each other, so you can create inheritance chains.
+
+The `free_transmission` template looks like this:
 
 ```yaml
 --8<-- "src/calliope/example_models/national_scale/model_config/techs.yaml:free-transmission"

--- a/docs/examples/national_scale/spores_run.py
+++ b/docs/examples/national_scale/spores_run.py
@@ -1,0 +1,154 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.16.4
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Generating SPORES
+# An interactive example of how to generate near-optimal system designs (or SPORES) out of a Calliope v0.7.0 model. This example relies solely on default software functionality and a custom Python function to determine how to assign penalties (scores) to previously explored system design options.
+
+# %%
+# Importing the required packages
+import calliope
+import xarray as xr
+
+# %% [markdown]
+# ## Cost-optimal model run and extraction of SPORES-relevant outputs
+
+# %%
+# Loading model files and building the model
+model = calliope.Model(
+    "example_models/latest_national_scale/model.yaml", scenario="simplified_spores"
+)
+model.build()
+
+# Solving
+model.solve()
+
+# Extracting SPORES-relevant data
+least_feasible_cost = model.results.cost.loc[{"costs": "monetary"}].sum().sum()
+print("The minimum cost for a feasible system design is {}".format(least_feasible_cost.values))
+
+
+# %% [markdown]
+# ## SPORES model run
+# ### Definition of the penalty-assignment methods
+
+# %%
+def scoring_integer(results, backend):
+    # Filter for technologies of interest
+    spores_techs = backend.inputs["spores_tracker"].notnull()
+    # Look at capacity deployment in the previous iteration
+    previous_cap = results.flow_cap 
+    # Make sure that penalties are applied only to non-negligible deployments of capacity
+    min_relevant_size = 0.1 * previous_cap.where(spores_techs).max(
+        ["nodes", "carriers", "techs"]
+    )
+    # Where capacity was deployed more than the minimal relevant size, assign an integer penalty (score)
+    new_score = previous_cap.copy()
+    new_score = new_score.where(spores_techs, other=0)
+    new_score = new_score.where(new_score > min_relevant_size, other=0)
+    new_score = new_score.where(new_score == 0, other=1000)
+    # Transform the score into a "cost" parameter
+    new_score.rename("cost_flow_cap")
+    new_score = new_score.expand_dims(costs=["spores_score"]).copy()
+    new_score = new_score.sum("carriers")
+    # Extract the existing cost parameters from the backend
+    all_costs = backend.get_parameter("cost_flow_cap", as_backend_objs=False)
+    try:
+        all_costs = all_costs.expand_dims(nodes=results.nodes).copy()
+    except:
+        pass
+    # Create a new version of the cost parameters by adding up the calculated scores
+    new_all_costs = all_costs
+    new_all_costs.loc[{"costs":"spores_score"}] += new_score.loc[{"costs":"spores_score"}]
+
+    return new_all_costs
+
+
+# %% [markdown]
+# ### Iterating over the desired number of alternatives
+
+# %%
+# Create some lists to store results as they get generated
+spores = [] # full results
+scores = [] # scores only
+spores_counter = 1
+number_of_spores = 5
+
+# %%
+for i in range(spores_counter, spores_counter + number_of_spores):
+
+    if spores_counter == 1:
+        # Store the cost-optimal results
+        spores.append(model.results.expand_dims(spores=[0]))
+        scores.append(
+            model.backend.get_parameter("cost_flow_cap", as_backend_objs=False)
+            .sel(costs="spores_score")
+            .expand_dims(spores=[0])
+        )
+        # Update the slack-cost backend parameter based on the calculated minimum feasible system design cost
+        model.backend.update_parameter("spores_cost_max", least_feasible_cost)
+        # Update the objective_cost_weights to reflect the ones defined for the SPORES mode
+        model.backend.update_parameter(
+            "objective_cost_weights", model.inputs.spores_objective_cost_weights
+        )
+    else:
+        pass
+
+    # Calculate weights based on a scoring method
+    spores_score = scoring_integer(model.results, model.backend)
+    # Assign a new score based on the calculated penalties
+    model.backend.update_parameter(
+        "cost_flow_cap", spores_score.reindex_like(model.inputs.cost_flow_cap)
+    )
+    # Run the model again to get a solution that reflects the new penalties
+    model.solve(force=True)
+    # Store the results
+    spores.append(model.results.expand_dims(spores=[i]))
+    scores.append(
+        model.backend.get_parameter("cost_flow_cap", as_backend_objs=False)
+        .sel(costs="spores_score")
+        .expand_dims(spores=[i])
+    )
+
+    spores_counter += 1
+        
+# Concatenate the results in the storage lists into xarray objects 
+spore_ds = xr.concat(spores, dim="spores")
+score_da = xr.concat(scores, dim="spores")
+
+# %% [markdown]
+# ## Plotting and sense-check
+
+# %%
+# Import plotting libraries
+import matplotlib.pyplot as plt
+import matplotlib as mpl
+
+# %%
+# Extract the deployed capacities across SPORES, which we want to visualise
+flow_caps = spore_ds.flow_cap.where(
+    model.backend.inputs["spores_tracker"].notnull()).sel(
+        carriers='power').to_series().dropna().unstack("spores")
+flow_caps
+
+# %%
+# Plot the capacities per location across the generated SPORES
+ax = plt.subplot(111)
+colors = mpl.colormaps['Pastel1'].colors
+flow_caps.plot.bar(
+    ax=ax, ylabel="Capacity (kW)", ylim=[0, 40000],
+    color=colors[0:len(flow_caps.columns)]
+)
+
+# %%

--- a/docs/examples/urban_scale/index.md
+++ b/docs/examples/urban_scale/index.md
@@ -47,6 +47,8 @@ The import section in our file looks like this:
 --8<-- "src/calliope/example_models/urban_scale/model.yaml:import"
 ```
 
+## Model definition
+
 ### Referencing tabular data
 
 As of Calliope v0.7.0 it is possible to load tabular data completely separately from the YAML model definition.
@@ -56,7 +58,7 @@ To do this we reference data tables under the `data_tables` key:
 --8<-- "src/calliope/example_models/urban_scale/model.yaml:data-tables"
 ```
 
-In the Calliope example models, we only load timeseries data from file, including for [energy demand](#demand-technologies), [electricity export price](#revenue-by-export) and [solar PV resource availability](#supply-technologies).
+In the Calliope urban scale example model, we only load timeseries data from file, including for [energy demand](#demand-technologies), [electricity export price](#revenue-by-export) and [solar PV resource availability](#supply-technologies).
 These are large tables of data that do not work well in YAML files!
 As an example, the data in the energy demand CSV file looks like this:
 
@@ -68,8 +70,6 @@ Since all the data refers to the one parameter `sink_use_equals`, we don't add t
 
 !!! info
     You can read more about loading data from file in [our dedicated tutorial][loading-tabular-data].
-
-## Model definition
 
 ### Indexed parameters
 
@@ -125,21 +125,6 @@ The definition of this technology in the example model's configuration looks as 
 
 ```yaml
 --8<-- "src/calliope/example_models/urban_scale/model_config/techs.yaml:pv"
-```
-
-### Interlude: inheriting from templates
-
-You will notice that the above technologies _inherit_ `interest_rate_setter`.
-Templates allow us to avoid excessive repetition in our model definition.
-In this case, `interest_rate_setter` defines an interest rate that will be used to annualise any investment costs the technology defines.
-
-Technologies / nodes can inherit from anything defined in `templates`.
-items in `templates` can also inherit from each other, so you can create inheritance chains.
-
-`interest_rate_setter` looks like this:
-
-```yaml
---8<-- "src/calliope/example_models/urban_scale/model_config/techs.yaml:interest-rate-setter"
 ```
 
 ### Conversion technologies
@@ -241,7 +226,7 @@ Gas is made available in each node without consideration of transmission.
 --8<-- "src/calliope/example_models/urban_scale/model_config/techs.yaml:transmission"
 ```
 
-To avoid excessive duplication in model definition, our transmission technologies inherit most of the their parameters from _templates_:
+To avoid excessive duplication in model definition, our transmission technologies inherit most of the their parameters from [templates](../../creating/templates.md):
 
 ```yaml
 --8<-- "src/calliope/example_models/urban_scale/model_config/techs.yaml:transmission-templates"

--- a/docs/user_defined_math/syntax.md
+++ b/docs/user_defined_math/syntax.md
@@ -210,7 +210,7 @@ If you define a lookup parameter "lookup_techs" as:
 ```yaml
 parameters:
   lookup_techs:
-    data: True
+    data: [True, True]
     index: [tech_1, tech_2]
     dims: [techs]
 ```

--- a/src/calliope/config/config_schema.yaml
+++ b/src/calliope/config/config_schema.yaml
@@ -58,6 +58,13 @@ properties:
               Unit of transmission link `distance` (m - metres, km - kilometres).
               Automatically derived distances from lat/lon coordinates will be given in this unit.
             enum: [m, km]
+          broadcast_param_data:
+            type: boolean
+            default: false
+            description:
+              If True, single data entries in YAML indexed parameters will be broadcast across all index items.
+              If False, the number of data entries in an indexed parameter needs to match the number of index items.
+              Defaults to False to mitigate unexpected broadcasting when applying overrides.
 
       build:
         type: object

--- a/src/calliope/example_models/national_scale/additional_math.yaml
+++ b/src/calliope/example_models/national_scale/additional_math.yaml
@@ -1,0 +1,7 @@
+constraints:
+  total_system_cost_max:
+    description: >
+      Limit total system cost. Conceived for use in SPORES mode to apply a maximum
+      relaxation to the system cost compared to the least-cost feasible option.
+    equations:
+      - expression: sum(cost[costs=monetary], over=[nodes, techs]) <= spores_cost_max * (1 + spores_slack)

--- a/src/calliope/example_models/national_scale/data_tables/costs.csv
+++ b/src/calliope/example_models/national_scale/data_tables/costs.csv
@@ -1,0 +1,6 @@
+parameters,cost_flow_cap,cost_storage_cap,cost_area_use,cost_source_cap,cost_flow_in,cost_flow_out
+comment,USD per kW,USD per kWh storage capacity,USD per m2,USD per kW,USD per kWh,USD per kWh
+ccgt,750,,,,0.02,
+csp,1000,50,200,200,,0.002
+battery,,200,,,,
+region1_to_region2,200,,,,,0.002

--- a/src/calliope/example_models/national_scale/model.yaml
+++ b/src/calliope/example_models/national_scale/model.yaml
@@ -20,7 +20,7 @@ config:
     mode: plan # Choices: plan, operate
 
   solve:
-    solver: cbc
+    solver: gurobi
     zero_threshold: 1e-10 # Any value coming out of the backend that is smaller than this (due to floating point errors, probably) will be set to zero
 # --8<-- [end:config]
 

--- a/src/calliope/example_models/national_scale/model.yaml
+++ b/src/calliope/example_models/national_scale/model.yaml
@@ -13,6 +13,7 @@ config:
     # What version of Calliope this model is intended for
     calliope_version: 0.7.0
     time_subset: ["2005-01-01", "2005-01-05"] # Subset of timesteps
+    broadcast_param_data: true  # allow single indexed parameter data entries to be broadcast across all index items, if there are multiple entries.
 
   build:
     ensure_feasibility: true # Switches on the "unmet demand" constraint
@@ -27,15 +28,28 @@ config:
 parameters:
   objective_cost_weights:
     data: 1
-    index: [monetary]
+    index: monetary
     dims: costs
   # `bigM` sets the scale of unmet demand, which cannot be too high, otherwise the optimisation will not converge
   bigM: 1e6
+  cost_interest_rate:
+    data: 0.10
+    index: monetary
+    dims: costs
 # --8<-- [end:parameters]
 
+# --8<-- [start:data-tables]
 data_tables:
   time_varying_parameters:
     data: data_tables/time_varying_params.csv
     rows: timesteps
     columns: [comment, nodes, techs, parameters]
     drop: comment
+  cost_parameters:
+    data: data_tables/costs.csv
+    rows: techs
+    columns: [parameters, comment]
+    drop: comment
+    add_dims:
+      costs: monetary
+# --8<-- [end:data-tables]

--- a/src/calliope/example_models/national_scale/model_config/techs.yaml
+++ b/src/calliope/example_models/national_scale/model_config/techs.yaml
@@ -4,40 +4,8 @@
 
 # Note: --8<--start:'' and --8<--end:'' is used in tutorial documentation only
 
-# --8<-- [start:cost-dim-setter]
-templates:
-  cost_dim_setter:
-    cost_flow_cap:
-      data: null
-      index: monetary
-      dims: costs
-    cost_flow_in:
-      data: null
-      index: monetary
-      dims: costs
-    cost_flow_out:
-      data: null
-      index: monetary
-      dims: costs
-    cost_storage_cap:
-      data: null
-      index: monetary
-      dims: costs
-    cost_area_use:
-      data: null
-      index: monetary
-      dims: costs
-    cost_source_cap:
-      data: null
-      index: monetary
-      dims: costs
-    cost_interest_rate:
-      data: 0.10
-      index: monetary
-      dims: costs
-# --8<-- [end:cost-dim-setter]
-
 # --8<-- [start:free-transmission]
+templates:
   free_transmission:
     name: "Local power transmission"
     color: "#6783E3"
@@ -56,16 +24,12 @@ techs:
     name: "Combined cycle gas turbine"
     color: "#E37A72"
     base_tech: supply
-    template: cost_dim_setter
     carrier_out: power
     flow_out_eff: 0.5
     flow_cap_max: 40000 # kW
     flow_cap_max_systemwide: 100000 # kW
     flow_ramping: 0.8
     lifetime: 25
-
-    cost_flow_cap.data: 750 # USD per kW
-    cost_flow_in.data: 0.02 # USD per kWh
   # --8<-- [end:ccgt]
 
   # --8<-- [start:csp]
@@ -73,7 +37,6 @@ techs:
     name: "Concentrating solar power"
     color: "#F9CF22"
     base_tech: supply
-    template: cost_dim_setter
     carrier_out: power
     source_unit: per_area
     include_storage: True
@@ -85,12 +48,6 @@ techs:
     area_use_max: .inf
     flow_cap_max: 10000
     lifetime: 25
-
-    cost_storage_cap.data: 50
-    cost_area_use.data: 200
-    cost_source_cap.data: 200
-    cost_flow_cap.data: 1000
-    cost_flow_out.data: 0.002
   # --8<-- [end:csp]
 
   ##
@@ -101,7 +58,6 @@ techs:
     name: "Battery storage"
     color: "#3B61E3"
     base_tech: storage
-    template: cost_dim_setter
     carrier_in: power
     carrier_out: power
     flow_cap_max: 1000 # kW
@@ -112,8 +68,6 @@ techs:
     flow_in_eff: 0.95
     storage_loss: 0 # No loss over time assumed
     lifetime: 25
-
-    cost_storage_cap.data: 200 # USD per kWh storage capacity
   # --8<-- [end:battery]
 
   ##
@@ -139,13 +93,10 @@ techs:
     name: "AC power transmission"
     color: "#8465A9"
     base_tech: transmission
-    template: cost_dim_setter
     carrier_in: power
     carrier_out: power
     flow_out_eff: 0.85
     lifetime: 25
-    cost_flow_cap.data: 200
-    cost_flow_out.data: 0.002
     flow_cap_max: 10000
 
   region1_to_region1_1:

--- a/src/calliope/example_models/national_scale/scenarios.yaml
+++ b/src/calliope/example_models/national_scale/scenarios.yaml
@@ -30,41 +30,45 @@ overrides:
         time_cluster: data_tables/cluster_days.csv
 
   spores:
-    config:
-      build.mode: spores
-      solve:
-        spores_score_cost_class: "spores_score"
-        spores_number: 3
+    config.build.add_math: ["additional_math.yaml"] # to create a slack-cost constraint
+    config.init.broadcast_param_data: false    
     parameters:
-      # In SPORES mode, slack to apply when setting the upper limit on system `spores_slack_cost_group` costs.
-      # The constraint will limit the costs to `(spores_slack + 1) * sum(costs[cost=spores_slack_cost_group])`.
-      spores_slack: 0.1
-      objective_cost_weights:
+      objective_cost_weights: # makes sure that a 'spores_score' class exists in the model and in the objective
         data: [1, 0]
         index: ["monetary", "spores_score"]
-      # In SPORES mode, the new objective function cost class weightings to apply after the initial base run.
       spores_objective_cost_weights:
-        data: [1, 0]
-        index: [spores_score, monetary]
+        data: [0, 1]
+        index: ["monetary", "spores_score"]
         dims: costs
-
-    # FIXME: replace group constraint in SPORES mode
-    # group_constraints:
-    #    systemwide_cost_max.cost_max.monetary: 1e10  # very large, non-infinite value
-    templates:
-      cost_dim_setter:
-        cost_flow_cap:
-          index: [monetary, spores_score]
-          dims: costs
-        cost_interest_rate:
-          data: [0.10, 1]
-          index: [monetary, spores_score]
-          dims: costs
+      spores_slack: 0.5
+      spores_tracker: # defines which techs are going to be subject to the SPORES weighting process
+        data: [true,true,true]
+        index: [ccgt,csp,battery]
+        dims: techs
+      spores_cost_max: 1e6 # parameter used in the custom-math slack cost constraint. Initially very high (infinite)
+    templates:    
+          cost_dim_setter:
+            cost_interest_rate:
+              data: 1
+              index: "spores_score"
+              dims: costs
     techs:
-      ccgt.cost_flow_cap.data: [750, 0]
-      csp.cost_flow_cap.data: [1000, 0]
-      battery.cost_flow_cap.data: [null, 0]
-      region1_to_region2.cost_flow_cap.data: [200, 0]
+        ccgt:
+            cost_flow_cap: {'data': [0], 'index': ['spores_score'], 'dims': 'costs'}
+            cost_flow_in: {'data': [0], 'index': ['spores_score'], 'dims': 'costs'}
+        csp:
+            cost_storage_cap: {'data': [0], 'index': ['spores_score'], 'dims': 'costs'}
+            cost_area_use: {'data': [0], 'index': ['spores_score'], 'dims': 'costs'}
+            cost_source_cap: {'data': [0], 'index': ['spores_score'], 'dims': 'costs'}
+            cost_flow_cap: {'data': [0], 'index': ['spores_score'], 'dims': 'costs'}
+            cost_flow_out: {'data': [0], 'index': ['spores_score'], 'dims': 'costs'}
+        battery:
+            cost_storage_cap: {'data': [0], 'index': ['spores_score'], 'dims': 'costs'}
+        region1_to_region2:
+            cost_flow_cap: {'data': [0], 'index': ['spores_score'], 'dims': 'costs'}
+            cost_flow_out: {'data': [0], 'index': ['spores_score'], 'dims': 'costs'}
+
+
   operate:
     config:
       init.time_subset: ["2005-01-01", "2005-01-10"]

--- a/src/calliope/example_models/urban_scale/model.yaml
+++ b/src/calliope/example_models/urban_scale/model.yaml
@@ -13,6 +13,7 @@ config:
     calliope_version: 0.7.0
     # Time series data path - can either be a path relative to this file, or an absolute path
     time_subset: ["2005-07-01", "2005-07-02"] # Subset of timesteps
+    broadcast_param_data: true  # allow single indexed parameter data entries to be broadcast across all index items, if there are multiple entries.
 
   build:
     mode: plan # Choices: plan, operate
@@ -31,6 +32,10 @@ parameters:
     dims: costs
   # `bigM` sets the scale of unmet demand, which cannot be too high, otherwise the optimisation will not converge
   bigM: 1e6
+  cost_interest_rate:
+    data: 0.10
+    index: monetary
+    dims: costs
 # --8<-- [end:parameters]
 
 # --8<-- [start:data-tables]

--- a/src/calliope/example_models/urban_scale/model_config/techs.yaml
+++ b/src/calliope/example_models/urban_scale/model_config/techs.yaml
@@ -4,20 +4,12 @@
 
 # --8<-- [start:--8<-- [end:Note: ']' and ']' is used in tutorial documentation only
 
-# --8<-- [start:interest-rate-setter]
 templates:
-  interest_rate_setter:
-    cost_interest_rate:
-      data: 0.10
-      index: monetary
-      dims: costs
-# --8<-- [end:interest-rate-setter]
 # --8<-- [start:transmission-templates]
   power_lines:
     name: "Electrical power distribution"
     color: "#6783E3"
     base_tech: transmission
-    template: interest_rate_setter
     carrier_in: electricity
     carrier_out: electricity
     flow_cap_max: 2000
@@ -32,7 +24,6 @@ templates:
     name: "District heat distribution"
     color: "#823739"
     base_tech: transmission
-    template: interest_rate_setter
     carrier_in: heat
     carrier_out: heat
     flow_cap_max: 2000
@@ -50,7 +41,6 @@ techs:
     name: "National grid import"
     color: "#C5ABE3"
     base_tech: supply
-    template: interest_rate_setter
     carrier_out: electricity
     source_use_max: .inf
     flow_cap_max: 2000
@@ -68,7 +58,6 @@ techs:
     name: "Natural gas import"
     color: "#C98AAD"
     base_tech: supply
-    template: interest_rate_setter
     carrier_out: gas
     source_use_max: .inf
     flow_cap_max: 2000
@@ -90,7 +79,6 @@ techs:
     color: "#F9D956"
     base_tech: supply
     carrier_out: electricity
-    template: interest_rate_setter
     carrier_export: electricity
     source_unit: per_area
     area_use_per_flow_cap: 7 # 7m2 of panels needed to fit 1kWp of panels
@@ -111,7 +99,6 @@ techs:
     name: "Natural gas boiler"
     color: "#8E2999"
     base_tech: conversion
-    template: interest_rate_setter
     carrier_in: gas
     carrier_out: heat
     flow_cap_max:
@@ -132,7 +119,6 @@ techs:
     name: "Combined heat and power"
     color: "#E4AB97"
     base_tech: conversion
-    template: interest_rate_setter
     carrier_in: gas
     carrier_out: [electricity, heat]
     carrier_export: electricity

--- a/src/calliope/preprocess/model_data.py
+++ b/src/calliope/preprocess/model_data.py
@@ -486,6 +486,13 @@ class ModelDataFactory:
             data = param_data["data"]
             index_items = [listify(idx) for idx in listify(param_data["index"])]
             dims = listify(param_data["dims"])
+            broadcast_param_data = self.config.broadcast_param_data
+            if not broadcast_param_data and len(listify(data)) != len(index_items):
+                raise exceptions.ModelError(
+                    f"{param_name} | Length mismatch between data ({data}) and index ({index_items}) for parameter definition. "
+                    "Check lengths of arrays or set `config.init.broadcast_param_data` to True "
+                    "to allow single data entries to be broadcast across all parameter index items."
+                )
         elif param_name in self.LOOKUP_PARAMS.keys():
             data = True
             index_items = [[i] for i in listify(param_data)]

--- a/tests/common/test_model/model.yaml
+++ b/tests/common/test_model/model.yaml
@@ -15,6 +15,8 @@ config:
   init:
     name: Test model
     time_subset: ["2005-01-01", "2005-01-02"]
+    broadcast_param_data: true
+
   build:
     mode: plan
   solve:

--- a/tests/test_preprocess_model_data.py
+++ b/tests/test_preprocess_model_data.py
@@ -431,6 +431,19 @@ class TestModelData:
             "foo | Cannot pass parameter data as a list unless the parameter is one of the pre-defined lookup arrays",
         )
 
+    @pytest.mark.parametrize("param_data", [1, [1], [1, 2, 3]])
+    def test_prepare_param_dict_no_broadcast_allowed(
+        self, model_data_factory, param_data
+    ):
+        model_data_factory.config.broadcast_param_data = False
+        param_dict = {"data": param_data, "index": [["foo"], ["bar"]], "dims": "foobar"}
+        with pytest.raises(exceptions.ModelError) as excinfo:  # noqa: PT011, false positive
+            model_data_factory._prepare_param_dict("foo", param_dict)
+        assert check_error_or_warning(
+            excinfo,
+            f"foo | Length mismatch between data ({param_data}) and index ([['foo'], ['bar']]) for parameter definition",
+        )
+
     def test_template_defs_inactive(
         self, my_caplog, model_data_factory: ModelDataFactory
     ):


### PR DESCRIPTION
## Summary of changes in this pull request

* Introduces a `spores` scenario as part of the national-scale example model
* Introduces a custom math file in the national-scale example model, which is activated in the `spores` scenario to create a slack cost constraint
* It provides a dedicated notebook to generate SPORES iteratively based on the `spores` scenario overrides and a custom Python function for assigning penalties at each iteration.

Based on internal discussions, we have come to realise that there are many ongoing SPORES developments that may be hard to always reconduct to a monolithic run mode in the core code. Instead, it may be best to implement SPORES as a method that simply allows you to run a model in `plan` mode once, and then N number more times with some external function being applied between each run, with the user providing that function. This way, this mode could be used not only for SPORES but also for robustness analysis and other things. 

This PR aims to show how SPORES can be indeed already used in v0.7.0 based on default software functionality plus a simple for-loop and a custom Python function to assign penalties for decision variables at each iteration of the loop. To move from this to the generalised mode described above, we would only need to decide how to make some bits of this code (such as the number of iterations, and the custom Python function) a default request for inputs to the user.

The new `run-iteratively-with-a-function` mode (a better name must be found, could also be `spores-and-more` if the main application remains SPORES), would essentially require the following three key inputs: 1) how many iterations to run; 2) what function to apply at each iteration; and 3) what backend parameter to updated based on the function.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved