### PR TITLE
Pin pydantic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.0.dev7
+
+### Internal changes
+
+|changed| Pinned upper bound of pydantic to < 2.11 while we await v2.11.4 to become available on conda forge (#753).
+
 ## 0.7.0.dev6 (2025-03-24)
 
 ### User-facing changes

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,4 +15,4 @@ pyparsing >= 3.2
 ruamel.yaml >= 0.18
 typing-extensions >= 4
 xarray >= 2024.1, < 2024.4 # pinned while https://github.com/pydata/xarray/issues/9755 is open
-pydantic >= 2.9.2
+pydantic >= 2.9.2, < 2.11 # pinned until v2.11.4 is available


### PR DESCRIPTION
Intermediate fix for #753 

Once v2.11.4 is released we'll want to set that as the lower bound. It's never ideal to have only one version of a dependency available to use, but their release cycle is quite frequent so I expect other minor/major versions to be available quite soon.

## Summary of changes in this pull request

*
*
*

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved