### PR TITLE
Allow node params on links

### DIFF
--- a/src/calliope/preprocess/data_sources.py
+++ b/src/calliope/preprocess/data_sources.py
@@ -154,7 +154,7 @@ class DataSource:
                     techs_incl_inheritance[tech].get("base_tech", None)
                     == "transmission"
                 ):
-                    self._raise_error(
+                    self._raise_warning(
                         "Cannot define transmission technology data over the `nodes` dimension"
                     )
                 else:
@@ -360,6 +360,12 @@ class DataSource:
         unique_index_names = set(tdf.index.names)
         if len(unique_index_names) != len(tdf.index.names):
             self._raise_error(f"Duplicate dimension names found: {tdf.index.names}")
+
+    def _raise_warning(self, message):
+        """Format warning message and then raise Calliope ModelWarning."""
+        raise exceptions.ModelWarning(
+            self.MESSAGE_TEMPLATE.format(name=self.name, message=message)
+        )
 
     def _raise_error(self, message):
         """Format error message and then raise Calliope ModelError."""

--- a/src/calliope/preprocess/data_sources.py
+++ b/src/calliope/preprocess/data_sources.py
@@ -5,6 +5,7 @@
 import logging
 from collections.abc import Hashable
 from pathlib import Path
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -363,9 +364,7 @@ class DataSource:
 
     def _raise_warning(self, message):
         """Format warning message and then raise Calliope ModelWarning."""
-        raise exceptions.ModelWarning(
-            self.MESSAGE_TEMPLATE.format(name=self.name, message=message)
-        )
+        warnings.warn(self.MESSAGE_TEMPLATE.format(name=self.name, message=message), exceptions.ModelWarning)
 
     def _raise_error(self, message):
         """Format error message and then raise Calliope ModelError."""


### PR DESCRIPTION
Fixes the following issue:

I am not allowed to set a constraint on `flow_out` of transmission links. I will get this error:

```
calliope.exceptions.ModelError: (data_sources, boundary_link_flow_out) | Cannot define transmission technology data over the `nodes` dimension.
``` 

I am trying to provide the model with a data table like this:

```
nodes,techs,timesteps,fix_link_flow_out
ESP,ESP_to_FRA,2017-01-01,120
```

And a constraint like this:

```
constraints:
  boundary_constraint_link_flow_out_group_ub:
    foreach: [nodes,techs,carriers,timesteps]
    where: "base_tech=transmission AND carriers=electricity AND fix_link_flow_out"
    equations:
      - expression: flow_out == fix_link_flow_out
```

## Summary of changes in this pull request

I convert the error message into a warning.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved