### PR TITLE
Fix save per SPORE & add SPORES docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.7.0.dev7
+
+### User-facing changes
+
+|new| documentation on SPORES-specific configuration options (#750, #752).
+
+|fixed| SPORES mode models not being appropriately serialised on saving to NetCDF (#751, #752).
+
 ## 0.7.0.dev6 (2025-03-24)
 
 ### User-facing changes

--- a/docs/advanced/mode.md
+++ b/docs/advanced/mode.md
@@ -75,48 +75,90 @@ As an example, if you wanted to generate 10 SPORES, all of which are within 10% 
 ```yaml
 config.build.mode: spores
 # The number of SPORES to generate:
-config.solve.spores.number: 10:
+config.solve.spores.number: 10
 # The fraction above the cost-optimal cost to set the maximum cost during SPORES:
 parameters.spores_slack: 0.1
 ```
 
-You will now also need a `spores_score` cost class in your model.
-The `spores_score` is the cost class against which the model optimises in the generation of SPORES.
-The recommended approach is to initialise it in your model definition for all technologies and locations that you want to limit within the scope of finding alternatives.
-Technologies at locations with higher scores will be penalised in the objective function, so are less likely to be chosen.
-In the [national scale example model](../examples/national_scale/index.md), this would look something like:
-
-```yaml
-templates:
-  add_spores_score:
-    template: cost_dim_setter
-    cost_flow_cap:
-      data: [null, null]
-      index: ["monetary", "spores_score"]
-      dims: costs
-    cost_interest_rate:
-      data: [0.1, 1]
-      index: ["monetary", "spores_score"]
-      dims: costs
-
-techs:
-  ccgt:
-    template: add_spores_score
-    cost_flow_cap.data: [750, 0]
-  csp:
-    template: add_spores_score
-    cost_flow_cap.data: [1000, 0]
-  battery:
-    template: add_spores_score
-    cost_flow_cap.data: [null, 0]
-  region1_to_region2:
-    template: add_spores_score
-    cost_flow_cap.data: [10000, 0]
-```
-
-!!! note
-    We ourselves use and recommend using `spores_score` to define the cost class that you will now optimise against.
-    However, it is user-defined, allowing you to choose any terminology that best fits your use case.
-
 To get a glimpse of how the results generated via SPORES compare to simple cost optimisation, check out our documentation
 on [comparing run modes](../examples/modes.py).
+
+### Limiting the search for alternatives to specific technologies
+
+By default, all technologies at all nodes will be subject to SPORES scoring.
+This means that they are all equally likely to be removed from the system when generating alternative system designs.
+You may want to instead focus on specific technologies when searching for alternatives.
+To do so, set a _tracking parameter_.
+This will be a parameter you set to `True` for all technologies that you want SPORES scores to be applied to.
+Any technology _not_ being tracked will not be penalised in the optimisation for having a non-zero capacity.
+
+!!! example
+
+    ```yaml
+    config.solve.spores.tracking_parameter: my_tracking_parameter
+    parameters:
+      my_tracking_parameter: # defines which techs are going to be subject to SPORES scoring
+        data: [true, true, true]
+        index: [ccgt, csp, battery]
+        dims: techs
+    ```
+
+    Or, at the technology level:
+
+    ```yaml
+    config.solve.spores.tracking_parameter: my_tracking_parameter
+    techs:
+      ccgt:
+        my_tracking_parameter: true
+      csp:
+        my_tracking_parameter: true
+      battery:
+        my_tracking_parameter: true
+      pv:
+        my_tracking_parameter: false # will not be tracked
+    ```
+
+### Saving results per SPORE
+
+Optimisation runs can be resource intensive.
+You should not lose all your results if the optimisation fails part way through your SPORES runs.
+To mitigate this, you can _save results per SPORE run_ to capture results up to any point of failure.
+
+!!! example
+
+    ```yaml
+    config.build.mode: spores
+    # The number of SPORES to generate:
+    config.solve.spores:
+      number: 10
+      save_per_spore_path: results/spores
+    # The fraction above the cost-optimal cost to set the maximum cost during SPORES:
+    parameters.spores_slack: 0.1
+    ```
+
+    Here, 11 result files will be present in the results, 1 for the baseline (non-SPORES) run + 10 SPORES runs.
+    Each SPORE run will be labelled `spore_<run number>.nc`, e.g. `results/spores/spore_10.nc`.
+
+!!! note
+    - The `save_per_spore_path` directory path will be considered as relative to the current working directory unless given as an absolute path.
+    - Even if you choose to save results per SPORE, the results will also be stored in memory.
+      Following the successful completion of all SPORES runs, results will be available in the `model.results` dataset.
+
+### Skipping the baseline optimisation run
+
+The `baseline` run does not set any SPORES scores or a system cost slack.
+It is equivalent to running the model in [plan](#plan-mode) mode.
+If you already a model with baseline results, you need not re-run that optimisation.
+Instead, you can _skip the baseline run_.
+
+!!! example
+
+    ```py
+    import calliope
+
+    # This model already has results from running in `plan` mode.
+    model = calliope.read_netcdf(...)
+
+    model.build(mode="spores")
+    model.solve(spores={"skip_baseline_run": True, "number": 10})
+    ```

--- a/docs/creating/techs.md
+++ b/docs/creating/techs.md
@@ -150,7 +150,7 @@ By defining just a data value, the resulting parameter will only be indexed over
 By using the indexed parameter format, you can add new dimensions.
 We saw this above with `costs`, but you can add _any_ dimension _except_ `nodes`.
 
-!!! examples
+!!! example
 
     ```yaml
     techs:

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,6 @@
 
     Some functionality is not yet available in 0.7, notably:
 
-    * `spores` mode
     * Plotting (see the [example notebooks](examples/index.md) for sample code on making plots directly with Plotly)
 
     To see a full list of changes, read our [page on migrating between v0.6 and v0.7](migrating.md).

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -604,13 +604,14 @@ class Model:
         if spores_config.save_per_spore_path is not None:
             spores_config.save_per_spore_path.mkdir(parents=True, exist_ok=True)
             LOGGER.info("Optimisation model | Saving SPORE baseline to file.")
-            baseline_results.assign_coords(spores="baseline").to_netcdf(
-                spores_config.save_per_spore_path / "baseline.nc"
+            io.save_netcdf(
+                baseline_results.assign_coords(spores="baseline"),
+                spores_config.save_per_spore_path / "baseline.nc",
             )
 
         # We store the results from each iteration in the `results_list` to later concatenate into a single dataset.
         results_list: list[xr.Dataset] = [baseline_results]
-        spore_range = range(1, spores_config.number + 1)
+        spore_range = [str(i) for i in range(1, spores_config.number + 1)]
         LOGGER.info(
             f"Optimisation model | Running SPORES with `{spores_config.scoring_algorithm}` scoring algorithm."
         )
@@ -623,8 +624,9 @@ class Model:
 
             if spores_config.save_per_spore_path is not None:
                 LOGGER.info(f"Optimisation model | Saving SPORE {spore} to file.")
-                iteration_results.assign_coords(spores=spore).to_netcdf(
-                    spores_config.save_per_spore_path / f"spore_{spore}.nc"
+                io.save_netcdf(
+                    iteration_results.assign_coords(spores=spore),
+                    spores_config.save_per_spore_path / f"spore_{spore}.nc",
                 )
 
         spores_dim = pd.Index(["baseline", *spore_range], name="spores")

--- a/src/calliope/schemas/general.py
+++ b/src/calliope/schemas/general.py
@@ -80,8 +80,8 @@ class CalliopeBaseModel(BaseModel):
                 )
                 new_dict[key] = val
         updated = super().model_copy(update=new_dict, deep=deep)
-        updated.model_validate(updated)
-        return updated
+        updated_with_type_casting = updated.model_validate(updated)
+        return updated_with_type_casting
 
     @classmethod
     def model_no_ref_schema(cls) -> AttrDict:

--- a/tests/test_core_model.py
+++ b/tests/test_core_model.py
@@ -263,6 +263,21 @@ class TestSporesMode:
         spores_model, _ = spores_model_and_log
         assert spores_model.backend.config.mode == "spores"
 
+    def test_io_save(self, spores_model_and_log, tmp_path):
+        """Verify that we have run in spores mode"""
+        spores_model, _ = spores_model_and_log
+        filepath = tmp_path / "test_io_save.nc"
+        spores_model.to_netcdf(filepath)
+        assert filepath.exists()
+
+    def test_io_load(self, spores_model_and_log, tmp_path):
+        """Verify that we have run in spores mode"""
+        spores_model, _ = spores_model_and_log
+        filepath = tmp_path / "test_io_load.nc"
+        spores_model.to_netcdf(filepath)
+        new_model = calliope.read_netcdf(filepath)
+        xr.testing.assert_allclose(spores_model._model_data, new_model._model_data)
+
     def test_spores_mode_success(self, spores_model_and_log_algorithms):
         """Solving in spores mode should lead to an optimal solution."""
         spores_model, _ = spores_model_and_log_algorithms
@@ -272,7 +287,7 @@ class TestSporesMode:
         """Solving in spores mode should lead to 3 sets of results."""
         spores_model, _ = spores_model_and_log_algorithms
         assert not set(spores_model.results.spores.values).symmetric_difference(
-            ["baseline", 1, 2]
+            ["baseline", "1", "2"]
         )
 
     def test_spores_scores(self, spores_model_and_log_algorithms):
@@ -316,7 +331,7 @@ class TestSporesMode:
             spores_model._model_data.spores_score_cumulative.diff("spores") > 0
         )
         numpy.testing.assert_array_equal(
-            has_cap.shift(spores=1).sel(spores=[1, 2]), spores_score_increased
+            has_cap.shift(spores=1).sel(spores=["1", "2"]), spores_score_increased
         )
 
     def test_use_tech_tracking(self, spores_model_with_tracker):
@@ -335,7 +350,7 @@ class TestSporesMode:
         out_dir = model.config.solve.spores.save_per_spore_path
         assert len(list(out_dir.glob("*.nc"))) == 3
 
-    @pytest.mark.parametrize("spore", ["baseline", 1, 2])
+    @pytest.mark.parametrize("spore", ["baseline", "1", "2"])
     def test_save_per_spore(self, spores_model_save_per_spore_and_log, spore):
         """We expect SPORES results to be saved to file once per iteration."""
         model, _ = spores_model_save_per_spore_and_log
@@ -344,7 +359,7 @@ class TestSporesMode:
         result = xr.open_dataset((out_dir / filename).with_suffix(".nc"))
         assert result.spores.item() == spore
 
-    @pytest.mark.parametrize("spore", ["baseline", 1, 2])
+    @pytest.mark.parametrize("spore", ["baseline", "1", "2"])
     def test_save_per_spore_log(self, spores_model_save_per_spore_and_log, spore):
         """We expect SPORES results saving to be logged."""
         _, log = spores_model_save_per_spore_and_log


### PR DESCRIPTION
Fixes #751 
Fixes #750 
Fixes #752 

@FLomb please check whether the updated docs make sense.

## Summary of changes in this pull request

* Saving per SPORE uses the Calliope I/O netcdf saver to ensure appropriate serialisation
* All SPORES index items are set to strings ("baseline", "1", etc.) to avoid type issues with saving to NetCDF.
* Documentation on SPORES update to reflect new implementation. This new implementation reduces the expected user input to initialise a SPORES model, as described in #716. 
* Side-fix: when updating the config model, the return of `model_validate` is used, to preserve any type casting from that validation process (e.g. string -> Path).

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved