### PR TITLE
Load math data during init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### User-facing changes
 
-|new| all math is defined at init in `config.init.math`, with the option to completely replace `plan.yaml` as the base mode (#763, #739).
+|new| all math is defined during init and then stored in `model._def.math`, with the option to completely replace `plan.yaml` as the base mode (#763, #739).
 
 |new| documentation on SPORES-specific configuration options (#750, #752).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### User-facing changes
 
+|new| all math is defined at init in `config.init.math`, with the option to completely replace `plan.yaml` as the base mode (#763, #739).
+
 |new| documentation on SPORES-specific configuration options (#750, #752).
 
 |fixed| SPORES mode models not being appropriately serialised on saving to NetCDF (#751, #752).

--- a/docs/advanced/constraints.md
+++ b/docs/advanced/constraints.md
@@ -183,4 +183,4 @@ Any excess stored energy would result in double the excess the following year, a
 
 !!! note
     Cyclic storage also functions when [time clustering](time.md#time-clustering), if allowing storage to be tracked between clusters.
-    However, it cannot be used in [`operate` run mode](mode.md#operate-mode).
+    However, it cannot be used in [`operate` mode](../pre_defined_math/mode.md#operate-mode).

--- a/docs/advanced/mode.md
+++ b/docs/advanced/mode.md
@@ -3,13 +3,13 @@
 Calliope can leverage different methods to solve your optimisation problem.
 By default, it is designed to find a system configuration with the lowest combined cost to invest in and then operate technologies, with complete knowledge of what the future holds.
 This is a method that is known as "perfect foresight" optimisation.
-We refer to it in our model as [`plan` mode](../advanced/mode.md#plan-mode).
+We refer to it in our model as [`base` mode](../advanced/mode.md#base-mode).
 
-In addition to perfect foresight optimisation, we have a [receding horizon "operate" optimisation mode](../advanced/mode.md#operate-mode) and [our "spores" mode](../advanced/mode.md#spores-mode) to generate alternative system configurations that are within a small deviation of the optimal cost that is computed in `plan` mode. Read on to find out more about each of these run modes.
+In addition to perfect foresight optimisation, we have a [receding horizon "operate" optimisation mode](../advanced/mode.md#operate-mode) and [our "spores" mode](../advanced/mode.md#spores-mode) to generate alternative system configurations that are within a small deviation of the optimal cost that is computed in `base` mode. Read on to find out more about each of these run modes.
 
-## Plan mode
+## Base mode
 
-In `plan` mode, the user defines upper and lower boundaries for technology capacities and the model decides on an optimal system configuration.
+In `base` mode, the user defines upper and lower boundaries for technology capacities and the model decides on an optimal system configuration.
 In this configuration, the total cost of investing in technologies and then using them to meet demand in every _timestep_ (e.g., every hour) is as low as possible.
 
 We scale investment costs so they are equivalent to time-varying (e.g., fuel and maintenance) costs by using _annualisation_.
@@ -41,7 +41,7 @@ Are your storage devices used appropriately when
 
 To specify a valid `operate` mode model, capacities for all technologies at all locations must be defined.
 This can be done by specifying `flow_cap`, `storage_cap`, `area_use`, `source_cap`, and `purchased_units` as _input parameters_.
-These will not clash with the decision variables of the same name that are found in `plan` mode as `operate` mode will deactivate those decision variables.
+These will not clash with the decision variables of the same name that are found in `base` mode as `operate` mode will deactivate those decision variables.
 
 Operate mode runs a model with a receding horizon control algorithm.
 This requires two additional configuration options to be defined:
@@ -147,7 +147,7 @@ To mitigate this, you can _save results per SPORE run_ to capture results up to 
 ### Skipping the baseline optimisation run
 
 The `baseline` run does not set any SPORES scores or a system cost slack.
-It is equivalent to running the model in [plan](#plan-mode) mode.
+It is equivalent to running the model in [`base`](#base-mode) mode.
 If you already have a model with baseline results, you don't need to re-run that optimisation.
 Instead, you can _skip the baseline run_.
 
@@ -156,7 +156,7 @@ Instead, you can _skip the baseline run_.
     ```py
     import calliope
 
-    # This model already has results from running in `plan` mode.
+    # This model already has results from running in `base` mode.
     model = calliope.read_netcdf(...)
 
     model.build(mode="spores")

--- a/docs/creating/config.md
+++ b/docs/creating/config.md
@@ -77,13 +77,19 @@ It has a very high cost associated with its use, so it will only appear when abs
 
 ### `config.build.mode`
 
-In the `build` section we have `mode`.
+The `build.mode` option specifies pre-defined mathematical formulations that require additional processing.
 A model can run in `base`, `operate`, or `spores` mode.
-In `base` mode, capacities are determined by the model, whereas in `operate` mode, capacities are fixed and the system is operated with a receding horizon control algorithm.
-In `spores` mode, the model is first run in `base` mode, then run `N` number of times to find alternative system configurations with similar monetary cost, but maximally different choice of technology capacity and location (node).
+
+* In `base` mode, the default option, Calliope will not execute any additional processing beyond building the mathematical problem defined in `config.init.base_math`.
+* In `operate` mode, capacities are fixed and the system is operated with a receding horizon control algorithm.
+* In `spores` mode, the model is first run in `base` mode, then run `N` number of times to find alternative system configurations with similar monetary cost, but maximally different choice of technology capacity and location (node).
 
 In most cases, you will want to use the `base` mode.
-In fact, you can use a set of results from using `base` model to initialise both the `operate` (`config.build.operate.use_cap_results`) and `spores` modes.
+In fact, you can use a set of results from models run in `base` mode to initialise both the `operate` (via`config.build.operate.use_cap_results`) and `spores` modes.
+
+!!! warning
+
+    Both `operate` and `spores` modes are designed to work with our pre-defined math and may stop working if it is overridden with [user-defined math](../user_defined_math/customise.md#re-defining-calliopes-pre-defined-base-math).
 
 ### `config.solve.solver`
 

--- a/docs/creating/config.md
+++ b/docs/creating/config.md
@@ -10,7 +10,7 @@ config:
     name: 'My energy model'
     time_subset: ['2005-01-01', '2005-01-05']
   build:
-    mode: plan
+    mode: base
   solve:
     solver: cbc
 ```
@@ -78,12 +78,12 @@ It has a very high cost associated with its use, so it will only appear when abs
 ### `config.build.mode`
 
 In the `build` section we have `mode`.
-A model can run in `plan`, `operate`, or `spores` mode.
-In `plan` mode, capacities are determined by the model, whereas in `operate` mode, capacities are fixed and the system is operated with a receding horizon control algorithm.
-In `spores` mode, the model is first run in `plan` mode, then run `N` number of times to find alternative system configurations with similar monetary cost, but maximally different choice of technology capacity and location (node).
+A model can run in `base`, `operate`, or `spores` mode.
+In `base` mode, capacities are determined by the model, whereas in `operate` mode, capacities are fixed and the system is operated with a receding horizon control algorithm.
+In `spores` mode, the model is first run in `base` mode, then run `N` number of times to find alternative system configurations with similar monetary cost, but maximally different choice of technology capacity and location (node).
 
-In most cases, you will want to use the `plan` mode.
-In fact, you can use a set of results from using `plan` model to initialise both the `operate` (`config.build.operate.use_cap_results`) and `spores` modes.
+In most cases, you will want to use the `base` mode.
+In fact, you can use a set of results from using `base` model to initialise both the `operate` (`config.build.operate.use_cap_results`) and `spores` modes.
 
 ### `config.solve.solver`
 

--- a/docs/examples/national_scale/notebook.py
+++ b/docs/examples/national_scale/notebook.py
@@ -259,7 +259,7 @@ df_capacity = (
 )
 df_capacity_coords = pd.merge(df_coords, df_capacity, left_on="nodes", right_on="nodes")
 
-fig = px.line_mapbox(
+fig = px.line_map(
     df_capacity_coords,
     lat="latitude",
     lon="longitude",

--- a/docs/examples/urban_scale/notebook.py
+++ b/docs/examples/urban_scale/notebook.py
@@ -256,7 +256,7 @@ df_capacity = (
 )
 df_capacity_coords = pd.merge(df_coords, df_capacity, left_on="nodes", right_on="nodes")
 
-fig = px.line_mapbox(
+fig = px.line_map(
     df_capacity_coords,
     lat="latitude",
     lon="longitude",
@@ -267,10 +267,10 @@ fig = px.line_mapbox(
     height=300,
 )
 fig.update_layout(
-    mapbox_style="open-street-map",
-    mapbox_zoom=11,
-    mapbox_center_lat=df_coords.latitude.mean(),
-    mapbox_center_lon=df_coords.longitude.mean(),
+    map_style="open-street-map",
+    map_zoom=11,
+    map_center_lat=df_coords.latitude.mean(),
+    map_center_lon=df_coords.longitude.mean(),
     margin={"r": 0, "t": 0, "l": 0, "b": 0},
     hoverdistance=50,
 )

--- a/docs/hooks/dummy_model/model.yaml
+++ b/docs/hooks/dummy_model/model.yaml
@@ -5,13 +5,13 @@ overrides:
       time_cluster: cluster_days.csv
     config.build:
       extra_math: ["storage_inter_cluster"]
-  spores:
-    config:
-      init.name: SPORES solve mode
-      build.mode: spores
-      solve.spores.number: 2
-    parameters:
-      spores_slack: 0.1
+  # spores:
+  #   config:
+  #     init.name: SPORES solve mode
+  #     build.mode: spores
+  #     solve.spores.number: 2
+  #   parameters:
+  #     spores_slack: 0.1
 
 config.init.name: base
 

--- a/docs/hooks/dummy_model/model.yaml
+++ b/docs/hooks/dummy_model/model.yaml
@@ -3,8 +3,6 @@ overrides:
     config.init:
       name: inter-cluster storage
       time_cluster: cluster_days.csv
-      math:
-        pre_defined: ["plan", "storage_inter_cluster"]
     config.build:
       extra_math: ["storage_inter_cluster"]
   spores:

--- a/docs/hooks/dummy_model/model.yaml
+++ b/docs/hooks/dummy_model/model.yaml
@@ -5,13 +5,13 @@ overrides:
       time_cluster: cluster_days.csv
     config.build:
       extra_math: ["storage_inter_cluster"]
-  # spores:
-  #   config:
-  #     init.name: SPORES solve mode
-  #     build.mode: spores
-  #     solve.spores.number: 2
-  #   parameters:
-  #     spores_slack: 0.1
+  spores:
+    config:
+      init.name: SPORES mode
+      build.mode: spores
+      solve.spores.number: 2
+    parameters:
+      spores_slack: 0.1
 
 config.init.name: base
 

--- a/docs/hooks/dummy_model/model.yaml
+++ b/docs/hooks/dummy_model/model.yaml
@@ -3,8 +3,10 @@ overrides:
     config.init:
       name: inter-cluster storage
       time_cluster: cluster_days.csv
+      math:
+        pre_defined: ["plan", "storage_inter_cluster"]
     config.build:
-      add_math: ["storage_inter_cluster"]
+      extra_math: ["storage_inter_cluster"]
   spores:
     config:
       init.name: SPORES solve mode

--- a/docs/hooks/generate_math_docs.py
+++ b/docs/hooks/generate_math_docs.py
@@ -63,18 +63,22 @@ def on_files(files: list, config: dict, **kwargs):
         custom_documentation = generate_custom_math_documentation(
             base_documentation, override
         )
-        write_file(
-            f"{override}.yaml",
-            textwrap.dedent(
+        if "mode" in model_config.get_key(f"overrides.{override}.config.init.name"):
+            text = textwrap.dedent(
                 f"""
-            Pre-defined additional math to apply {custom_documentation.name} __on top of__ the [base mathematical formulation][base-math].
-            This math is _only_ applied if referenced in the `config.build.extra_math` list as `{override}`.
+            Pre-defined **mode math** to apply {custom_documentation.name} __on top of__ the [base mathematical formulation][base-math].
+            This math is _only_ applied when `config.build.mode` is set to `"{override}"`.
             """
-            ),
-            custom_documentation,
-            files,
-            config,
-        )
+            )
+        else:
+            text = textwrap.dedent(
+                f"""
+            Pre-defined **extra math** to apply {custom_documentation.name} __on top of__ the [base mathematical formulation][base-math].
+            This math is _only_ applied if referenced in the `config.build.extra_math` list as `"{override}"`.
+            """
+            )
+
+        write_file(f"{override}.yaml", text, custom_documentation, files, config)
 
     return files
 

--- a/docs/hooks/generate_math_docs.py
+++ b/docs/hooks/generate_math_docs.py
@@ -171,13 +171,13 @@ def generate_custom_math_documentation(
     expr_del = []
     for component_group, component_group_dict in model.applied_math.items():
         for name, component_dict in component_group_dict.items():
-            if name in base_documentation.math.data[component_group]:
+            if name in base_documentation.math[component_group]:
                 if not component_dict.get("active", True):
                     expr_del.append(name)
                     component_dict["description"] = "|REMOVED|"
                     component_dict["active"] = True
                 elif (
-                    base_documentation.math.data[component_group].get(name, {})
+                    base_documentation.math[component_group].get(name, {})
                     != component_dict
                 ):
                     _add_to_description(component_dict, "|UPDATED|")

--- a/docs/hooks/generate_math_docs.py
+++ b/docs/hooks/generate_math_docs.py
@@ -68,7 +68,7 @@ def on_files(files: list, config: dict, **kwargs):
             textwrap.dedent(
                 f"""
             Pre-defined additional math to apply {custom_documentation.name} __on top of__ the [base mathematical formulation][base-math].
-            This math is _only_ applied if referenced in the `config.init.add_math` list as `{override}`.
+            This math is _only_ applied if referenced in the `config.build.extra_math` list as `{override}`.
             """
             ),
             custom_documentation,

--- a/docs/hooks/generate_math_docs.py
+++ b/docs/hooks/generate_math_docs.py
@@ -169,7 +169,7 @@ def generate_custom_math_documentation(
 
     full_del = []
     expr_del = []
-    for component_group, component_group_dict in model.applied_math.data.items():
+    for component_group, component_group_dict in model.applied_math.items():
         for name, component_dict in component_group_dict.items():
             if name in base_documentation.math.data[component_group]:
                 if not component_dict.get("active", True):

--- a/docs/hooks/generate_readable_schema.py
+++ b/docs/hooks/generate_readable_schema.py
@@ -23,7 +23,7 @@ TEMPDIR = tempfile.TemporaryDirectory()
 SCHEMAS = {
     "config_schema": config_schema.CalliopeConfig.model_no_ref_schema(),
     "model_schema": schema.MODEL_SCHEMA,
-    "math_schema": math_schema.CalliopeMathDef.model_no_ref_schema(),
+    "math_schema": math_schema.ModeMath.model_no_ref_schema(),
     "data_table_schema": data_table_schema.CalliopeDataTable.model_no_ref_schema(),
 }
 

--- a/docs/hooks/generate_readable_schema.py
+++ b/docs/hooks/generate_readable_schema.py
@@ -23,7 +23,7 @@ TEMPDIR = tempfile.TemporaryDirectory()
 SCHEMAS = {
     "config_schema": config_schema.CalliopeConfig.model_no_ref_schema(),
     "model_schema": schema.MODEL_SCHEMA,
-    "math_schema": math_schema.ModeMath.model_no_ref_schema(),
+    "math_schema": math_schema.MathSchema.model_no_ref_schema(),
     "data_table_schema": data_table_schema.CalliopeDataTable.model_no_ref_schema(),
 }
 

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -159,7 +159,7 @@ This split means you can change configuration options on-the-fly if you are work
       init:
         time_subset: ["2005-01", "2005-02"]
       build:
-        mode: plan
+        mode: base
       solve:
         solver: cbc
     ```
@@ -169,7 +169,7 @@ This split means you can change configuration options on-the-fly if you are work
     ```python
     import calliope
     model = calliope.Model(time_subset=["2005-01", "2005-02"])
-    model.build(mode="plan")
+    model.build(mode="base")
     model.solve(solver="cbc")
     ```
 

--- a/docs/pre_defined_math/index.md
+++ b/docs/pre_defined_math/index.md
@@ -1,24 +1,29 @@
 # Pre-defined math
 
 As of Calliope version 0.7, the math used to build optimisation problems is stored in YAML files.
-The pre-defined math is a re-implementation of the formerly hardcoded math formulation in this YAML format.
+Our pre-defined math is a re-implementation of the formerly hardcoded math formulation in this YAML format.
 
-The pre-defined math for your chosen run [mode](../creating/config.md#configbuildmode) is _always_ applied to your model when you `build` the optimisation problem.
-We have also pre-defined some additional math, which you can _optionally_ load into your model.
-For instance, the [inter-cluster storage][inter-cluster-storage-math] math allows you to track storage levels in technologies more accurately when you are using timeseries clustering in your model.
+Calliope follows a strict order of priority when applying math: **base math -> mode math -> extra math**.
 
-To load optional, pre-defined math on top of the base math, you can reference it by name in your model configuration:
+* **Base math**, defined in `config.init.base_math`, is _always_ applied to any Calliope problem.
+By default, it is a 'snapshot' [capacity planning problem][base-math] with perfect foresight.
+* **Mode math**, activated via `config.build.mode`, is reserved for special cases that require additional processing within Calliope.
+This includes [operate](mode.md#operate-mode) and [spores](mode.md#spores-mode) modes.
+* **Extra math**, activated via `config.build.extra_math`, is for additional formulations that can be _optionally_ loaded on top of the base math.
+For instance, the [inter-cluster storage][inter-cluster-storage-math] extra math allows you to track storage levels in technologies more accurately when you are using timeseries clustering in your model.
 
-```yaml
-config:
-  build:
-    extra_math: [storage_inter_cluster]
-```
+To load optional pre-defined math on top of the base math, you can reference it by name in your model configuration.
 
-If you are running in the `base` run mode, this will first apply all the [`base`][base-math] pre-defined math, then the [`storage_inter_cluster`][inter-cluster-storage-math] pre-defined math.
+!!! example
+    In the example below, Calliope will first apply all the [`base`][base-math] pre-defined math, then the [`storage_inter_cluster`][inter-cluster-storage-math] pre-defined math.
+
+    ```yaml
+    config:
+    build:
+        extra_math: [storage_inter_cluster]
+    ```
+
 All pre-defined math YAML files can be found in [`math` directory of the Calliope source code](https://github.com/calliope-project/calliope/blob/main/src/calliope/math/storage_inter_cluster.yaml).
 
 If you want to introduce new constraints, decision variables, or objectives, you can do so as part of the collection of YAML files describing your model.
 See the [user-defined math](../user_defined_math/index.md) section for an in-depth guide to applying your own math.
-
-The pre-defined math can be explored in this section by selecting one of the options in the left-hand-side table of contents.

--- a/docs/pre_defined_math/index.md
+++ b/docs/pre_defined_math/index.md
@@ -7,15 +7,15 @@ The pre-defined math for your chosen run [mode](../creating/config.md#configbuil
 We have also pre-defined some additional math, which you can _optionally_ load into your model.
 For instance, the [inter-cluster storage][inter-cluster-storage-math] math allows you to track storage levels in technologies more accurately when you are using timeseries clustering in your model.
 
-To load optional, pre-defined math on top of the base math, you can reference it by name (_without_ the file extension) in your model configuration:
+To load optional, pre-defined math on top of the base math, you can reference it by name in your model configuration:
 
 ```yaml
 config:
   build:
-    add_math: [storage_inter_cluster]
+    extra_math: [storage_inter_cluster]
 ```
 
-If you are running in the `plan` run mode, this will first apply all the [`plan`][base-math] pre-defined math, then the [`storage_inter_cluster`][inter-cluster-storage-math] pre-defined math.
+If you are running in the `base` run mode, this will first apply all the [`base`][base-math] pre-defined math, then the [`storage_inter_cluster`][inter-cluster-storage-math] pre-defined math.
 All pre-defined math YAML files can be found in [`math` directory of the Calliope source code](https://github.com/calliope-project/calliope/blob/main/src/calliope/math/storage_inter_cluster.yaml).
 
 If you want to introduce new constraints, decision variables, or objectives, you can do so as part of the collection of YAML files describing your model.

--- a/docs/pre_defined_math/mode.md
+++ b/docs/pre_defined_math/mode.md
@@ -1,11 +1,11 @@
-# Run modes
+# Build modes
 
 Calliope can leverage different methods to solve your optimisation problem.
 By default, it is designed to find a system configuration with the lowest combined cost to invest in and then operate technologies, with complete knowledge of what the future holds.
 This is a method that is known as "perfect foresight" optimisation.
-We refer to it in our model as [`base` mode](../advanced/mode.md#base-mode).
+We refer to it in our model as [`base` mode](#base-mode).
 
-In addition to perfect foresight optimisation, we have a [receding horizon "operate" optimisation mode](../advanced/mode.md#operate-mode) and [our "spores" mode](../advanced/mode.md#spores-mode) to generate alternative system configurations that are within a small deviation of the optimal cost that is computed in `base` mode. Read on to find out more about each of these run modes.
+In addition to perfect foresight optimisation, we have a [receding horizon "operate" optimisation mode](../pre_defined_math/mode.md#operate-mode) and [our "spores" mode](../pre_defined_math/mode.md#spores-mode) to generate alternative system configurations that are within a small deviation of the optimal cost that is computed in `base` mode. Read on to find out more about each of these run modes.
 
 ## Base mode
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -96,7 +96,7 @@ Then, run `operate` mode with these capacities to get a higher resolution operat
 If necessary, this process could be iterated.
 
 !!! info "See also"
-    [Documentation on `operate` mode](advanced/mode.md#operate-mode)
+    [Documentation on `operate` mode](pre_defined_math/mode.md#operate-mode)
 
 ## Influence of solver choice on speed
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -91,7 +91,7 @@ The exact extent of this is as-yet untested.
 Solution time increases more than linearly with the number of decision variables.
 As it splits the model into temporal chunks, `operate` mode can help to alleviate solution time of big problems.
 This is clearly at the expense of fixing technology capacities.
-However, one solution is to use a heavily time clustered `plan` mode to get indicative model capacities.
+However, one solution is to use a heavily time clustered `base` mode to get indicative model capacities.
 Then, run `operate` mode with these capacities to get a higher resolution operation strategy.
 If necessary, this process could be iterated.
 

--- a/docs/user_defined_math/customise.md
+++ b/docs/user_defined_math/customise.md
@@ -18,16 +18,15 @@ storage_max:
 
 The other elements of the `storage_max` constraints have not changed (`foreach`, `where`, ...), so we do not need to define them again when adding our own twist on the pre-defined math.
 
-When defining your model, you can reference any number of YAML files containing the math you want to add in `config.init.math`.
+When defining your model, you can reference any number of YAML files containing the math you want to add in `config.init.extra_math`.
 Both absolute paths and paths relative to `model.yaml` are valid.
 
 ```yaml
 config:
   init:
-    math:
-      extra:
-        my_new_math_1: "my_new_math_1.yaml"
-        my_new_math_2: "/home/your_name/Documents/my_new_math_2.yaml"
+    extra_math:
+      my_new_math_1: "my_new_math_1.yaml"
+      my_new_math_2: "/home/your_name/Documents/my_new_math_2.yaml"
 ```
 
 You can then add this math during `build` by specifying it in `config.build.extra_math`.
@@ -59,9 +58,8 @@ This will tell Calliope to overwrite *all* of our pre-defined `base` math with y
 ```yaml
 config:
   init:
-    math:
-      base: "my_new_base_math"
-      extra: {my_new_base_math: your/base_math_file.yaml}
+    base_math: "my_new_base_math"
+    extra_math: {my_new_base_math: your/base_math_file.yaml}
 ```
 
 !!! danger

--- a/docs/user_defined_math/customise.md
+++ b/docs/user_defined_math/customise.md
@@ -1,10 +1,12 @@
-# Adding your own math to a model
+# Adding your own extra math to a model
 
 Once you understand the [math components](components.md) and the [formulation syntax](syntax.md), you'll be ready to introduce your own math to a model.
 
 You can find examples of additional math that we have put together in our [math example gallery](examples/index.md).
 
-Whenever you introduce your own math, it will be applied on top of the pre-defined math for your chosen run [mode](../creating/config.md#configbuildmode).
+Whenever you introduce your own extra math, it will be applied on top of the pre-defined math for your chosen run [mode](../creating/config.md#configbuildmode).
+The order of priority is **base math -> mode -> extra math**.
+
 Therefore, you can override the pre-defined math as well as add new math.
 For example, you may want to introduce a timeseries parameter to the pre-defined `storage_max` constraint to limit maximum storage capacity on a per-timestep basis:
 
@@ -16,25 +18,25 @@ storage_max:
 
 The other elements of the `storage_max` constraints have not changed (`foreach`, `where`, ...), so we do not need to define them again when adding our own twist on the pre-defined math.
 
-!!! note
-
-    If you prefer to start from scratch with your math, you can ask Calliope to _not_ load the pre-defined math for your chosen run mode by setting `#!yaml config.build.ignore_base_math: true`.
-
-When defining your model, you can reference any number of YAML files containing the math you want to add in `config.build`.
-The paths are relative to your main model configuration file:
+When defining your model, you can reference any number of YAML files containing the math you want to add in `config.init.math`.
+Both absolute paths and paths relative to `model.yaml` are valid.
 
 ```yaml
 config:
-  build:
-    add_math: [my_new_math_1.yaml, my_new_math_2.yaml]
+  init:
+    math:
+      extra:
+        my_new_math_1: "my_new_math_1.yaml"
+        my_new_math_2: "/home/your_name/Documents/my_new_math_2.yaml"
 ```
 
-You can also define a mixture of your own math and the [pre-defined math](../pre_defined_math/index.md):
+You can then add this math during `build` by specifying it in `config.build.extra_math`.
+It is even possible to define a mixture of your math and other [pre-defined math](../pre_defined_math/index.md):
 
 ```yaml
 config:
   build:
-    add_math: [my_new_math_1.yaml, storage_inter_cluster, my_new_math_2.md]
+    extra_math: [my_new_math_1, storage_inter_cluster, my_new_math_2]
 ```
 
 Finally, when working in an interactive Python session, you can add math as a dictionary at build time:
@@ -43,11 +45,28 @@ Finally, when working in an interactive Python session, you can add math as a di
 model.build(add_math_dict={...})
 ```
 
-This will be applied after the pre-defined mode math and any math from file listed in `config.build.add_math`.
+This will be applied after the pre-defined mode math and any extra math listed in `config.build.extra_math`.
 
 !!! note
 
     When working in an interactive Python session, you can view the final math dictionary that has been applied to build the optimisation problem by inspecting `model.applied_math` after a successful call to `model.build()`.
+
+## Re-defining Calliope's pre-defined base math
+
+If you prefer to start from scratch with your math, you can ask Callipe to use it as the base of the problem.
+This will tell Calliope to overwrite *all* of our pre-defined `base` math with your file.
+
+```yaml
+config:
+  init:
+    math:
+      base: "my_new_base_math"
+      extra: {my_new_base_math: your/base_math_file.yaml}
+```
+
+!!! danger
+
+    Modes and other pre-defined options such as `operate` and `spores` might not work as expected!
 
 ## Adding your parameters to the YAML schema
 

--- a/docs/user_defined_math/customise.md
+++ b/docs/user_defined_math/customise.md
@@ -18,7 +18,7 @@ The other elements of the `storage_max` constraints have not changed (`foreach`,
 
 !!! note
 
-    If you prefer to start from scratch with your math, you can ask Calliope to _not_ load the pre-defined math for your chosen run mode by setting `#!yaml config.build.ignore_mode_math: true`.
+    If you prefer to start from scratch with your math, you can ask Calliope to _not_ load the pre-defined math for your chosen run mode by setting `#!yaml config.build.ignore_base_math: true`.
 
 When defining your model, you can reference any number of YAML files containing the math you want to add in `config.build`.
 The paths are relative to your main model configuration file:

--- a/docs/user_defined_math/customise.md
+++ b/docs/user_defined_math/customise.md
@@ -1,13 +1,15 @@
-# Adding your own extra math to a model
+# Adding your own math to a model
 
 Once you understand the [math components](components.md) and the [formulation syntax](syntax.md), you'll be ready to introduce your own math to a model.
 
-You can find examples of additional math that we have put together in our [math example gallery](examples/index.md).
+!!! info
+    You can find examples of additional math that we have put together in our [math example gallery](examples/index.md).
 
-Whenever you introduce your own extra math, it will be applied on top of the pre-defined math for your chosen run [mode](../creating/config.md#configbuildmode).
-The order of priority is **base math -> mode -> extra math**.
+Whenever you introduce your own math, it can either be _added_ on top of our [pre-defined math](../pre_defined_math/index.md) or _replace_ it entirely.
 
-Therefore, you can override the pre-defined math as well as add new math.
+## Adding extra math
+
+The simplest way to add math is to extend Calliope's pre-existing formulation by defining a new **extra math** option.
 For example, you may want to introduce a timeseries parameter to the pre-defined `storage_max` constraint to limit maximum storage capacity on a per-timestep basis:
 
 ```yaml
@@ -16,7 +18,7 @@ storage_max:
     - expression: storage <= storage_cap * time_varying_parameter
 ```
 
-The other elements of the `storage_max` constraints have not changed (`foreach`, `where`, ...), so we do not need to define them again when adding our own twist on the pre-defined math.
+This will not change other elements of the `storage_max` constraints (`foreach`, `where`, ...), so we do not need to define them again when adding our own twist on the pre-defined math.
 
 When defining your model, you can reference any number of YAML files containing the math you want to add in `config.init.extra_math`.
 Both absolute paths and paths relative to `model.yaml` are valid.
@@ -38,6 +40,9 @@ config:
     extra_math: [my_new_math_1, storage_inter_cluster, my_new_math_2]
 ```
 
+???+ tip
+    Always remember Calliope's strict order of priority: **base math -> mode -> extra math**.
+
 Finally, when working in an interactive Python session, you can add math as a dictionary at build time:
 
 ```python
@@ -47,13 +52,11 @@ model.build(add_math_dict={...})
 This will be applied after the pre-defined mode math and any extra math listed in `config.build.extra_math`.
 
 !!! note
-
     When working in an interactive Python session, you can view the final math dictionary that has been applied to build the optimisation problem by inspecting `model.applied_math` after a successful call to `model.build()`.
 
 ## Re-defining Calliope's pre-defined base math
 
-If you prefer to start from scratch with your math, you can ask Callipe to use it as the base of the problem.
-This will tell Calliope to overwrite *all* of our pre-defined `base` math with your file.
+If you prefer to start from scratch with your math, you can ask Callipe to completely replace our pre-defined **base math** with your own.
 
 ```yaml
 config:
@@ -62,8 +65,9 @@ config:
     extra_math: {my_new_base_math: your/base_math_file.yaml}
 ```
 
-!!! danger
+This will tell Calliope to overwrite _all_ of our pre-defined `base` math with your file.
 
+!!! danger
     Modes and other pre-defined options such as `operate` and `spores` might not work as expected!
 
 ## Adding your parameters to the YAML schema
@@ -109,12 +113,10 @@ This is usually one of `float` or `str`.
 * x-operate-param (bool): If True, this parameter's schema data will only be loaded into the optimisation problem if running in "operate" mode.
 
 !!! note
-
     Schema attributes which start with `x-` are Calliope-specific.
     They are not used at all for YAML validation and instead get picked up by us using the utility function [calliope.util.schema.extract_from_schema][].
 
 !!! warning
-
     The schema is updated in-place so your edits to it will remain active as long as you are running in the same session.
     You can reset your updates to the schema and return to the pre-defined schema by calling [`calliope.util.schema.reset()`][calliope.util.schema.reset]
 
@@ -137,7 +139,6 @@ You can then convert this to a PDF or HTML page using your renderer of choice.
 We recommend you only use HTML as the equations can become too long for a PDF page.
 
 !!! note
-
     You can add interactive elements to your documentation, if you are planning to host them online using MKDocs.
     This includes tabs to flip between rich-text math and the input YAML snippet, and dropdown lists for math component cross-references.
     Just set the `mkdocs_features` argument to `True` in `math_documentation.write`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,7 +141,6 @@ nav:
     - advanced/index.md
     - advanced/time.md
     - advanced/scripts.md
-    - advanced/mode.md
     - advanced/solver.md
     - advanced/backend_choice.md
     - advanced/backend_interface.md

--- a/src/calliope/attrdict.py
+++ b/src/calliope/attrdict.py
@@ -214,7 +214,6 @@ class AttrDict(dict):
         other: Self | dict,
         allow_override: bool = False,
         allow_replacement: bool = False,
-        allow_subdict_override_with_none: bool = False,
     ):
         """In-place merge with another AttrDict.
 
@@ -224,9 +223,6 @@ class AttrDict(dict):
                 already defined keys. Defaults to False.
             allow_replacement (bool, optional): allow "_REPLACE_" key to replace an
                 entire sub-dict. Defaults to False.
-            allow_subdict_override_with_none (bool, optional): if False, keys in the
-                form `this.that: None` in `other` will be ignored if subdicts exist in
-                self like `this.that.foo: 1`, rather than wiping them. Defaults to False.
 
         Raises:
             KeyError: `other` has an already defined key and `allow_override == False`

--- a/src/calliope/backend/__init__.py
+++ b/src/calliope/backend/__init__.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import xarray as xr
 
+from calliope.attrdict import AttrDict
 from calliope.backend.gurobi_backend_model import GurobiBackendModel
 from calliope.backend.latex_backend_model import (
     ALLOWED_MATH_FILE_FORMATS,
@@ -11,7 +12,6 @@ from calliope.backend.latex_backend_model import (
 )
 from calliope.backend.pyomo_backend_model import PyomoBackendModel
 from calliope.exceptions import BackendError
-from calliope.preprocess import CalliopeMath
 
 if TYPE_CHECKING:
     from calliope.backend.backend_model import BackendModel
@@ -19,14 +19,14 @@ if TYPE_CHECKING:
 
 
 def get_model_backend(
-    build_config: "config_schema.Build", data: xr.Dataset, math: CalliopeMath
+    build_config: "config_schema.Build", data: xr.Dataset, math: AttrDict
 ) -> "BackendModel":
     """Assign a backend using the given configuration.
 
     Args:
         build_config: Build configuration options.
         data (Dataset): model data for the backend.
-        math (CalliopeMath): Calliope math.
+        math (AttrDict): Calliope math.
 
     Raises:
         exceptions.BackendError: If invalid backend was requested.

--- a/src/calliope/backend/backend_model.py
+++ b/src/calliope/backend/backend_model.py
@@ -298,7 +298,7 @@ class BackendModelGenerator(ABC):
         if name not in self.math[component_type]:
             self.math.union({f"{component_type}.{name}": component_dict})
 
-        if break_early and not component_dict.get("active", True):
+        if break_early and not component_dict["active"]:
             self.log(
                 component_type, name, "Component deactivated and therefore not built."
             )

--- a/src/calliope/backend/backend_model.py
+++ b/src/calliope/backend/backend_model.py
@@ -636,7 +636,7 @@ class BackendModel(BackendModelGenerator, Generic[T]):
     def add_piecewise_constraint(  # noqa: D102, override
         self, name: str, constraint_dict: parsing.UnparsedPiecewiseConstraint
     ) -> None:
-        if "breakpoints" in constraint_dict.get("foreach", []):
+        if "breakpoints" in constraint_dict["foreach"]:
             raise BackendError(
                 f"(piecewise_constraints, {name}) | `breakpoints` dimension should not be in `foreach`. "
                 "Instead, index `x_values` and `y_values` parameters over `breakpoints`."

--- a/src/calliope/backend/backend_model.py
+++ b/src/calliope/backend/backend_model.py
@@ -1058,7 +1058,7 @@ class BackendModel(BackendModelGenerator, Generic[T]):
                 f"Applying bound according to the {bound} parameter values.",
             )
             bound_array = self.get_parameter(bound)
-            fill_na = bound_array.attrs.get("default", fill_na)
+            fill_na = bound_array.attrs["default"]
             references.add(bound)
         else:
             bound_array = xr.DataArray(bound)

--- a/src/calliope/backend/gurobi_backend_model.py
+++ b/src/calliope/backend/gurobi_backend_model.py
@@ -136,11 +136,11 @@ class GurobiBackendModel(backend_model.BackendModel):
         domain_dict = {"real": gurobipy.GRB.CONTINUOUS, "integer": gurobipy.GRB.INTEGER}
 
         def _variable_setter(where: xr.DataArray, references: set):
-            domain_type = domain_dict[variable_dict.get("domain", "real")]
+            domain_type = domain_dict[variable_dict["domain"]]
 
             bounds = variable_dict["bounds"]
-            lb = self._get_variable_bound(bounds["min"], name, references, -np.inf)
-            ub = self._get_variable_bound(bounds["max"], name, references, np.inf)
+            lb = self._get_variable_bound(bounds["min"], name, references)
+            ub = self._get_variable_bound(bounds["max"], name, references)
             var = self._apply_func(
                 self._instance.addVar, where, 1, lb, ub, vtype=domain_type
             )

--- a/src/calliope/backend/gurobi_backend_model.py
+++ b/src/calliope/backend/gurobi_backend_model.py
@@ -14,16 +14,17 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from calliope.attrdict import AttrDict
 from calliope.backend import backend_model, parsing
 from calliope.exceptions import BackendError, BackendWarning
 from calliope.exceptions import warn as model_warn
-from calliope.preprocess import CalliopeMath
 from calliope.schemas import config_schema
 
 if importlib.util.find_spec("gurobipy") is not None:
     import gurobipy
 
 T = TypeVar("T")
+# TODO-Ivan: below seems to be repated in several files? Fix.
 _COMPONENTS_T = Literal[
     "variables", "constraints", "objectives", "parameters", "global_expressions"
 ]
@@ -60,13 +61,13 @@ class GurobiBackendModel(backend_model.BackendModel):
         }
 
     def __init__(
-        self, inputs: xr.Dataset, math: CalliopeMath, build_config: config_schema.Build
+        self, inputs: xr.Dataset, math: AttrDict, build_config: config_schema.Build
     ) -> None:
         """Gurobi solver interface class.
 
         Args:
             inputs (xr.Dataset): Calliope model data.
-            math (CalliopeMath): Calliope math.
+            math (AttrDict): Calliope math.
             build_config: Build configuration options.
         """
         if importlib.util.find_spec("gurobipy") is None:
@@ -403,7 +404,7 @@ class GurobiBackendModel(backend_model.BackendModel):
                 )
                 continue
 
-            existing_bound_param = self.math.data.get_key(
+            existing_bound_param = self.math.get_key(
                 f"variables.{name}.bounds.{bound_name}", None
             )
             if existing_bound_param in self.parameters:

--- a/src/calliope/backend/gurobi_backend_model.py
+++ b/src/calliope/backend/gurobi_backend_model.py
@@ -8,7 +8,7 @@ import importlib
 import logging
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Literal, SupportsFloat, TypeVar, overload
+from typing import Any, Literal, SupportsFloat, overload
 
 import numpy as np
 import pandas as pd
@@ -16,18 +16,13 @@ import xarray as xr
 
 from calliope.attrdict import AttrDict
 from calliope.backend import backend_model, parsing
+from calliope.backend.backend_model import ALL_COMPONENTS_T
 from calliope.exceptions import BackendError, BackendWarning
 from calliope.exceptions import warn as model_warn
 from calliope.schemas import config_schema
 
 if importlib.util.find_spec("gurobipy") is not None:
     import gurobipy
-
-T = TypeVar("T")
-# TODO-Ivan: below seems to be repated in several files? Fix.
-_COMPONENTS_T = Literal[
-    "variables", "constraints", "objectives", "parameters", "global_expressions"
-]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -322,10 +317,10 @@ class GurobiBackendModel(backend_model.BackendModel):
             raise ValueError("File extension must be `.lp`")
         self._instance.write(str(path))
 
-    def _create_obj_list(self, key: str, component_type: _COMPONENTS_T) -> None:
+    def _create_obj_list(self, key: str, component_type: ALL_COMPONENTS_T) -> None:
         pass
 
-    def delete_component(self, key: str, component_type: _COMPONENTS_T) -> None:
+    def delete_component(self, key: str, component_type: ALL_COMPONENTS_T) -> None:
         """Delete object from the backend model object linked to a component.
 
         Args:

--- a/src/calliope/backend/latex_backend_model.py
+++ b/src/calliope/backend/latex_backend_model.py
@@ -12,9 +12,9 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from calliope.attrdict import AttrDict
 from calliope.backend import backend_model, parsing
 from calliope.exceptions import ModelError
-from calliope.preprocess import CalliopeMath
 from calliope.schemas import config_schema
 
 ALLOWED_MATH_FILE_FORMATS = Literal["tex", "rst", "md"]
@@ -305,7 +305,7 @@ class LatexBackendModel(backend_model.BackendModelGenerator):
     def __init__(
         self,
         inputs: xr.Dataset,
-        math: CalliopeMath,
+        math: AttrDict,
         build_config: config_schema.Build,
         include: Literal["all", "valid"] = "all",
     ) -> None:
@@ -313,7 +313,7 @@ class LatexBackendModel(backend_model.BackendModelGenerator):
 
         Args:
             inputs (xr.Dataset): model data.
-            math (CalliopeMath): Calliope math.
+            math (AttrDict): Calliope math.
             build_config: Build configuration options.
             include (Literal["all", "valid"], optional):
                 Defines whether to include all possible math equations ("all") or only those for which at least one index item in the "where" string is valid ("valid"). Defaults to "all".

--- a/src/calliope/backend/latex_backend_model.py
+++ b/src/calliope/backend/latex_backend_model.py
@@ -485,12 +485,12 @@ class LatexBackendModel(backend_model.BackendModelGenerator):
         self.log("objectives", name, "Objective activated.", level="info")
 
     def _create_obj_list(  # noqa: D102, override
-        self, key: str, component_type: backend_model._COMPONENTS_T
+        self, key: str, component_type: backend_model.ALL_COMPONENTS_T
     ) -> None:
         return None
 
     def delete_component(  # noqa: D102, override
-        self, key: str, component_type: backend_model._COMPONENTS_T
+        self, key: str, component_type: backend_model.ALL_COMPONENTS_T
     ) -> None:
         if key in self._dataset and self._dataset[key].obj_type == component_type:
             del self._dataset[key]

--- a/src/calliope/backend/latex_backend_model.py
+++ b/src/calliope/backend/latex_backend_model.py
@@ -441,7 +441,7 @@ class LatexBackendModel(backend_model.BackendModelGenerator):
             var_da
         )
 
-        domain = domain_dict[variable_dict.get("domain", "real")]
+        domain = domain_dict[variable_dict["domain"]]
         lb, ub = self._get_variable_bounds_string(
             name, variable_dict["bounds"], bound_refs
         )

--- a/src/calliope/backend/parsing.py
+++ b/src/calliope/backend/parsing.py
@@ -30,6 +30,7 @@ class UnparsedEquation(TypedDict):
 
     where: NotRequired[str]
     expression: str
+    active: bool
 
 
 class UnparsedConstraint(TypedDict):
@@ -41,6 +42,7 @@ class UnparsedConstraint(TypedDict):
     equations: Required[list[UnparsedEquation]]
     sub_expressions: NotRequired[dict[str, list[UnparsedEquation]]]
     slices: NotRequired[dict[str, list[UnparsedEquation]]]
+    active: bool
 
 
 class UnparsedPiecewiseConstraint(TypedDict):
@@ -53,6 +55,7 @@ class UnparsedPiecewiseConstraint(TypedDict):
     x_values: Required[str]
     y_expression: Required[str]
     y_values: Required[str]
+    active: bool
 
 
 class UnparsedExpression(UnparsedConstraint):
@@ -67,8 +70,6 @@ class UnparsedVariableBound(TypedDict):
 
     min: str
     max: str
-    equals: str
-    scale: NotRequired[str]
 
 
 class UnparsedVariable(TypedDict):
@@ -81,6 +82,7 @@ class UnparsedVariable(TypedDict):
     where: str
     domain: NotRequired[str]
     bounds: UnparsedVariableBound
+    active: bool
 
 
 class UnparsedObjective(TypedDict):
@@ -90,6 +92,7 @@ class UnparsedObjective(TypedDict):
     equations: Required[list[UnparsedEquation]]
     sub_expressions: NotRequired[dict[str, list[UnparsedEquation]]]
     sense: str
+    active: bool
 
 
 UNPARSED_DICTS = (

--- a/src/calliope/backend/pyomo_backend_model.py
+++ b/src/calliope/backend/pyomo_backend_model.py
@@ -27,9 +27,9 @@ from pyomo.core.kernel.piecewise_library.transforms import (
 from pyomo.opt import SolverFactory  # type: ignore
 from pyomo.util.model_size import build_model_size_report  # type: ignore
 
+from calliope.attrdict import AttrDict
 from calliope.exceptions import BackendError, BackendWarning
 from calliope.exceptions import warn as model_warn
-from calliope.preprocess import CalliopeMath
 from calliope.schemas import config_schema
 from calliope.util.logging import LogWriter
 
@@ -61,13 +61,13 @@ class PyomoBackendModel(backend_model.BackendModel):
     """Pyomo-specific backend functionality."""
 
     def __init__(
-        self, inputs: xr.Dataset, math: CalliopeMath, build_config: config_schema.Build
+        self, inputs: xr.Dataset, math: AttrDict, build_config: config_schema.Build
     ) -> None:
         """Pyomo solver interface class.
 
         Args:
             inputs (xr.Dataset): Calliope model data.
-            math (CalliopeMath): Calliope math.
+            math (AttrDict): Calliope math.
             build_config: Build configuration options.
         """
         super().__init__(inputs, math, build_config, pmo.block())
@@ -468,7 +468,7 @@ class PyomoBackendModel(backend_model.BackendModel):
                 )
                 continue
 
-            existing_bound_param = self.math.data.get_key(
+            existing_bound_param = self.math.get_key(
                 f"variables.{name}.bounds.{bound_name}", None
             )
             if existing_bound_param in self.parameters:

--- a/src/calliope/backend/pyomo_backend_model.py
+++ b/src/calliope/backend/pyomo_backend_model.py
@@ -159,7 +159,7 @@ class PyomoBackendModel(backend_model.BackendModel):
         domain_dict = {"real": pmo.RealSet, "integer": pmo.IntegerSet}
 
         def _variable_setter(where, references):
-            domain_type = domain_dict[variable_dict.get("domain", "real")]
+            domain_type = domain_dict[variable_dict["domain"]]
             bounds = variable_dict["bounds"]
             lb = self._get_variable_bound(bounds["min"], name, references)
             ub = self._get_variable_bound(bounds["max"], name, references)

--- a/src/calliope/backend/pyomo_backend_model.py
+++ b/src/calliope/backend/pyomo_backend_model.py
@@ -10,7 +10,7 @@ from abc import ABC
 from collections.abc import Iterable
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
-from typing import Any, Literal, SupportsFloat, TypeVar, overload
+from typing import Any, Literal, SupportsFloat, overload
 
 import numpy as np
 import pandas as pd
@@ -28,22 +28,12 @@ from pyomo.opt import SolverFactory  # type: ignore
 from pyomo.util.model_size import build_model_size_report  # type: ignore
 
 from calliope.attrdict import AttrDict
+from calliope.backend import backend_model, parsing
+from calliope.backend.backend_model import ALL_COMPONENTS_T
 from calliope.exceptions import BackendError, BackendWarning
 from calliope.exceptions import warn as model_warn
 from calliope.schemas import config_schema
 from calliope.util.logging import LogWriter
-
-from . import backend_model, parsing
-
-T = TypeVar("T")
-_COMPONENTS_T = Literal[
-    "variables",
-    "constraints",
-    "piecewise_constraints",
-    "objectives",
-    "parameters",
-    "global_expressions",
-]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -366,7 +356,7 @@ class PyomoBackendModel(backend_model.BackendModel):
     def to_lp(self, path: str | Path) -> None:  # noqa: D102, override
         self._instance.write(str(path), format="lp", symbolic_solver_labels=True)
 
-    def _create_obj_list(self, key: str, component_type: _COMPONENTS_T) -> None:
+    def _create_obj_list(self, key: str, component_type: ALL_COMPONENTS_T) -> None:
         """Attach an empty pyomo kernel list object to the pyomo model object.
 
         Args:
@@ -388,7 +378,7 @@ class PyomoBackendModel(backend_model.BackendModel):
             )()
 
     def delete_component(  # noqa: D102, override
-        self, key: str, component_type: _COMPONENTS_T
+        self, key: str, component_type: ALL_COMPONENTS_T
     ) -> None:
         component_dict = getattr(self._instance, component_type)
         if key in component_dict:

--- a/src/calliope/config/model_def_schema.yaml
+++ b/src/calliope/config/model_def_schema.yaml
@@ -402,7 +402,7 @@ properties:
             title: Rated flow capacity.
             description: >-
               Sets `flow_cap` to a parameter in operate mode.
-              NOTE: this parameter cannot be used in `plan` mode as it clashes with the decision variable of the same name.
+              NOTE: this parameter cannot be used with `plan` as it clashes with the decision variable of the same name.
             x-unit: power.
 
           flow_cap_max:
@@ -542,7 +542,7 @@ properties:
             title: Area used.
             description: >-
               Sets `area_use` to a parameter in operate mode.
-              NOTE: this parameter cannot be used in `plan` mode as it clashes with the decision variable of the same name.
+              NOTE: this parameter cannot be used with `plan` as it clashes with the decision variable of the same name.
             x-unit: $\text{area}$.
 
           area_use_max:
@@ -580,7 +580,7 @@ properties:
             title: Rated storage capacity.
             description: >-
               Sets `storage_cap` to a parameter in operate mode.
-              NOTE: this parameter cannot be used in `plan` mode as it clashes with the decision variable of the same name.
+              NOTE: this parameter cannot be used with `plan` as it clashes with the decision variable of the same name.
             x-unit: $\text{area}$.
 
           storage_cap_max:
@@ -676,7 +676,7 @@ properties:
             title: Number of purchased units.
             description: >-
               Sets `purchased_units` to a parameter in operate mode.
-              NOTE: this parameter cannot be used in `plan` mode as it clashes with the decision variable of the same name.
+              NOTE: this parameter cannot be used with `plan` as it clashes with the decision variable of the same name.
             x-unit: integer
 
           purchased_units_min:
@@ -807,7 +807,7 @@ properties:
             title: Installed source consumption capacity.
             description: >-
               Sets `source_cap` to a parameter in operate mode.
-              NOTE: this parameter cannot be used in `plan` mode as it clashes with the decision variable of the same name.
+              NOTE: this parameter cannot be used with `plan` as it clashes with the decision variable of the same name.
             x-unit: power.
 
           source_cap_max:

--- a/src/calliope/example_models/national_scale/model.yaml
+++ b/src/calliope/example_models/national_scale/model.yaml
@@ -17,7 +17,7 @@ config:
 
   build:
     ensure_feasibility: true # Switches on the "unmet demand" constraint
-    mode: plan # Choices: plan, operate
+    mode: base # Choices: base, operate
 
   solve:
     solver: cbc

--- a/src/calliope/example_models/urban_scale/model.yaml
+++ b/src/calliope/example_models/urban_scale/model.yaml
@@ -14,9 +14,8 @@ config:
     # Time series data path - can either be a path relative to this file, or an absolute path
     time_subset: ["2005-07-01", "2005-07-02"] # Subset of timesteps
     broadcast_param_data: true  # allow single indexed parameter data entries to be broadcast across all index items, if there are multiple entries.
-    math:
-      extra:
-        additional_math: "additional_math.yaml"
+    extra_math:
+      additional_math: "additional_math.yaml"
 
   build:
     mode: base # Choices: base, operate

--- a/src/calliope/example_models/urban_scale/model.yaml
+++ b/src/calliope/example_models/urban_scale/model.yaml
@@ -19,7 +19,7 @@ config:
         additional_math: "additional_math.yaml"
 
   build:
-    mode: plan # Choices: plan, operate
+    mode: base # Choices: base, operate
     ensure_feasibility: true # Switching on unmet demand
     extra_math: ["additional_math"]
 

--- a/src/calliope/example_models/urban_scale/model.yaml
+++ b/src/calliope/example_models/urban_scale/model.yaml
@@ -14,11 +14,14 @@ config:
     # Time series data path - can either be a path relative to this file, or an absolute path
     time_subset: ["2005-07-01", "2005-07-02"] # Subset of timesteps
     broadcast_param_data: true  # allow single indexed parameter data entries to be broadcast across all index items, if there are multiple entries.
+    math:
+      extra:
+        additional_math: "additional_math.yaml"
 
   build:
     mode: plan # Choices: plan, operate
     ensure_feasibility: true # Switching on unmet demand
-    add_math: ["additional_math.yaml"]
+    extra_math: ["additional_math"]
 
   solve:
     solver: cbc

--- a/src/calliope/math/operate.yaml
+++ b/src/calliope/math/operate.yaml
@@ -1,6 +1,3 @@
-import:
-  - plan.yaml
-
 constraints:
   flow_capacity_per_storage_capacity_min.active: false
   flow_capacity_per_storage_capacity_max.active: false

--- a/src/calliope/math/spores.yaml
+++ b/src/calliope/math/spores.yaml
@@ -1,6 +1,3 @@
-import:
-  - plan.yaml
-
 constraints:
   total_system_cost_max:
     description: >

--- a/src/calliope/math/storage_inter_cluster.yaml
+++ b/src/calliope/math/storage_inter_cluster.yaml
@@ -1,9 +1,6 @@
 # Constraints and variables to improve the representation of storage technologies in a model using time clustering to optimise using representative days.
 # Although the pattern of storage fluctuations is fixed for all days linked to a specific representative day,
 # an excess or deficit of stored carrier can exist at the end of each of these days and can be utilised by the next representative day in the timeseries.
-import:
-  - plan.yaml
-
 constraints:
   storage_max:
     active: False

--- a/src/calliope/math/storage_inter_cluster.yaml
+++ b/src/calliope/math/storage_inter_cluster.yaml
@@ -1,6 +1,8 @@
 # Constraints and variables to improve the representation of storage technologies in a model using time clustering to optimise using representative days.
 # Although the pattern of storage fluctuations is fixed for all days linked to a specific representative day,
 # an excess or deficit of stored carrier can exist at the end of each of these days and can be utilised by the next representative day in the timeseries.
+import:
+  - plan.yaml
 
 constraints:
   storage_max:

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -142,16 +142,15 @@ class Model:
         """Initialise the model using pre-processed YAML files and optional dataframes/dicts.
 
         Args:
-            model_definition (calliope.AttrDict): preprocessed model configuration.
+            model_definition (dict | str | Path): preprocessed model configuration.
             scenario (str | None): scenario specified by users
             override_dict (dict | None): overrides to apply after scenarios.
             data_table_dfs (dict[str, pd.DataFrame] | None): files with additional model information.
             **kwargs: initialisation overrides.
         """
         (model_def_full, applied_overrides) = preprocess.prepare_model_definition(
-            model_definition, scenario, override_dict
+            model_definition, scenario, override_dict, **kwargs
         )
-        model_def_full.union({"config.init": kwargs}, allow_override=True)
         # Ensure model definition is correct
         model_def_schema.CalliopeModelDef(**model_def_full)
 

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -18,7 +18,7 @@ from calliope import backend, exceptions, io, preprocess
 from calliope.attrdict import AttrDict
 from calliope.postprocess import postprocess as postprocess_results
 from calliope.preprocess.model_data import ModelDataFactory
-from calliope.schemas import config_schema, model_def_schema
+from calliope.schemas import config_schema
 from calliope.util.logging import log_time
 from calliope.util.schema import MODEL_SCHEMA, extract_from_schema
 
@@ -148,18 +148,16 @@ class Model:
             data_table_dfs (dict[str, pd.DataFrame] | None): files with additional model information.
             **kwargs: initialisation overrides.
         """
-        (model_def_full, applied_overrides) = preprocess.prepare_model_definition(
-            model_definition, scenario, override_dict, **kwargs
-        )
-        # Ensure model definition is correct
-        model_def_schema.CalliopeModelDef(**model_def_full)
-
         log_time(
             LOGGER,
             self._timings,
             "model_run_creation",
             comment="Model: preprocessing stage 1 (model_run)",
         )
+        (model_def_full, applied_overrides) = preprocess.prepare_model_definition(
+            model_definition, scenario, override_dict, **kwargs
+        )
+
         model_config = config_schema.CalliopeConfig(**model_def_full.pop("config"))
 
         param_metadata = {"default": extract_from_schema(MODEL_SCHEMA, "default")}

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -137,7 +137,7 @@ class Model:
     @property
     def math_priority(self):
         """Order of math formulations, with the last overwriting previous ones."""
-        names = [self.config.init.math.base]
+        names = [self.config.init.base_math]
         if self.config.build.mode != "base":
             names.append(self.config.build.mode)
         names += self.config.build.extra_math

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -266,15 +266,8 @@ class Model:
         else:
             backend_input = self._model_data
 
-        math_names = []
-        if not self.config.build.ignore_base_math:
-            math_names.append(self.config.init.math.base)
-        if mode != "plan":  # TODO-Ivan: default should be None
-            math_names.append(mode)
-        math_names += self.config.build.extra_math
-
         self.applied_math = preprocess.build_applied_math(
-            self._def.math, math_names, add_math_dict
+            self.config, self._def.math, add_math_dict
         )
         self.backend = backend.get_model_backend(
             self.config.build, backend_input, self.applied_math

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -474,7 +474,7 @@ class Model:
             to_parameterise = extract_from_schema(MODEL_SCHEMA, "x-operate-param")
             if not self._is_solved:
                 raise exceptions.ModelError(
-                    "Cannot use plan mode capacity results in operate mode if a solution does not yet exist for the model."
+                    "Cannot use base mode capacity results in operate mode if a solution does not yet exist for the model."
                 )
             for parameter in to_parameterise.keys():
                 if parameter in self._model_data:

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -109,7 +109,7 @@ class Model:
     @property
     def name(self):
         """Get the model name."""
-        return self._model_data.attrs["name"]
+        return self._def.config.init.name
 
     @property
     def config(self) -> config_schema.CalliopeConfig:
@@ -157,7 +157,7 @@ class Model:
             LOGGER,
             self._timings,
             "model_run_creation",
-            comment="Model: preprocessing stage 1 (model_run)",
+            comment="Model: preprocessing stage 1 (definition)",
         )
         (model_def_full, applied_overrides) = preprocess.prepare_model_definition(
             model_definition, scenario, override_dict, **kwargs
@@ -165,6 +165,12 @@ class Model:
 
         self._def = model_def_schema.CalliopeModelDef(**model_def_full)
 
+        log_time(
+            LOGGER,
+            self._timings,
+            "model_data_creation",
+            comment="Model: preprocessing stage 2 (data)",
+        )
         param_metadata = {"default": extract_from_schema(MODEL_SCHEMA, "default")}
         attributes = {
             "calliope_version_defined": self._def.config.init.calliope_version,
@@ -185,15 +191,6 @@ class Model:
         model_data_factory.build()
 
         self._model_data = model_data_factory.dataset
-
-        log_time(
-            LOGGER,
-            self._timings,
-            "model_data_creation",
-            comment="Model: preprocessing stage 2 (model_data)",
-        )
-
-        self._model_data.attrs["name"] = self._def.config.init.name
 
         log_time(
             LOGGER,
@@ -270,7 +267,7 @@ class Model:
         else:
             backend_input = self._model_data
 
-        init_math_list = [] if self.config.build.ignore_mode_math else [mode]
+        init_math_list = [] if self.config.build.ignore_base_math else [mode]
         end_math_list = [] if add_math_dict is None else [add_math_dict]
         full_math_list = init_math_list + self.config.build.add_math + end_math_list
         LOGGER.debug(f"Math preprocessing | Loading math: {full_math_list}")

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -273,11 +273,11 @@ class Model:
         else:
             backend_input = self._model_data
 
-        self.applied_math = preprocess.build_applied_math(
+        applied_math = preprocess.build_applied_math(
             self.math_priority, self._def.math, add_math_dict
         )
         self.backend = backend.get_model_backend(
-            self.config.build, backend_input, self.applied_math
+            self.config.build, backend_input, applied_math
         )
         self.backend.add_optimisation_components()
 
@@ -287,6 +287,7 @@ class Model:
             "build_complete",
             comment="Model: backend build complete",
         )
+        self.applied_math = applied_math
         self._is_built = True
 
     def solve(self, force: bool = False, warmstart: bool = False, **kwargs) -> None:

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -134,6 +134,17 @@ class Model:
         """Get solved status."""
         return self._is_solved
 
+    @property
+    def math_priority(self):
+        """Order of math formulations, with the last overwriting previous ones."""
+        names = []
+        if not self.config.build.ignore_base_math:
+            names.append(self.config.init.math.base)
+        if self.config.build.mode != "base":
+            names.append(self.config.build.mode)
+        names += self.config.build.extra_math
+        return names
+
     def _init_from_model_definition(
         self,
         model_definition: dict | str | Path,
@@ -265,7 +276,7 @@ class Model:
             backend_input = self._model_data
 
         self.applied_math = preprocess.build_applied_math(
-            self.config, self._def.math, add_math_dict
+            self.math_priority, self._def.math, add_math_dict
         )
         self.backend = backend.get_model_backend(
             self.config.build, backend_input, self.applied_math

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -137,9 +137,7 @@ class Model:
     @property
     def math_priority(self):
         """Order of math formulations, with the last overwriting previous ones."""
-        names = []
-        if not self.config.build.ignore_base_math:
-            names.append(self.config.init.math.base)
+        names = [self.config.init.math.base]
         if self.config.build.mode != "base":
             names.append(self.config.build.mode)
         names += self.config.build.extra_math

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -38,8 +38,7 @@ class Model:
     """A Calliope Model."""
 
     _TS_OFFSET = pd.Timedelta(1, unit="nanoseconds")
-    ATTRS_SAVED = ("applied_math", "_def", "def_path")
-    # TODO-Ivan: check if def_path is still needed
+    ATTRS_SAVED = ("applied_math", "_def")
 
     def __init__(
         self,
@@ -74,7 +73,6 @@ class Model:
         self.applied_math: AttrDict
         self.backend: BackendModel
         self._def: model_def_schema.CalliopeModelDef
-        self.def_path: str | None = None
         self._start_window_idx: int = 0
         self._is_built: bool = False
         self._is_solved: bool = False
@@ -91,9 +89,6 @@ class Model:
                 )
             self._init_from_model_data(model_definition)
         else:
-            if not isinstance(model_definition, dict):
-                # Only file definitions allow relative files.
-                self.def_path = str(model_definition)
             self._init_from_model_definition(
                 model_definition, scenario, override_dict, data_table_dfs, **kwargs
             )
@@ -180,11 +175,12 @@ class Model:
             "scenario": scenario,
             "defaults": param_metadata["default"],
         }
-        # FIXME-config: remove config input once model_def_full uses pydantic
+
+        def_path = None if isinstance(model_definition, dict) else str(model_definition)
         model_data_factory = ModelDataFactory(
             self._def.config.init,
             model_def_full,
-            self.def_path,
+            def_path,
             data_table_dfs,
             attributes,
             param_metadata,

--- a/src/calliope/preprocess/__init__.py
+++ b/src/calliope/preprocess/__init__.py
@@ -3,4 +3,4 @@
 from calliope.preprocess.data_tables import DataTable
 from calliope.preprocess.model_data import ModelDataFactory
 from calliope.preprocess.model_definition import prepare_model_definition
-from calliope.preprocess.model_math import CalliopeMath
+from calliope.preprocess.model_math import build_applied_math, initialise_math

--- a/src/calliope/preprocess/__init__.py
+++ b/src/calliope/preprocess/__init__.py
@@ -3,4 +3,4 @@
 from calliope.preprocess.data_tables import DataTable
 from calliope.preprocess.model_data import ModelDataFactory
 from calliope.preprocess.model_definition import prepare_model_definition
-from calliope.preprocess.model_math import CalliopeMath, load_math_modes
+from calliope.preprocess.model_math import CalliopeMath

--- a/src/calliope/preprocess/__init__.py
+++ b/src/calliope/preprocess/__init__.py
@@ -3,4 +3,4 @@
 from calliope.preprocess.data_tables import DataTable
 from calliope.preprocess.model_data import ModelDataFactory
 from calliope.preprocess.model_definition import prepare_model_definition
-from calliope.preprocess.model_math import CalliopeMath
+from calliope.preprocess.model_math import CalliopeMath, load_math_modes

--- a/src/calliope/preprocess/model_definition.py
+++ b/src/calliope/preprocess/model_definition.py
@@ -54,7 +54,7 @@ def prepare_model_definition(
 
     # Pre-fill config. defaults and fetch the math definition
     config = config_schema.CalliopeConfig(**model_def["config"])
-    model_def["math"] = initialise_math(config.init.math, definition_path)
+    model_def["math"] = initialise_math(config.init.extra_math, definition_path)
 
     # Validate
     # TODO: returned object should be CalliopeModelDef

--- a/src/calliope/preprocess/model_definition.py
+++ b/src/calliope/preprocess/model_definition.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from calliope import exceptions
 from calliope.attrdict import AttrDict
 from calliope.io import read_rich_yaml, to_yaml
-from calliope.preprocess.model_math import load_math_modes
+from calliope.preprocess.model_math import initialise_math
 from calliope.schemas import config_schema, model_def_schema
 from calliope.util.tools import listify
 
@@ -40,10 +40,10 @@ def prepare_model_definition(
     # Identify the instantiation case
     if isinstance(model_definition, dict):
         raw_data = AttrDict(model_definition)
-        path = None
+        definition_path = None
     else:
         raw_data = read_rich_yaml(model_definition)
-        path = model_definition
+        definition_path = model_definition
 
     # Apply overrides and similar modifications 'on top' of the given definition
     model_def, applied_overrides = _load_scenario_overrides(
@@ -54,9 +54,7 @@ def prepare_model_definition(
 
     # Pre-fill config. defaults and fetch the math definition
     config = config_schema.CalliopeConfig(**model_def["config"])
-    model_def["math"] = load_math_modes(
-        path, config.init.base_math, config.init.extra_math
-    )
+    model_def["math"] = initialise_math(config.init.math, definition_path)
 
     # Validate
     # TODO-Ivan: should this return the schema object?

--- a/src/calliope/preprocess/model_definition.py
+++ b/src/calliope/preprocess/model_definition.py
@@ -57,7 +57,7 @@ def prepare_model_definition(
     model_def["math"] = initialise_math(config.init.math, definition_path)
 
     # Validate
-    # TODO-Ivan: should this return the schema object?
+    # TODO: returned object should be CalliopeModelDef
     model_def_schema.CalliopeModelDef(**model_def)
 
     return model_def, applied_overrides

--- a/src/calliope/preprocess/model_definition.py
+++ b/src/calliope/preprocess/model_definition.py
@@ -8,40 +8,52 @@ from pathlib import Path
 from calliope import exceptions
 from calliope.attrdict import AttrDict
 from calliope.io import read_rich_yaml, to_yaml
+from calliope.preprocess.model_math import load_math_modes
 from calliope.util.tools import listify
 
 LOGGER = logging.getLogger(__name__)
 
 
 def prepare_model_definition(
-    data: str | Path | dict,
+    model_definition: str | Path | dict,
     scenario: str | None = None,
     override_dict: dict | None = None,
+    **kwargs,
 ) -> tuple[AttrDict, str]:
     """Arrange model definition data folloging our standardised order of priority.
 
     Should always be called when defining calliope models from configuration files.
     The order of priority is:
 
-    - override_dict > scenarios > data section > template
+    - init_kwargs > override_dict > scenarios > data section > template
 
     Args:
-        data (str | Path | dict): model data file or dictionary.
+        model_definition (str | Path | dict): model data file or dictionary.
         scenario (str | None, optional): scenario to run. Defaults to None.
         override_dict (dict | None, optional): additional overrides. Defaults to None.
+        **kwargs: Initialisation overrides.
 
     Returns:
-        tuple[AttrDict, str]: _description_
+        tuple[AttrDict, str]: fully defined setup
     """
-    if isinstance(data, dict):
-        model_def = AttrDict(data)
+    # Identify the instantiation case
+    if isinstance(model_definition, dict):
+        raw_data = AttrDict(model_definition)
+        path = None
     else:
-        model_def = read_rich_yaml(data)
+        raw_data = read_rich_yaml(model_definition)
+        path = model_definition
+
+    # Apply overrides and similar modifications 'on top' of the given definition
     model_def, applied_overrides = _load_scenario_overrides(
-        model_def, scenario, override_dict
+        raw_data, scenario, override_dict
     )
-    template_solver = TemplateSolver(model_def)
-    model_def = template_solver.resolved_data
+    model_def = TemplateSolver(model_def).resolved_data
+    model_def.union({"config.init": kwargs}, allow_override=True)
+
+    # Fetch the math definition
+    extra_math = model_def.get_key("config.init.extra_math", {})
+    model_def["math"] = load_math_modes(path, extra_math)
 
     return model_def, applied_overrides
 

--- a/src/calliope/preprocess/model_definition.py
+++ b/src/calliope/preprocess/model_definition.py
@@ -21,7 +21,7 @@ def prepare_model_definition(
     override_dict: dict | None = None,
     **kwargs,
 ) -> tuple[AttrDict, str]:
-    """Arrange model definition data folloging our standardised order of priority.
+    """Arrange model definition data following our standardised order of priority.
 
     Should always be called when defining calliope models from configuration files.
     The order of priority is:

--- a/src/calliope/preprocess/model_math.py
+++ b/src/calliope/preprocess/model_math.py
@@ -5,7 +5,6 @@
 import importlib.resources
 import logging
 import typing
-from copy import deepcopy
 from pathlib import Path
 
 from calliope.attrdict import AttrDict
@@ -23,161 +22,6 @@ ORDERED_COMPONENTS_T = typing.Literal[
     "piecewise_constraints",
     "objectives",
 ]
-
-
-class CalliopeMath:
-    """Calliope math handling."""
-
-    ATTRS_TO_SAVE = ("history", "data")
-    ATTRS_TO_LOAD = ("history",)
-
-    def __init__(
-        self, math_to_add: list[str | dict], model_def_path: str | Path | None = None
-    ):
-        """Calliope YAML math handler.
-
-        Args:
-            math_to_add (list[str | dict]):
-                List of Calliope math to load.
-                If a string, it can be a reference to pre-/user-defined math files.
-                If a dictionary, it is equivalent in structure to a YAML math file.
-            model_def_path (str | Path | None, optional): Model definition path, needed when using relative paths. Defaults to None.
-        """
-        self.history: list[str] = []
-        self.data: AttrDict = AttrDict(
-            {name: {} for name in typing.get_args(ORDERED_COMPONENTS_T)}
-        )
-
-        for math in math_to_add:
-            if isinstance(math, dict):
-                self.add(AttrDict(math))
-            else:
-                self._init_from_string(math, model_def_path)
-
-    def __eq__(self, other):
-        """Compare between two model math instantiations."""
-        if not isinstance(other, CalliopeMath):
-            return NotImplemented
-        return self.history == other.history and self.data == other.data
-
-    def __iter__(self):
-        """Enable dictionary conversion."""
-        for key in self.ATTRS_TO_SAVE:
-            yield key, deepcopy(getattr(self, key))
-
-    def __repr__(self) -> str:
-        """Custom string representation of class."""
-        return f"""Calliope math definition dictionary with:
-    {len(self.data["variables"])} decision variable(s)
-    {len(self.data["global_expressions"])} global expression(s)
-    {len(self.data["constraints"])} constraint(s)
-    {len(self.data["piecewise_constraints"])} piecewise constraint(s)
-    {len(self.data["objectives"])} objective(s)
-        """
-
-    def add(self, math: AttrDict):
-        """Add math into the model.
-
-        Args:
-            math (AttrDict): Valid math dictionary.
-        """
-        self.data.union(math, allow_override=True)
-
-    @classmethod
-    def from_dict(cls, math_dict: dict) -> "CalliopeMath":
-        """Load a CalliopeMath object from a dictionary representation, recuperating relevant attributes.
-
-        Args:
-            math_dict (dict): Dictionary representation of a CalliopeMath object.
-
-        Returns:
-            CalliopeMath: Loaded from supplied dictionary representation.
-        """
-        new_self = cls([math_dict["data"]])
-        for attr in cls.ATTRS_TO_LOAD:
-            setattr(new_self, attr, math_dict[attr])
-        return new_self
-
-    def in_history(self, math_name: str) -> bool:
-        """Evaluate if math has already been applied.
-
-        Args:
-            math_name (str): Math file to check.
-
-        Returns:
-            bool: `True` if found in history. `False` otherwise.
-        """
-        return math_name in self.history
-
-    def validate(self) -> None:
-        """Test current math and optional external math against the MATH schema."""
-        ModeMath(**self.data)
-        LOGGER.info("Math preprocessing | validated math against schema.")
-
-    def _add_pre_defined_file(self, filename: str) -> None:
-        """Add pre-defined Calliope math.
-
-        Args:
-            filename (str): name of Calliope internal math (no suffix).
-
-        Raises:
-            ModelError: If math has already been applied.
-        """
-        if self.in_history(filename):
-            raise ModelError(
-                f"Math preprocessing | Overwriting with previously applied pre-defined math: '{filename}'."
-            )
-        with importlib.resources.as_file(
-            importlib.resources.files("calliope") / "math"
-        ) as f:
-            self._add_file(f / f"{filename}.yaml", filename)
-
-    def _add_user_defined_file(
-        self, relative_filepath: str | Path, model_def_path: str | Path | None
-    ) -> None:
-        """Add user-defined Calliope math, relative to the model definition path.
-
-        Args:
-            relative_filepath (str | Path): Path to user math, relative to model definition.
-            model_def_path (str | Path): Model definition path.
-
-        Raises:
-            ModelError: If file has already been applied.
-        """
-        math_name = str(relative_filepath)
-        if self.in_history(math_name):
-            raise ModelError(
-                f"Math preprocessing | Overwriting with previously applied user-defined math: '{relative_filepath}'."
-            )
-        self._add_file(relative_path(model_def_path, relative_filepath), math_name)
-
-    def _init_from_string(
-        self, math_to_add: str, model_def_path: str | Path | None = None
-    ):
-        """Load math definition from a list of files.
-
-        Args:
-            math_to_add (str): Calliope math file to load. Suffix implies user-math.
-            model_def_path (str | Path | None, optional): Model definition path. Defaults to None.
-
-        Raises:
-            ModelError: User-math requested without providing `model_def_path`.
-        """
-        if not math_to_add.endswith((".yaml", ".yml")):
-            self._add_pre_defined_file(math_to_add)
-        else:
-            self._add_user_defined_file(math_to_add, model_def_path)
-
-    def _add_file(self, yaml_filepath: Path, name: str) -> None:
-        try:
-            math = read_rich_yaml(yaml_filepath, allow_override=True)
-        except FileNotFoundError:
-            raise ModelError(
-                f"Math preprocessing | File does not exist: {yaml_filepath}"
-            )
-        self.add(math)
-        self.history.append(name)
-        LOGGER.info(f"Math preprocessing | added file '{name}'.")
 
 
 def _load_internal_math(math_to_add: str) -> AttrDict:
@@ -204,41 +48,44 @@ def initialise_math(
     Returns:
         AttrDict: dataset with individual math options.
     """
-    LOGGER.info(
-        f"Math preprocessing | initialising pre-defined {math_config.pre_defined}."
-    )
-    math_formulation = AttrDict(
+    LOGGER.info(f"Math init | loading pre-defined {math_config.pre_defined}.")
+    math_dataset = AttrDict(
         {name: _load_internal_math(name) for name in math_config.pre_defined}
     )
     if math_config.extra:
-        LOGGER.info(
-            f"Math preprocessing | initialising extras {list(math_config.extra.keys())}."
-        )
+        LOGGER.info(f"Math init | loading extras {list(math_config.extra.keys())}.")
         for name, path in math_config.extra.items():
-            math_formulation.union({name: _load_user_math(path, model_def_path)})
+            math_dataset.union({name: _load_user_math(path, model_def_path)})
 
-    return math_formulation
+    return math_dataset
 
 
-def build_applied_math(math_dict: AttrDict, names: list[str]) -> AttrDict:
+def build_applied_math(
+    init_math: dict, names: list[str], add_math: dict | None = None
+) -> AttrDict:
     """Construct a validated math dictionary, applying the requested math in order.
 
     Args:
-        math_dict (AttrDict): initialised math dataset.
-        names (list[str]): Names of the math to apply in order.
+        init_math (dict): initialised math dataset.
+        names (list[str]): names of the math to apply in order.
+        add_math (dict | None, optional): additional math to apply at the end. Defaults to None.
 
     Raises:
         ModelError: a given name was not found in the math dictionary.
 
     Returns:
-        AttrDict: validated math object.
+        AttrDict: constructed and validated math dataset.
     """
-    LOGGER.info(f"Math preprocessing | building applied math with {names}.")
+    LOGGER.info(f"Math build | building applied math with {names}.")
     math = AttrDict()
     for name in names:
         try:
-            math.union(math_dict[name], allow_override=True)
+            math.union(init_math[name], allow_override=True)
         except KeyError:
             raise ModelError(f"Requested math '{name}' was not initialised.")
+    if add_math:
+        LOGGER.info("Math build | appending additional math.")
+        math.union(add_math, allow_override=True)
+
     ModeMath(**math)  # TODO-Ivan: respect defaults!
     return math

--- a/src/calliope/preprocess/model_math.py
+++ b/src/calliope/preprocess/model_math.py
@@ -27,7 +27,7 @@ ORDERED_COMPONENTS_T = typing.Literal[
 def _load_internal_math(math_to_add: str) -> AttrDict:
     """Load standard Calliope math modes."""
     file = importlib.resources.files("calliope") / "math" / f"{math_to_add}.yaml"
-    return read_rich_yaml(str(file), allow_override=True)  # TODO-Ivan: remove
+    return read_rich_yaml(str(file))
 
 
 def _load_user_math(math_to_add: str, model_def_path: str | Path | None) -> AttrDict:
@@ -79,7 +79,7 @@ def build_applied_math(
     names = []
     if not config.build.ignore_base_math:
         names.append(config.init.math.base)
-    if config.build.mode != "plan":  # TODO-Ivan: default should be None?
+    if config.build.mode != "plan":  # TODO-Ivan: default should be "base"?
         names.append(config.build.mode)
     names += config.build.extra_math
 

--- a/src/calliope/preprocess/model_math.py
+++ b/src/calliope/preprocess/model_math.py
@@ -79,7 +79,7 @@ def build_applied_math(
     names = []
     if not config.build.ignore_base_math:
         names.append(config.init.math.base)
-    if config.build.mode != "plan":  # TODO-Ivan: default should be "base"?
+    if config.build.mode != "base":
         names.append(config.build.mode)
     names += config.build.extra_math
 

--- a/src/calliope/preprocess/model_math.py
+++ b/src/calliope/preprocess/model_math.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from calliope.attrdict import AttrDict
 from calliope.exceptions import ModelError
 from calliope.io import read_rich_yaml
-from calliope.schemas.math_schema import CalliopeMathDef
+from calliope.schemas.math_schema import ModeMath
 from calliope.util.tools import relative_path
 
 LOGGER = logging.getLogger(__name__)
@@ -110,7 +110,7 @@ class CalliopeMath:
 
     def validate(self) -> None:
         """Test current math and optional external math against the MATH schema."""
-        CalliopeMathDef(**self.data)
+        ModeMath(**self.data)
         LOGGER.info("Math preprocessing | validated math against schema.")
 
     def _add_pre_defined_file(self, filename: str) -> None:

--- a/src/calliope/preprocess/model_math.py
+++ b/src/calliope/preprocess/model_math.py
@@ -27,14 +27,14 @@ ORDERED_COMPONENTS_T = typing.Literal[
 
 def _load_internal_math(filename: str) -> AttrDict:
     """Load standard Calliope math modes."""
-    file = resources.files("calliope") / "math" / f"{filename}.yaml"
-    return read_rich_yaml(str(file))
+    file = Path(str(resources.files("calliope"))) / "math" / f"{filename}.yaml"
+    return read_rich_yaml(file)
 
 
 def _load_user_math(file_path: str, model_def_path: str | Path | None) -> AttrDict:
     """Load user defined math modes."""
     file = relative_path(model_def_path, file_path)
-    return read_rich_yaml(str(file))
+    return read_rich_yaml(file)
 
 
 def initialise_math(

--- a/src/calliope/preprocess/model_math.py
+++ b/src/calliope/preprocess/model_math.py
@@ -24,15 +24,15 @@ ORDERED_COMPONENTS_T = typing.Literal[
 ]
 
 
-def _load_internal_math(math_to_add: str) -> AttrDict:
+def _load_internal_math(filename: str) -> AttrDict:
     """Load standard Calliope math modes."""
-    file = importlib.resources.files("calliope") / "math" / f"{math_to_add}.yaml"
+    file = importlib.resources.files("calliope") / "math" / f"{filename}.yaml"
     return read_rich_yaml(str(file))
 
 
-def _load_user_math(math_to_add: str, model_def_path: str | Path | None) -> AttrDict:
+def _load_user_math(file_path: str, model_def_path: str | Path | None) -> AttrDict:
     """Load user defined math modes."""
-    file = relative_path(model_def_path, math_to_add)
+    file = relative_path(model_def_path, file_path)
     return read_rich_yaml(str(file))
 
 

--- a/src/calliope/preprocess/model_math.py
+++ b/src/calliope/preprocess/model_math.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from calliope.attrdict import AttrDict
 from calliope.exceptions import ModelError, ModelWarning
 from calliope.io import read_rich_yaml
-from calliope.schemas.config_schema import InitMath
 from calliope.schemas.math_schema import MathSchema
 from calliope.util.tools import relative_path
 
@@ -38,13 +37,17 @@ def _load_user_math(file_path: str, model_def_path: str | Path | None) -> AttrDi
 
 
 def initialise_math(
-    math_config: InitMath, model_def_path: str | Path | None = None
+    extra_math: dict[str, str] | None = None, model_def_path: str | Path | None = None
 ) -> AttrDict:
     """Loads and combines internal and user math files into a unified dataset.
 
     Args:
-        math_config (InitMath): math initialisation configuration.
-        model_def_path (str | Path | None): Path to the model definition directory.
+        base_math (str): name of the file to use as base.
+        extra_math (dict[str, str] | None, optional): names and paths to extra math. Defaults to None.
+        model_def_path (str | Path | None, optional): Path to the model definition. Defaults to None.
+
+    Raises:
+        ModelWarning: pre-defined file has been overwritten.
 
     Returns:
         AttrDict: dataset with individual math options.
@@ -54,9 +57,9 @@ def initialise_math(
     math_dataset = AttrDict(
         {name: _load_internal_math(name) for name in PRE_DEFINED_MATH}
     )
-    if math_config.extra:
-        LOGGER.info(f"Math init | loading extras {list(math_config.extra.keys())}.")
-        for name, path in math_config.extra.items():
+    if extra_math:
+        LOGGER.info(f"Math init | loading extras {list(extra_math.keys())}.")
+        for name, path in extra_math.items():
             if name in PRE_DEFINED_MATH:
                 raise ModelWarning(f"Overwriting pre-defined '{name}' math.")
             math_dataset.union({name: _load_user_math(path, model_def_path)})

--- a/src/calliope/schemas/config_schema.py
+++ b/src/calliope/schemas/config_schema.py
@@ -10,7 +10,7 @@ from pydantic import Field
 
 from calliope.schemas.general import AttrStr, CalliopeBaseModel, UniqueList
 
-Mode = Literal["plan", "operate", "spores"]
+Mode = Literal["base", "operate", "spores"]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -27,7 +27,7 @@ class InitMath(CalliopeBaseModel):
 
     base: AttrStr = "plan"
     """Name of the math file to build on top of.
-    Must be in either `pre_defined` or `extra`.
+    Can be any name in either `pre_defined` or `extra`.
     """
     pre_defined: UniqueList = Field(default=["plan", "operate", "spores"])
     "Pre-defined Calliope math files to include."
@@ -40,10 +40,10 @@ class Init(CalliopeBaseModel):
 
     model_config = {"title": "Model initialisation configuration"}
     name: str | None = None
-    """Model name"""
+    """Model name."""
 
     calliope_version: str | None = None
-    """Calliope framework version this model is intended for"""
+    """Calliope framework version this model is intended for."""
 
     broadcast_param_data: bool = Field(default=False)
     """
@@ -103,7 +103,7 @@ class BuildOperate(CalliopeBaseModel):
     """
 
     use_cap_results: bool = Field(default=False)
-    """If the model already contains `plan` mode results, use those optimal capacities as input parameters to the `operate` mode run."""
+    """If the model already contains `plan` results, use those optimal capacities as input parameters to the `operate` mode run."""
 
 
 class Build(CalliopeBaseModel):
@@ -111,7 +111,7 @@ class Build(CalliopeBaseModel):
 
     model_config = {"title": "Model build configuration"}
 
-    mode: Mode = Field(default="plan")
+    mode: Mode = Field(default="base")
     """Mode in which to run the optimisation.
     Triggers additional processing and appends additional math formulations.
     Math order: base -> mode
@@ -172,7 +172,7 @@ class SolveSpores(CalliopeBaseModel):
     """
 
     skip_baseline_run: bool = Field(default=False)
-    """If the model already contains `plan` mode results, use those as the initial base run results and start with SPORES iterations immediately."""
+    """If the model already contains `plan` results, use those as the initial base run results and start with SPORES iterations immediately."""
 
     tracking_parameter: str | None = None
     """If given, an input parameter name with which to filter technologies for consideration in SPORES scoring."""

--- a/src/calliope/schemas/config_schema.py
+++ b/src/calliope/schemas/config_schema.py
@@ -68,7 +68,7 @@ class Init(CalliopeBaseModel):
     base_math: AttrStr = Field(default="plan")
     """
     Base math formulation, where all other math will be applied.
-    Can be either Calliope's 'plan' formulation, or a path to a user file.
+    Can be either Calliope's 'plan' formulation, or a path to a user file that completely re-defines the math.
     Relative paths are assumed to be relative to the model definition file.
     """
 
@@ -117,10 +117,10 @@ class Build(CalliopeBaseModel):
     Relative paths will be assumed to be relative to the model definition file given when creating a calliope Model (`calliope.Model(model_definition=...)`)
     """
 
-    ignore_mode_math: bool = Field(default=False)
+    ignore_base_math: bool = Field(default=False)
     """
-    If True, do not initialise the mathematical formulation with the pre-defined math for the given run `mode`.
-    This option can be used to completely re-define the Calliope mathematical formulation.
+    If True, do not initialise the mathematical formulation with the math given in `config.init.base_math`.
+    This option is useful when comparing multiple distinct formulations.
     """
 
     backend: Literal["pyomo", "gurobi"] = Field(default="pyomo")

--- a/src/calliope/schemas/config_schema.py
+++ b/src/calliope/schemas/config_schema.py
@@ -123,12 +123,6 @@ class Build(CalliopeBaseModel):
     Math order: base -> mode -> extra
     """
 
-    ignore_base_math: bool = Field(default=False)
-    """
-    If True, do not initialise the base mathematical formulation with the math given in `config.init.math.base`.
-    This option may be useful when comparing multiple distinct formulations.
-    """
-
     backend: Literal["pyomo", "gurobi"] = Field(default="pyomo")
     """Module with which to build the optimisation problem."""
 

--- a/src/calliope/schemas/config_schema.py
+++ b/src/calliope/schemas/config_schema.py
@@ -19,20 +19,6 @@ SPORES_SCORING_OPTIONS = Literal[
 ]
 
 
-class InitMath(CalliopeBaseModel):
-    """Defines the math to add to the model.
-
-    Files will be loaded in the following order: base -> mode -> extra.
-    """
-
-    base: AttrStr = "plan"
-    """Name of the math file to build on top of.
-    Can be any pre-defined math file or user-defined `extra` file.
-    """
-    extra: dict[AttrStr, str] = Field(default={})
-    "Dictionary with the names and paths of additional math files."
-
-
 class Init(CalliopeBaseModel):
     """All configuration options used when initialising a Calliope model."""
 
@@ -79,8 +65,13 @@ class Init(CalliopeBaseModel):
     Automatically derived distances from lat/lon coordinates will be given in this unit.
     """
 
-    math: InitMath = InitMath()
-    """Math initialisation options."""
+    base_math: AttrStr = "plan"
+    """Name of the math file to build on top of.
+    Can be any pre-defined math file or user-defined file in `extra_math`.
+    """
+
+    extra_math: dict[AttrStr, str] = Field(default={})
+    "Dictionary with the names and paths of additional math files."
 
 
 class BuildOperate(CalliopeBaseModel):

--- a/src/calliope/schemas/config_schema.py
+++ b/src/calliope/schemas/config_schema.py
@@ -8,7 +8,7 @@ from typing import Literal
 
 from pydantic import Field
 
-from calliope.schemas.general import CalliopeBaseModel, UniqueList
+from calliope.schemas.general import AttrStr, CalliopeBaseModel, UniqueList
 
 Mode = Literal["plan", "operate", "spores"]
 
@@ -63,6 +63,13 @@ class Init(CalliopeBaseModel):
     """
     Unit of transmission link `distance` (m - metres, km - kilometres).
     Automatically derived distances from lat/lon coordinates will be given in this unit.
+    """
+
+    extra_math: dict[AttrStr, str] = Field(default={})
+    """
+    Dictionary of references to files which contain additional mathematical formulations in the form {'mode_name': 'file/path/math.yaml'}.
+    Ensure the file type is given as a suffix (".yaml" or ".yml").
+    Relative paths will be assumed to be relative to the model definition file given when creating a calliope Model (`calliope.Model(model_definition=...)`)
     """
 
 

--- a/src/calliope/schemas/config_schema.py
+++ b/src/calliope/schemas/config_schema.py
@@ -110,21 +110,23 @@ class Build(CalliopeBaseModel):
     """Base configuration options used when building a Calliope optimisation problem (`calliope.Model.build`)."""
 
     model_config = {"title": "Model build configuration"}
-    mode: Mode = Field(default="plan")
-    """Mode in which to run the optimisation."""
 
-    add_math: UniqueList[str] = Field(default=[])
+    mode: Mode = Field(default="plan")
+    """Mode in which to run the optimisation.
+    Triggers additional processing and appends additional math formulations.
+    Math order: base -> mode
     """
-    List of references to files which contain additional mathematical formulations to be applied on top of or instead of the base mode math.
-    If referring to an pre-defined Calliope math file (see documentation for available files), do not append the reference with ".yaml".
-    If referring to your own math file, ensure the file type is given as a suffix (".yaml" or ".yml").
-    Relative paths will be assumed to be relative to the model definition file given when creating a calliope Model (`calliope.Model(model_definition=...)`)
+
+    extra_math: UniqueList[str] = Field(default=[])
+    """
+    List of additional math to be applied on top of the base mode math and mode math.
+    Math order: base -> mode -> extra
     """
 
     ignore_base_math: bool = Field(default=False)
     """
-    If True, do not initialise the mathematical formulation with the math given in `config.init.base_math`.
-    This option is useful when comparing multiple distinct formulations.
+    If True, do not initialise the base mathematical formulation with the math given in `config.init.math.base`.
+    This option may be useful when comparing multiple distinct formulations.
     """
 
     backend: Literal["pyomo", "gurobi"] = Field(default="pyomo")

--- a/src/calliope/schemas/config_schema.py
+++ b/src/calliope/schemas/config_schema.py
@@ -19,6 +19,22 @@ SPORES_SCORING_OPTIONS = Literal[
 ]
 
 
+class InitMath(CalliopeBaseModel):
+    """Defines the math to add to the model.
+
+    Files will be loaded in the following order: base -> mode -> extra.
+    """
+
+    base: AttrStr = "plan"
+    """Name of the math file to build on top of.
+    Must be in either `pre_defined` or `extra`.
+    """
+    pre_defined: UniqueList = Field(default=["plan", "operate", "spores"])
+    "Pre-defined Calliope math files to include."
+    extra: dict[AttrStr, str] = Field(default={})
+    "Dictionary with the names and paths of additional math files."
+
+
 class Init(CalliopeBaseModel):
     """All configuration options used when initialising a Calliope model."""
 
@@ -65,20 +81,8 @@ class Init(CalliopeBaseModel):
     Automatically derived distances from lat/lon coordinates will be given in this unit.
     """
 
-    base_math: AttrStr = Field(default="plan")
-    """
-    Base math formulation, where all other math will be applied.
-    Can be either Calliope's 'plan' formulation, or a path to a user file that completely re-defines the math.
-    Relative paths are assumed to be relative to the model definition file.
-    """
-
-    extra_math: dict[AttrStr, str | None] = Field(default={})
-    """
-    Additional mathematical formulations that may be applied on top of the base math.
-    If referring to an pre-defined Calliope math file, do not append the reference with ".yaml" (e.g., 'operate').
-    If referring to your own math file, ensure the file type is given as a suffix (".yaml" or ".yml").
-    Relative paths are assumed to be relative to the model definition file.
-    """
+    math: InitMath = InitMath()
+    """Math initialisation options."""
 
 
 class BuildOperate(CalliopeBaseModel):

--- a/src/calliope/schemas/config_schema.py
+++ b/src/calliope/schemas/config_schema.py
@@ -27,10 +27,8 @@ class InitMath(CalliopeBaseModel):
 
     base: AttrStr = "plan"
     """Name of the math file to build on top of.
-    Can be any name in either `pre_defined` or `extra`.
+    Can be any pre-defined math file or user-defined `extra` file.
     """
-    pre_defined: UniqueList = Field(default=["plan", "operate", "spores"])
-    "Pre-defined Calliope math files to include."
     extra: dict[AttrStr, str] = Field(default={})
     "Dictionary with the names and paths of additional math files."
 

--- a/src/calliope/schemas/config_schema.py
+++ b/src/calliope/schemas/config_schema.py
@@ -65,11 +65,19 @@ class Init(CalliopeBaseModel):
     Automatically derived distances from lat/lon coordinates will be given in this unit.
     """
 
-    extra_math: dict[AttrStr, str] = Field(default={})
+    base_math: AttrStr = Field(default="plan")
     """
-    Dictionary of references to files which contain additional mathematical formulations in the form {'mode_name': 'file/path/math.yaml'}.
-    Ensure the file type is given as a suffix (".yaml" or ".yml").
-    Relative paths will be assumed to be relative to the model definition file given when creating a calliope Model (`calliope.Model(model_definition=...)`)
+    Base math formulation, where all other math will be applied.
+    Can be either Calliope's 'plan' formulation, or a path to a user file.
+    Relative paths are assumed to be relative to the model definition file.
+    """
+
+    extra_math: dict[AttrStr, str | None] = Field(default={})
+    """
+    Additional mathematical formulations that may be applied on top of the base math.
+    If referring to an pre-defined Calliope math file, do not append the reference with ".yaml" (e.g., 'operate').
+    If referring to your own math file, ensure the file type is given as a suffix (".yaml" or ".yml").
+    Relative paths are assumed to be relative to the model definition file.
     """
 
 

--- a/src/calliope/schemas/config_schema.py
+++ b/src/calliope/schemas/config_schema.py
@@ -92,7 +92,7 @@ class BuildOperate(CalliopeBaseModel):
     """
 
     use_cap_results: bool = Field(default=False)
-    """If the model already contains `plan` results, use those optimal capacities as input parameters to the `operate` mode run."""
+    """If the model already contains `base` results, use those optimal capacities as input parameters to the `operate` mode run."""
 
 
 class Build(CalliopeBaseModel):
@@ -155,7 +155,7 @@ class SolveSpores(CalliopeBaseModel):
     """
 
     skip_baseline_run: bool = Field(default=False)
-    """If the model already contains `plan` results, use those as the initial base run results and start with SPORES iterations immediately."""
+    """If the model already contains `base` results, use those as the initial base run results and start with SPORES iterations immediately."""
 
     tracking_parameter: str | None = None
     """If given, an input parameter name with which to filter technologies for consideration in SPORES scoring."""

--- a/src/calliope/schemas/general.py
+++ b/src/calliope/schemas/general.py
@@ -80,8 +80,7 @@ class CalliopeBaseModel(BaseModel):
                 )
                 new_dict[key] = val
         updated = super().model_copy(update=new_dict, deep=deep)
-        updated.model_validate(updated)
-        return updated
+        return updated.model_validate(updated)
 
     @classmethod
     def model_no_ref_schema(cls) -> AttrDict:

--- a/src/calliope/schemas/general.py
+++ b/src/calliope/schemas/general.py
@@ -76,7 +76,7 @@ class CalliopeBaseModel(BaseModel):
                 new_dict[key] = key_class.update(val)
             else:
                 LOGGER.info(
-                    f"Updating {self.model_config['title']} `{key}`: {key_class} -> {val}"
+                    f"Updating {self.__class__.__name__} `{key}`: {key_class} -> {val}"
                 )
                 new_dict[key] = val
         updated = super().model_copy(update=new_dict, deep=deep)

--- a/src/calliope/schemas/math_schema.py
+++ b/src/calliope/schemas/math_schema.py
@@ -180,22 +180,22 @@ class Objective(MathComponent):
 
 
 class ModeMath(CalliopeBaseModel):
-    """Mathematical definition of a Calliope mode.
+    """Mathematical definition of Calliope math.
 
     Contains mathematical programming components available for optimising with Calliope.
-    Modes can contain partial definitions if they are meant to be layered on top of another mode.
-    E.g.: layering 'plan' and 'operate'.
+    Can contain partial definitions if they are meant to be layered on top of another.
+    E.g.: layering 'plan' and 'operate' math.
     """
 
     model_config = {"title": "Model math schema"}
 
-    variables: dict[AttrStr, Variable]
+    variables: dict[AttrStr, Variable] | None = None
     """All decision variables to include in the optimisation problem."""
     global_expressions: dict[AttrStr, GlobalExpression] | None = None
     """All global expressions that can be applied to the optimisation problem."""
-    constraints: dict[AttrStr, Constraint]
+    constraints: dict[AttrStr, Constraint] | None = None
     """All constraints to apply to the optimisation problem."""
     piecewise_constraints: dict[AttrStr, PiecewiseConstraint] | None = None
     """All _piecewise_ constraints to apply to the optimisation problem."""
-    objectives: dict[AttrStr, Objective]
+    objectives: dict[AttrStr, Objective] | None = None
     """Possible objectives to apply to the optimisation problem."""

--- a/src/calliope/schemas/math_schema.py
+++ b/src/calliope/schemas/math_schema.py
@@ -179,22 +179,23 @@ class Objective(MathComponent):
     optimisation."""
 
 
-class CalliopeMathDef(CalliopeBaseModel):
-    """Calliope mathematical definition.
+class ModeMath(CalliopeBaseModel):
+    """Mathematical definition of a Calliope mode.
 
-    All options available to formulate math to use in solving an optimisation problem
-    with Calliope.
+    Contains mathematical programming components available for optimising with Calliope.
+    Modes can contain partial definitions if they are meant to be layered on top of another mode.
+    E.g.: layering 'plan' and 'operate'.
     """
 
     model_config = {"title": "Model math schema"}
 
+    variables: dict[AttrStr, Variable]
+    """All decision variables to include in the optimisation problem."""
+    global_expressions: dict[AttrStr, GlobalExpression] | None = None
+    """All global expressions that can be applied to the optimisation problem."""
     constraints: dict[AttrStr, Constraint]
     """All constraints to apply to the optimisation problem."""
     piecewise_constraints: dict[AttrStr, PiecewiseConstraint] | None = None
     """All _piecewise_ constraints to apply to the optimisation problem."""
-    global_expressions: dict[AttrStr, GlobalExpression] | None = None
-    """All global expressions that can be applied to the optimisation problem."""
-    variables: dict[AttrStr, Variable]
-    """All decision variables to include in the optimisation problem."""
     objectives: dict[AttrStr, Objective]
     """Possible objectives to apply to the optimisation problem."""

--- a/src/calliope/schemas/math_schema.py
+++ b/src/calliope/schemas/math_schema.py
@@ -9,72 +9,37 @@ from pydantic import Field
 from calliope.schemas.general import AttrStr, CalliopeBaseModel, NumericVal, UniqueList
 
 
-class EquationItem(CalliopeBaseModel):
-    """Equation item schema.
+class ExpressionItem(CalliopeBaseModel):
+    """Schema for equations, subexpressions and slices."""
 
-    Equations may define conditions (`where`) defining on which index items in the
-    product of sets (`foreach`) they will be applied. Conditions must be set up such
-    that a maximum of one equation can be applied per index item.
-    """
-
-    where: str | None = None
-    """Condition to determine whether the accompanying expression is built.
-    At all if `foreach` is not given, or for specific index items within the product
-    of the sets given by `foreach`."""
+    where: str = "True"
+    """Condition to determine whether the accompanying expression is built."""
     expression: str
-    """Equation expression valid for this component in the form LHS OPERATOR RHS, where
-    LHS and RHS are math expressions and OPERATOR is one of [==, <=, >=]."""
-
-
-class SubExpressionItem(CalliopeBaseModel):
-    """Sub-expression item schema.
-
-    Math sub-expressions which are used to replace any instances in which they are
-    referenced in a component's equations. They must be referenced by their
-    name preceded with the "$" symbol, e.g., `foo` in `$foo == 1` or `$foo + 1`.
+    """Expression for this component.
+    - Equations: LHS OPERATOR RHS, where LHS and RHS are math expressions and OPERATOR is one of [==, <=, >=].
+    - Subexpressions: be one term or a combination of terms using the operators [+, -, *, /, **].
+    - Slices: a list of set items or a call to a helper function.
     """
-
-    where: str | None = None
-    """Condition to determine whether the accompanying sub-expression is built."""
-    expression: str
-    """Math sub-expression which can be one term or a combination of terms using the
-    operators [+, -, *, /, **]."""
-
-
-class SliceItem(CalliopeBaseModel):
-    """Slice item schema.
-
-    Array index slices which are used to replace any instances in which they are
-    referenced in a component's equations or sub-expressions. They must be referenced
-    by their name preceded with the "$" symbol, e.g., `foo` in `flow_out_eff[techs=$foo]`.
-    """
-
-    where: str | None = None
-    """Condition to determine whether the accompanying index slice is built."""
-    expression: str
-    """Index slice expression, such as a list of set items or a call to a helper
-    function."""
 
 
 class MathComponent(CalliopeBaseModel):
     """Generic math component class."""
 
-    title: str | None = None
+    title: str = ""
     """The component long name, for use in visualisation."""
-    description: str | None = None
+    description: str = ""
     """A verbose description of the component."""
     active: bool = Field(default=True)
-    """If False, this component will be ignored entirely at the optimisation problem
-    build phase."""
+    """If False, this component will be ignored during the build phase."""
 
 
 class MathIndexedComponent(MathComponent):
     """Generic indexed component class."""
 
-    foreach: UniqueList[AttrStr] | None = None
+    foreach: UniqueList[AttrStr] = Field(default=[])
     """Sets (a.k.a. dimensions) of the model over which the math formulation component
     will be built."""
-    where: str | None = None
+    where: str = "True"
     """Top-level condition to determine whether the component exists in this
     optimisation problem. At all if `foreach` is not given, or for specific index items
     within the product of the sets given by `foreach`."""
@@ -83,11 +48,11 @@ class MathIndexedComponent(MathComponent):
 class Constraint(MathIndexedComponent):
     """Schema for named constraints."""
 
-    equations: list[EquationItem]
+    equations: list[ExpressionItem]
     """Constraint math equations."""
-    sub_expressions: dict[AttrStr, list[SubExpressionItem]] | None = None
+    sub_expressions: dict[AttrStr, list[ExpressionItem]] = Field(default={})
     """Constraint named sub-expressions."""
-    slices: dict[AttrStr, list[SliceItem]] | None = None
+    slices: dict[AttrStr, list[ExpressionItem]] = Field(default={})
     """Constraint named index slices."""
 
 
@@ -119,15 +84,15 @@ class GlobalExpression(MathIndexedComponent):
     be defined above `B`.
     """
 
-    unit: str | None = None
+    unit: str = ""
     """Generalised unit of the component (e.g., length, time, quantity_per_hour, ...)."""
     default: NumericVal | None = None
     """If set, will be the default value for the expression."""
-    equations: list[EquationItem]
+    equations: list[ExpressionItem]
     """Global expression math equations."""
-    sub_expressions: dict[AttrStr, list[SubExpressionItem]] | None = None
+    sub_expressions: dict[AttrStr, list[ExpressionItem]] = Field(default={})
     """Global expression named sub-expressions."""
-    slices: dict[AttrStr, list[SliceItem]] | None = None
+    slices: dict[AttrStr, list[ExpressionItem]] = Field(default={})
     """Global expression named index slices."""
 
 
@@ -138,9 +103,9 @@ class Bounds(CalliopeBaseModel):
     a single value that is applied across all decision variable index items.
     """
 
-    max: AttrStr | NumericVal | None = None
+    max: AttrStr | NumericVal
     """Decision variable upper bound, either as a reference to an input parameter or as a number."""
-    min: AttrStr | NumericVal | None = None
+    min: AttrStr | NumericVal
     """Decision variable lower bound, either as a reference to an input parameter or as a number."""
 
 
@@ -151,7 +116,7 @@ class Variable(MathIndexedComponent):
     objective for it to exist in the optimisation problem that is sent to the solver.
     """
 
-    unit: str | None = None
+    unit: str = ""
     """Generalised unit of the component (e.g., length, time, quantity_per_hour, ...)."""
     default: NumericVal | None = None
     """If set, will be the default value for the variable."""
@@ -168,18 +133,18 @@ class Objective(MathComponent):
     will be activated for the optimisation problem.
     """
 
-    equations: list[EquationItem]
+    equations: list[ExpressionItem]
     """Objective math equations."""
-    sub_expressions: dict[AttrStr, list[SubExpressionItem]] | None = None
+    sub_expressions: dict[AttrStr, list[ExpressionItem]] = Field(default={})
     """Objective named sub-expressions."""
-    slices: dict[AttrStr, list[SliceItem]] | None = None
+    slices: dict[AttrStr, list[ExpressionItem]] = Field(default={})
     """Objective named index slices."""
     sense: Literal["minimise", "maximise", "minimize", "maximize"]
     """Whether the objective function should be minimised or maximised in the
     optimisation."""
 
 
-class ModeMath(CalliopeBaseModel):
+class MathSchema(CalliopeBaseModel):
     """Mathematical definition of Calliope math.
 
     Contains mathematical programming components available for optimising with Calliope.
@@ -189,13 +154,13 @@ class ModeMath(CalliopeBaseModel):
 
     model_config = {"title": "Model math schema"}
 
-    variables: dict[AttrStr, Variable] | None = None
+    variables: dict[AttrStr, Variable] = Field(default={})
     """All decision variables to include in the optimisation problem."""
-    global_expressions: dict[AttrStr, GlobalExpression] | None = None
+    global_expressions: dict[AttrStr, GlobalExpression] = Field(default={})
     """All global expressions that can be applied to the optimisation problem."""
-    constraints: dict[AttrStr, Constraint] | None = None
+    constraints: dict[AttrStr, Constraint] = Field(default={})
     """All constraints to apply to the optimisation problem."""
-    piecewise_constraints: dict[AttrStr, PiecewiseConstraint] | None = None
+    piecewise_constraints: dict[AttrStr, PiecewiseConstraint] = Field(default={})
     """All _piecewise_ constraints to apply to the optimisation problem."""
-    objectives: dict[AttrStr, Objective] | None = None
+    objectives: dict[AttrStr, Objective] = Field(default={})
     """Possible objectives to apply to the optimisation problem."""

--- a/src/calliope/schemas/model_def_schema.py
+++ b/src/calliope/schemas/model_def_schema.py
@@ -11,7 +11,6 @@ from calliope.schemas.dimension_data_schema import (
     IndexedParam,
 )
 from calliope.schemas.general import AttrStr, CalliopeBaseModel
-from calliope.schemas.math_schema import ModeMath
 
 
 class CalliopeModelDef(CalliopeBaseModel):
@@ -24,4 +23,4 @@ class CalliopeModelDef(CalliopeBaseModel):
     data_tables: dict[AttrStr, CalliopeDataTable] | None = None
     nodes: dict[AttrStr, CalliopeNode] | None = None
     techs: dict[AttrStr, CalliopeTech] | None = None
-    math: dict[AttrStr, ModeMath]
+    math: dict[AttrStr, dict]

--- a/src/calliope/schemas/model_def_schema.py
+++ b/src/calliope/schemas/model_def_schema.py
@@ -11,6 +11,7 @@ from calliope.schemas.dimension_data_schema import (
     IndexedParam,
 )
 from calliope.schemas.general import AttrStr, CalliopeBaseModel
+from calliope.schemas.math_schema import ModeMath
 
 
 class CalliopeModelDef(CalliopeBaseModel):
@@ -23,3 +24,4 @@ class CalliopeModelDef(CalliopeBaseModel):
     data_tables: dict[AttrStr, CalliopeDataTable] | None = None
     nodes: dict[AttrStr, CalliopeNode] | None = None
     techs: dict[AttrStr, CalliopeTech] | None = None
+    math: dict[AttrStr, ModeMath]

--- a/tests/common/lp_files/cost_operation_variable.lp
+++ b/tests/common/lp_files/cost_operation_variable.lp
@@ -40,4 +40,3 @@ bounds
    0 <= variables(flow_out)(a__test_supply_gas__gas__2005_01_01_00_00) <= +inf
    0 <= variables(flow_out)(a__test_supply_gas__gas__2005_01_01_01_00) <= +inf
 end
-

--- a/tests/common/lp_files/cost_operation_variable_with_export.lp
+++ b/tests/common/lp_files/cost_operation_variable_with_export.lp
@@ -48,4 +48,3 @@ bounds
    0 <= variables(flow_out)(a__test_supply_gas__gas__2005_01_01_00_00) <= +inf
    0 <= variables(flow_out)(a__test_supply_gas__gas__2005_01_01_01_00) <= +inf
 end
-

--- a/tests/common/national_scale_from_data_tables/model.yaml
+++ b/tests/common/national_scale_from_data_tables/model.yaml
@@ -8,7 +8,7 @@ config:
 
   build:
     ensure_feasibility: true # Switches on the "unmet demand" constraint
-    mode: plan # Choices: plan, operate
+    mode: base # Choices: base, operate
 
   solve:
     solver: cbc

--- a/tests/common/test_model/energy_cap_per_storage_cap.yaml
+++ b/tests/common/test_model/energy_cap_per_storage_cap.yaml
@@ -4,7 +4,7 @@ config:
     time_subset: ["2005-01-01 00:00", "2005-01-01 01:00"]
 
   build:
-    mode: plan
+    mode: base
     ensure_feasibility: true
   solve:
     solver: cbc

--- a/tests/common/test_model/model.yaml
+++ b/tests/common/test_model/model.yaml
@@ -18,7 +18,7 @@ config:
     broadcast_param_data: true
 
   build:
-    mode: plan
+    mode: base
   solve:
     solver: cbc
 

--- a/tests/common/test_model/model_minimal.yaml
+++ b/tests/common/test_model/model_minimal.yaml
@@ -5,7 +5,7 @@ config:
   init:
     name: Minimal test model
   build:
-    mode: plan
+    mode: base
   solve:
     solver: cbc
 

--- a/tests/common/test_model/weighted_obj_func.yaml
+++ b/tests/common/test_model/weighted_obj_func.yaml
@@ -3,7 +3,7 @@ config:
     name: Cost capacity constraint test model
     time_subset: ["2005-01-01", "2005-01-01"]
   build:
-    mode: plan
+    mode: base
   solve:
     solver: cbc
 

--- a/tests/common/util.py
+++ b/tests/common/util.py
@@ -12,7 +12,7 @@ import calliope.preprocess
 def build_test_model_def(override_dict=None, scenario=None, model_file="model.yaml"):
     """Get the definition dictionary of a test model."""
     model_def, _ = calliope.preprocess.prepare_model_definition(
-        data=Path(__file__).parent / "test_model" / model_file,
+        model_definition=Path(__file__).parent / "test_model" / model_file,
         scenario=scenario,
         override_dict=override_dict,
     )

--- a/tests/common/util.py
+++ b/tests/common/util.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import xarray as xr
 
 import calliope
-import calliope.backend
 from calliope import preprocess
 
 
@@ -82,7 +81,7 @@ def build_lp(
     model: calliope.Model,
     outfile: str | Path,
     math_data: dict[str, dict | list] | None = None,
-) -> "calliope.backend.backend_model.BackendModel":
+) -> None:
     """
     Write a barebones LP file with which to compare in tests.
     All model parameters and variables will be loaded automatically, as well as a dummy objective if one isn't provided as part of `math`.
@@ -138,4 +137,3 @@ def build_lp(
 
     # reintroduce the trailing newline since both Pyomo and file formatters love them.
     Path(outfile).write_text("\n".join(stripped_lines) + "\n")
-    return model.backend

--- a/tests/common/util.py
+++ b/tests/common/util.py
@@ -92,7 +92,7 @@ def build_lp(
         outfile (str | Path): Path to LP file.
         math (dict | None, optional): All constraint/global expression/objective math to apply. Defaults to None.
     """
-    math = preprocess.build_applied_math(model.config, model._def.math)
+    math = preprocess.build_applied_math(model.math_priority, model._def.math)
 
     math_to_add = calliope.AttrDict()
     if isinstance(math_data, dict):

--- a/tests/common/util.py
+++ b/tests/common/util.py
@@ -132,7 +132,7 @@ def build_lp(
 
     model.build(
         add_math_dict=math.data,
-        ignore_mode_math=True,
+        ignore_base_math=True,
         objective=obj_to_activate,
         add_math=[],
         pre_validate_math_strings=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -296,10 +296,12 @@ def populate_backend_model(backend):
             "where": "with_inf",
             "bounds": {"min": -np.inf, "max": np.inf},
             "domain": "real",
+            "active": True,
         },
     )
     backend.add_variable(
-        "no_dim_var", {"bounds": {"min": -1, "max": 1}, "domain": "real"}
+        "no_dim_var",
+        {"bounds": {"min": -1, "max": 1}, "domain": "real", "active": True},
     )
     backend.add_global_expression(
         "multi_dim_expr",
@@ -307,6 +309,7 @@ def populate_backend_model(backend):
             "foreach": ["nodes", "techs"],
             "where": "all_true",
             "equations": [{"expression": "multi_dim_var * all_true"}],
+            "active": True,
         },
     )
     backend.add_constraint(
@@ -318,6 +321,7 @@ def populate_backend_model(backend):
                     "expression": "sum(multi_dim_expr, over=[nodes, techs]) + no_dim_var <= 2"
                 }
             ],
+            "active": True,
         },
     )
     return backend

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,7 @@ import xarray as xr
 
 from calliope.attrdict import AttrDict
 from calliope.backend import latex_backend_model, pyomo_backend_model
-from calliope.preprocess import CalliopeMath
-from calliope.schemas import config_schema
+from calliope.schemas import config_schema, math_schema
 from calliope.util.schema import MODEL_SCHEMA, extract_from_schema
 
 from .common.util import build_test_model as build_model
@@ -160,16 +159,7 @@ def simple_conversion_plus():
 
 @pytest.fixture(scope="module")
 def dummy_model_math():
-    math = {
-        "data": {
-            "constraints": {},
-            "variables": {},
-            "global_expressions": {},
-            "objectives": {},
-        },
-        "history": [],
-    }
-    return CalliopeMath.from_dict(math)
+    return AttrDict(math_schema.MathSchema().model_dump())
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -295,9 +295,12 @@ def populate_backend_model(backend):
             "foreach": ["nodes", "techs"],
             "where": "with_inf",
             "bounds": {"min": -np.inf, "max": np.inf},
+            "domain": "real",
         },
     )
-    backend.add_variable("no_dim_var", {"bounds": {"min": -1, "max": 1}})
+    backend.add_variable(
+        "no_dim_var", {"bounds": {"min": -1, "max": 1}, "domain": "real"}
+    )
     backend.add_global_expression(
         "multi_dim_expr",
         {

--- a/tests/test_backend_general.py
+++ b/tests/test_backend_general.py
@@ -282,6 +282,7 @@ class TestGetters:
             "description",
             "yaml_snippet",
             "coords_in_name",
+            "title",
         }
 
         assert not expected_keys.symmetric_difference(constraint.attrs.keys())

--- a/tests/test_backend_general.py
+++ b/tests/test_backend_general.py
@@ -334,6 +334,7 @@ class TestAdders:
                 {"expression": "sum(flow_out, over=[nodes, timesteps]) >= 100"}
             ],
             "where": "carrier_out",  # <- no error is raised because of this
+            "active": True,
         }
         constraint_name = "constraint-without-nan"
 
@@ -355,6 +356,7 @@ class TestAdders:
             "foreach": ["techs", "carriers"],
             "equations": [{"expression": "sum(flow_out, over=[nodes, timesteps])"}],
             "where": "carrier_out",  # <- no error is raised because of this
+            "active": True,
         }
         expression_name = "expression-without-nan"
 
@@ -379,6 +381,7 @@ class TestAdders:
             # as 'nodes' is not listed here, the constraint will have excess dimensions
             "foreach": ["techs", "carriers"],
             "equations": [{"expression": "flow_cap >= 100"}],
+            "active": True,
         }
         constraint_name = "constraint-with-excess-dimensions"
 
@@ -401,6 +404,7 @@ class TestAdders:
             # as 'nodes' is not listed here, the constraint will have excess dimensions
             "foreach": ["techs", "carriers"],
             "equations": [{"expression": "flow_cap + 1"}],
+            "active": True,
         }
         expr_name = "expr-with-excess-dimensions"
 
@@ -423,6 +427,7 @@ class TestAdders:
             "foreach": ["nodes", "techs"],
             "where": "True",
             "equations": [{"expression": eq, "where": "False"}],
+            "active": True,
         }
         adder("foo", constr_dict)
 
@@ -445,7 +450,7 @@ class TestAdders:
     def test_add_allnull_var(self, solved_model_func):
         """If `where` string resolves to False in all array elements, the component won't be built."""
         solved_model_func.backend.add_variable(
-            "foo", {"foreach": ["nodes"], "where": "False"}
+            "foo", {"foreach": ["nodes"], "where": "False", "active": True}
         )
         assert "foo" not in solved_model_func.backend._dataset.data_vars.keys()
 
@@ -453,7 +458,7 @@ class TestAdders:
         """If `where` string resolves to False in all array elements, the component won't be built."""
         eq = {"expression": "bigM", "where": "False"}
         solved_model_func.backend.add_objective(
-            "foo", {"equations": [eq, eq], "sense": "minimise"}
+            "foo", {"equations": [eq, eq], "sense": "minimise", "active": True}
         )
         assert "foo" not in solved_model_func.backend._dataset.data_vars.keys()
 
@@ -462,7 +467,7 @@ class TestAdders:
         eq = {"expression": "bigM", "where": "True"}
         with pytest.raises(calliope.exceptions.BackendError) as excinfo:
             solved_model_func.backend.add_objective(
-                "foo", {"equations": [eq, eq], "sense": "minimise"}
+                "foo", {"equations": [eq, eq], "sense": "minimise", "active": True}
             )
         assert check_error_or_warning(
             excinfo,
@@ -719,6 +724,7 @@ class TestPiecewiseConstraints:
             "y_values": "piecewise_y",
             "y_expression": "source_cap",
             "description": "FOO",
+            "active": True,
         }
 
     @pytest.fixture(scope="class")

--- a/tests/test_backend_gurobi.py
+++ b/tests/test_backend_gurobi.py
@@ -92,9 +92,9 @@ class TestNewBackend:
         )
 
     def test_add_valid_obj(self, simple_supply_gurobi):
-        eq = {"expression": "bigM", "where": "True"}
+        eq = {"expression": "bigM", "where": "True", "active": True}
         simple_supply_gurobi.backend.add_objective(
-            "foo", {"equations": [eq], "sense": "minimise"}
+            "foo", {"equations": [eq], "sense": "minimise", "active": True}
         )
         assert "foo" in simple_supply_gurobi.backend.objectives
 
@@ -106,7 +106,12 @@ class TestNewBackend:
 
     def test_new_objective_set(self, simple_supply_gurobi_func):
         simple_supply_gurobi_func.backend.add_objective(
-            "foo", {"equations": [{"expression": "bigM"}], "sense": "minimise"}
+            "foo",
+            {
+                "equations": [{"expression": "bigM"}],
+                "sense": "minimise",
+                "active": True,
+            },
         )
         simple_supply_gurobi_func.backend.set_objective("foo")
         simple_supply_gurobi_func.backend.verbose_strings()
@@ -118,7 +123,12 @@ class TestNewBackend:
     def test_new_objective_set_log(self, caplog, simple_supply_gurobi_func):
         caplog.set_level(logging.INFO)
         simple_supply_gurobi_func.backend.add_objective(
-            "foo", {"equations": [{"expression": "bigM"}], "sense": "minimise"}
+            "foo",
+            {
+                "equations": [{"expression": "bigM"}],
+                "sense": "minimise",
+                "active": True,
+            },
         )
         simple_supply_gurobi_func.backend.set_objective("foo")
         assert ":foo | Objective activated." in caplog.text
@@ -355,6 +365,7 @@ class TestPiecewiseConstraints:
             "y_values": "piecewise_y",
             "y_expression": "source_cap",
             "description": "FOO",
+            "active": True,
         }
 
     @pytest.fixture(scope="class")

--- a/tests/test_backend_latex_backend.py
+++ b/tests/test_backend_latex_backend.py
@@ -42,6 +42,7 @@ class TestLatexBackendModel:
                 "foreach": ["nodes", "techs"],
                 "where": "with_inf",
                 "bounds": {"min": 0, "max": 1},
+                "domain": "real",
             },
         )
         # some null values might be introduced by the foreach array, so we just check the upper bound
@@ -63,6 +64,7 @@ class TestLatexBackendModel:
                 "foreach": ["nodes", "techs"],
                 "where": "False",
                 "bounds": {"min": 0, "max": 1},
+                "domain": "real",
             },
         )
         # some null values might be introduced by the foreach array, so we just check the upper bound

--- a/tests/test_backend_latex_backend.py
+++ b/tests/test_backend_latex_backend.py
@@ -130,6 +130,7 @@ class TestLatexBackendModel:
                 "foreach": ["nodes", "techs"],
                 "where": "with_inf",
                 "equations": [{"expression": "multi_dim_var >= no_dims"}],
+                "active": True,
             },
         )
         # some null values might be introduced by the foreach array, so we just check the upper bound

--- a/tests/test_backend_pyomo.py
+++ b/tests/test_backend_pyomo.py
@@ -1630,7 +1630,7 @@ class TestNewBackend:
     def temp_path(self, tmpdir_factory):
         return tmpdir_factory.mktemp("custom_math")
 
-    @pytest.mark.parametrize("mode", ["operate", "plan"])
+    @pytest.mark.parametrize("mode", ["operate", "base"])
     def test_add_run_mode_custom_math(self, caplog, mode):
         caplog.set_level(logging.DEBUG)
         m = build_model({}, "simple_supply,two_hours,investment_costs")

--- a/tests/test_backend_pyomo.py
+++ b/tests/test_backend_pyomo.py
@@ -12,7 +12,6 @@ import calliope
 import calliope.backend
 import calliope.exceptions as exceptions
 from calliope import preprocess
-from calliope.backend import PyomoBackendModel
 
 from .common.util import build_test_model as build_model
 from .common.util import check_error_or_warning, check_variable_exists
@@ -1630,17 +1629,6 @@ class TestNewBackend:
     def temp_path(self, tmpdir_factory):
         return tmpdir_factory.mktemp("custom_math")
 
-    @pytest.mark.parametrize("mode", ["operate", "base"])
-    def test_add_run_mode_custom_math(self, caplog, mode):
-        caplog.set_level(logging.DEBUG)
-        m = build_model({}, "simple_supply,two_hours,investment_costs")
-        math = preprocess.build_applied_math(m.config, m._def.math)
-
-        build_config = m.config.build.update({"mode": mode})
-        backend = PyomoBackendModel(m.inputs, math, build_config)
-
-        assert backend.math == math
-
     def test_add_run_mode_custom_math_before_build(self, caplog):
         """Run mode math is applied before anything else."""
         caplog.set_level(logging.DEBUG)
@@ -2283,7 +2271,9 @@ class TestValidateMathDict:
     def validate_math(self):
         def _validate_math(math_dict: dict):
             m = build_model({}, "simple_supply,investment_costs")
-            math = preprocess.build_applied_math(m.config, m._def.math, math_dict)
+            math = preprocess.build_applied_math(
+                m.math_priority, m._def.math, math_dict
+            )
             backend = calliope.backend.PyomoBackendModel(
                 m._model_data, math, m.config.build
             )

--- a/tests/test_backend_pyomo.py
+++ b/tests/test_backend_pyomo.py
@@ -1523,7 +1523,7 @@ class TestClusteringConstraints:
         override = {
             "config.init.time_subset": ["2005-01-01", "2005-01-04"],
             "config.init.time_cluster": "data_tables/cluster_days.csv",
-            "config.build.add_math": (
+            "config.build.extra_math": (
                 ["storage_inter_cluster"] if storage_inter_cluster else []
             ),
             "config.build.cyclic_storage": cyclic,

--- a/tests/test_backend_pyomo.py
+++ b/tests/test_backend_pyomo.py
@@ -1756,7 +1756,7 @@ class TestNewBackend:
 
     def test_add_allnull_var(self, simple_supply):
         simple_supply.backend.add_variable(
-            "foo", {"foreach": ["nodes"], "where": "False"}
+            "foo", {"foreach": ["nodes"], "where": "False", "active": True}
         )
         assert "foo" not in simple_supply.backend._instance.variables.keys()
 
@@ -1770,6 +1770,7 @@ class TestNewBackend:
             "foreach": ["nodes", "techs"],
             "where": "True",
             "equations": [{"expression": eq, "where": "False"}],
+            "active": True,
         }
         adder("foo", constr_dict)
 
@@ -1796,6 +1797,7 @@ class TestNewBackend:
             "equations": [
                 {"expression": "sum(flow_out, over=[nodes, timesteps]) >= 100"}
             ],
+            "active": True,
             # "where": "carrier_out",  # <- no error would be raised with this uncommented
         }
         constraint_name = "constraint-with-nan"
@@ -1838,7 +1840,7 @@ class TestNewBackend:
     def test_add_valid_obj(self, simple_supply):
         eq = {"expression": "bigM", "where": "True"}
         simple_supply.backend.add_objective(
-            "foo", {"equations": [eq], "sense": "minimise"}
+            "foo", {"equations": [eq], "sense": "minimise", "active": True}
         )
         assert "foo" in simple_supply.backend.objectives
         assert not simple_supply.backend.objectives.foo.item().active
@@ -1849,7 +1851,12 @@ class TestNewBackend:
 
     def test_new_objective_set(self, simple_supply_build_func):
         simple_supply_build_func.backend.add_objective(
-            "foo", {"equations": [{"expression": "bigM"}], "sense": "minimise"}
+            "foo",
+            {
+                "equations": [{"expression": "bigM"}],
+                "sense": "minimise",
+                "active": True,
+            },
         )
         simple_supply_build_func.backend.set_objective("foo")
 
@@ -1860,7 +1867,12 @@ class TestNewBackend:
     def test_new_objective_set_log(self, caplog, simple_supply_build_func):
         caplog.set_level(logging.INFO)
         simple_supply_build_func.backend.add_objective(
-            "foo", {"equations": [{"expression": "bigM"}], "sense": "minimise"}
+            "foo",
+            {
+                "equations": [{"expression": "bigM"}],
+                "sense": "minimise",
+                "active": True,
+            },
         )
         simple_supply_build_func.backend.set_objective("foo")
         assert ":foo | Objective activated." in caplog.text
@@ -2067,6 +2079,7 @@ class TestPiecewiseConstraints:
             "y_values": "piecewise_y",
             "y_expression": "sum(flow_in, over=timesteps)",
             "description": "FOO",
+            "active": True,
         }
 
     @pytest.fixture(scope="class")

--- a/tests/test_core_model.py
+++ b/tests/test_core_model.py
@@ -501,13 +501,6 @@ class TestBuild:
     def init_model(self):
         return build_model({}, "simple_supply,two_hours,investment_costs")
 
-    def test_ignore_mode_math(self, init_model):
-        init_model.build(ignore_base_math=True, force=True)
-        assert all(
-            var.obj_type == "parameters"
-            for var in init_model.backend._dataset.data_vars.values()
-        )
-
     def test_add_math_dict_with_mode_math(self, init_model):
         init_model.build(
             add_math_dict={"constraints": {"system_balance": {"active": False}}},
@@ -515,13 +508,6 @@ class TestBuild:
         )
         assert len(init_model.backend.constraints) > 0
         assert "system_balance" not in init_model.backend.constraints
-
-    def test_add_math_dict_ignore_mode_math(self, init_model):
-        new_var = {
-            "variables": {"foo": {"active": True, "bounds": {"min": -1, "max": 1}}}
-        }
-        init_model.build(add_math_dict=new_var, ignore_base_math=True, force=True)
-        assert set(init_model.backend.variables) == {"foo"}
 
 
 class TestSolve:

--- a/tests/test_core_model.py
+++ b/tests/test_core_model.py
@@ -398,7 +398,7 @@ class TestBuild:
         return build_model({}, "simple_supply,two_hours,investment_costs")
 
     def test_ignore_mode_math(self, init_model):
-        init_model.build(ignore_mode_math=True, force=True)
+        init_model.build(ignore_base_math=True, force=True)
         assert all(
             var.obj_type == "parameters"
             for var in init_model.backend._dataset.data_vars.values()
@@ -416,7 +416,7 @@ class TestBuild:
         new_var = {
             "variables": {"foo": {"active": True, "bounds": {"min": -1, "max": 1}}}
         }
-        init_model.build(add_math_dict=new_var, ignore_mode_math=True, force=True)
+        init_model.build(add_math_dict=new_var, ignore_base_math=True, force=True)
         assert set(init_model.backend.variables) == {"foo"}
 
 

--- a/tests/test_core_util.py
+++ b/tests/test_core_util.py
@@ -11,7 +11,7 @@ import pytest
 
 import calliope
 from calliope.io import read_rich_yaml
-from calliope.schemas.math_schema import CalliopeMathDef
+from calliope.schemas.math_schema import ModeMath
 from calliope.util import schema
 from calliope.util.generate_runs import generate_runs
 from calliope.util.logging import log_time
@@ -194,7 +194,7 @@ class TestValidateDict:
         base_math.union(
             read_rich_yaml(dict_path, allow_override=True), allow_override=True
         )
-        CalliopeMathDef(**base_math)
+        ModeMath(**base_math)
 
 
 class TestExtractFromSchema:

--- a/tests/test_core_util.py
+++ b/tests/test_core_util.py
@@ -11,7 +11,7 @@ import pytest
 
 import calliope
 from calliope.io import read_rich_yaml
-from calliope.schemas.math_schema import ModeMath
+from calliope.schemas.math_schema import MathSchema
 from calliope.util import schema
 from calliope.util.generate_runs import generate_runs
 from calliope.util.logging import log_time
@@ -194,7 +194,7 @@ class TestValidateDict:
         base_math.union(
             read_rich_yaml(dict_path, allow_override=True), allow_override=True
         )
-        ModeMath(**base_math)
+        MathSchema(**base_math)
 
 
 class TestExtractFromSchema:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -122,7 +122,7 @@ class TestIO:
             ("serialised_nones", ["foo_none", "scenario"]),
             (
                 "serialised_dicts",
-                ["foo_dict", "foo_attrdict", "defaults", "config", "applied_math"],
+                ["foo_dict", "foo_attrdict", "defaults", "_def", "applied_math"],
             ),
             ("serialised_sets", ["foo_set", "foo_set_1_item"]),
             ("serialised_single_element_list", ["foo_list_1_item", "foo_set_1_item"]),

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -277,7 +277,12 @@ class CustomMathExamples(ABC):
                 overrides = {}
 
             model = build_test_model(
-                {"config.build.add_math": [abs_filepath], **overrides}, scenario
+                {
+                    "config.init.math.extra": {"user_math": abs_filepath},
+                    "config.build.extra_math": ["user_math"],
+                    **overrides,
+                },
+                scenario,
             )
 
             compare_lps(model, custom_math, filename)

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -95,7 +95,8 @@ class TestBaseMath:
     @pytest.fixture(scope="class")
     def init_math_config(self, barebones_math_file):
         return {
-            "math": {"base": "barebones", "extra": {"barebones": barebones_math_file}}
+            "base_math": "barebones",
+            "extra_math": {"barebones": barebones_math_file},
         }
 
     @pytest.mark.parametrize(
@@ -390,9 +391,9 @@ class CustomMathExamples(ABC):
 
             model = util.build_test_model(
                 {
-                    "config.init.math": {
-                        "base": "barebones",
-                        "extra": {"barebones": barebones_math_file},
+                    "config.init": {
+                        "base_math": "barebones",
+                        "extra_math": {"barebones": barebones_math_file},
                     },
                     **overrides,
                 },

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -6,13 +6,13 @@ import numpy as np
 import pytest
 from pyomo.repn.tests import lp_diff
 
-from calliope import AttrDict
-from calliope.io import read_rich_yaml
+from calliope import AttrDict, Model, io
+from calliope.preprocess import model_math
 
-from .common.util import build_lp, build_test_model
+from .common import util
 
 CALLIOPE_DIR: Path = importlib.resources.files("calliope")
-PLAN_MATH: AttrDict = read_rich_yaml(CALLIOPE_DIR / "math" / "plan.yaml")
+PLAN_MATH: AttrDict = io.read_rich_yaml(CALLIOPE_DIR / "math" / "plan.yaml")
 
 
 @pytest.fixture(scope="class")
@@ -20,7 +20,7 @@ def compare_lps(tmpdir_factory):
     def _compare_lps(model, custom_math, filename):
         lp_file = filename + ".lp"
         generated_file = Path(tmpdir_factory.mktemp("lp_files")) / lp_file
-        backend = build_lp(model, generated_file, custom_math)  # noqa: F841
+        util.build_lp(model, generated_file, custom_math)
         expected_file = Path(__file__).parent / "common" / "lp_files" / lp_file
         # Pyomo diff ignores trivial numeric differences (10 == 10.0)
         # But it does not ignore a re-ordering of components
@@ -37,18 +37,84 @@ def compare_lps(tmpdir_factory):
     return _compare_lps
 
 
+@pytest.fixture(scope="module")
+def barebones_math_file(tmp_path_factory) -> str:
+    """Write a barebones calliope math file.
+
+    Setup:
+    - No constraints.
+    - All variables and expressions in `plan.yaml`.
+    - A standard dummy objective.
+    """
+    math = AttrDict({k: PLAN_MATH[k] for k in {"variables", "global_expressions"}})
+    math.set_key(
+        "objectives.dummy_obj",
+        {"equations": [{"expression": "1 + 1"}], "sense": "minimize"},
+    )
+    barebones_path = tmp_path_factory.mktemp("barebones") / "barebones.yaml"
+    io.to_yaml(math, barebones_path)
+    return str(barebones_path)
+
+
 def _diff_files(file1, file2):
     file1_lines = file1.read_text().split("\n")
     file2_lines = file2.read_text().split("\n")
     return set(file1_lines).symmetric_difference(file2_lines)
 
 
+def build_lp_file(
+    model: Model,
+    test_math: dict,
+    outfile: str | Path,
+    objective: str = "dummy_obj",
+    extra_math_files: list[str] | None = None,
+):
+    if extra_math_files is None:
+        extra_math_files = []
+    model.build(
+        add_math_dict=test_math,
+        objective=objective,
+        extra_math=extra_math_files,
+        pre_validate_math_strings=False,
+    )
+    model.backend.verbose_strings()
+    model.backend.to_lp(outfile)
+
+    # strip trailing whitespace from `outfile` after the fact,
+    # so it can be reliably compared other files in future
+    with Path(outfile).open("r") as f:
+        stripped_lines = []
+        while line := f.readline():
+            stripped_lines.append(line.rstrip())
+    # reintroduce the trailing newline.
+    Path(outfile).write_text("\n".join(stripped_lines) + "\n")
+
+
+def compare_lps_new(generated_lp: Path):
+    expected_file = Path(__file__).parent / "common" / "lp_files" / generated_lp.name
+    diff_ordered = lp_diff.load_and_compare_lp_baseline(
+        generated_lp.as_posix(), expected_file.as_posix()
+    )
+    # Our unordered comparison ignores component ordering but cannot handle
+    # trivial differences in numerics (as everything is a string to it)
+    diff_unordered = _diff_files(generated_lp, expected_file)
+    # If one of the above matches across the board, we're good to go.
+    assert diff_ordered == ([], []) or not diff_unordered
+
+
 class TestBaseMath:
     TEST_REGISTER: set = set()
 
     @pytest.fixture(scope="class")
-    def base_math(self):
-        return read_rich_yaml(CALLIOPE_DIR / "math" / "plan.yaml")
+    def lp_temp_path(self, tmp_path_factory):
+        """Use a single temp. location to make manual checks easier."""
+        return tmp_path_factory.mktemp("lp_files")
+
+    @pytest.fixture(scope="class")
+    def init_math_config(self, barebones_math_file):
+        return {
+            "math": {"base": "barebones", "extra": {"barebones": barebones_math_file}}
+        }
 
     @pytest.mark.parametrize(
         ("variable", "constraint", "overrides"),
@@ -64,7 +130,7 @@ class TestBaseMath:
         ],
     )
     def test_capacity_variables_and_bounds(
-        self, compare_lps, variable, constraint, overrides
+        self, lp_temp_path, init_math_config, variable, constraint, overrides
     ):
         """Check that variables are initiated with the appropriate bounds,
         and that the lower bound is updated from zero via a separate constraint if required.
@@ -72,15 +138,6 @@ class TestBaseMath:
         constraint_full = f"constraints.{constraint}"
         self.TEST_REGISTER.add(f"variables.{variable}")
         self.TEST_REGISTER.add(constraint_full)
-        model = build_test_model(
-            {
-                f"nodes.b.techs.test_supply_elec.{variable}_max": 100,
-                f"nodes.a.techs.test_supply_elec.{variable}_min": 1,
-                f"nodes.a.techs.test_supply_elec.{variable}_max": np.nan,
-                **overrides,
-            },
-            "simple_supply,two_hours,investment_costs",
-        )
         # Custom objective ensures that all variables appear in the LP file.
         # Variables not found in either an objective or constraint will never appear in the LP.
         sum_in_objective = "[nodes]" if variable != "flow_cap" else "[nodes, carriers]"
@@ -97,77 +154,110 @@ class TestBaseMath:
         custom_math = AttrDict(
             {constraint_full: PLAN_MATH.get_key(constraint_full), **custom_objective}
         )
-        compare_lps(model, custom_math, variable)
+        model = util.build_test_model(
+            {
+                f"nodes.b.techs.test_supply_elec.{variable}_max": 100,
+                f"nodes.a.techs.test_supply_elec.{variable}_min": 1,
+                f"nodes.a.techs.test_supply_elec.{variable}_max": np.nan,
+                **overrides,
+            },
+            "simple_supply,two_hours,investment_costs",
+            **init_math_config,
+        )
+        # compare_lps(model, custom_math, variable)
+        lp_file = lp_temp_path / (variable + ".lp")
+        build_lp_file(model, custom_math, lp_file, objective="foo")
+        compare_lps_new(lp_file)
 
-    def test_storage_max(self, compare_lps):
+    def test_storage_max(self, lp_temp_path, init_math_config):
         self.TEST_REGISTER.add("constraints.storage_max")
-        model = build_test_model(scenario="simple_storage,two_hours,investment_costs")
+        model = util.build_test_model(
+            scenario="simple_storage,two_hours,investment_costs", **init_math_config
+        )
         custom_math = {
             "constraints": {"storage_max": PLAN_MATH.constraints.storage_max}
         }
-        compare_lps(model, custom_math, "storage_max")
+        lp_file = lp_temp_path / "storage_max.lp"
+        build_lp_file(model, custom_math, lp_file)
+        compare_lps_new(lp_file)
 
-    def test_flow_out_max(self, compare_lps):
+    def test_flow_out_max(self, lp_temp_path, init_math_config):
         self.TEST_REGISTER.add("constraints.flow_out_max")
-        model = build_test_model({}, "simple_supply,two_hours,investment_costs")
+        model = util.build_test_model(
+            {}, "simple_supply,two_hours,investment_costs", **init_math_config
+        )
 
         custom_math = {
             "constraints": {"flow_out_max": PLAN_MATH.constraints.flow_out_max}
         }
-        compare_lps(model, custom_math, "flow_out_max")
+        lp_file = lp_temp_path / "flow_out_max.lp"
+        build_lp_file(model, custom_math, lp_file)
+        compare_lps_new(lp_file)
 
-    def test_balance_conversion(self, compare_lps):
+    def test_balance_conversion(self, lp_temp_path, init_math_config):
         self.TEST_REGISTER.add("constraints.balance_conversion")
 
-        model = build_test_model(
-            scenario="simple_conversion,two_hours,investment_costs"
+        model = util.build_test_model(
+            scenario="simple_conversion,two_hours,investment_costs", **init_math_config
         )
         custom_math = {
             "constraints": {
                 "balance_conversion": PLAN_MATH.constraints.balance_conversion
             }
         }
+        lp_file = lp_temp_path / "balance_conversion.lp"
+        build_lp_file(model, custom_math, lp_file)
+        compare_lps_new(lp_file)
 
-        compare_lps(model, custom_math, "balance_conversion")
-
-    def test_source_max(self, compare_lps):
+    def test_source_max(self, lp_temp_path, init_math_config):
         self.TEST_REGISTER.add("constraints.source_max")
-        model = build_test_model(
-            {}, "simple_supply_plus,resample_two_days,investment_costs"
+        model = util.build_test_model(
+            {},
+            "simple_supply_plus,resample_two_days,investment_costs",
+            **init_math_config,
         )
         custom_math = {
             "constraints": {"my_constraint": PLAN_MATH.constraints.source_max}
         }
-        compare_lps(model, custom_math, "source_max")
+        lp_file = lp_temp_path / "source_max.lp"
+        build_lp_file(model, custom_math, lp_file)
+        compare_lps_new(lp_file)
 
-    def test_balance_transmission(self, compare_lps):
+    def test_balance_transmission(self, lp_temp_path, init_math_config):
         """Test with the electricity transmission tech being one way only, while the heat transmission tech is the default two-way."""
         self.TEST_REGISTER.add("constraints.balance_transmission")
-        model = build_test_model(
-            {"techs.test_link_a_b_elec.one_way": True}, "simple_conversion,two_hours"
+        model = util.build_test_model(
+            {"techs.test_link_a_b_elec.one_way": True},
+            "simple_conversion,two_hours",
+            **init_math_config,
         )
         custom_math = {
             "constraints": {"my_constraint": PLAN_MATH.constraints.balance_transmission}
         }
-        compare_lps(model, custom_math, "balance_transmission")
+        lp_file = lp_temp_path / "balance_transmission.lp"
+        build_lp_file(model, custom_math, lp_file)
+        compare_lps_new(lp_file)
 
-    def test_balance_storage(self, compare_lps):
+    def test_balance_storage(self, lp_temp_path, init_math_config):
         """Test balance storage with one tech having and one tech not having per-tech cyclic storage."""
         self.TEST_REGISTER.add("constraints.balance_storage")
-        model = build_test_model(
+        model = util.build_test_model(
             {
                 "nodes.a.techs.test_storage.cyclic_storage": True,
                 "nodes.b.techs.test_storage.cyclic_storage": False,
             },
             "simple_storage,two_hours",
+            **init_math_config,
         )
         custom_math = {
             "constraints": {"my_constraint": PLAN_MATH.constraints.balance_storage}
         }
-        compare_lps(model, custom_math, "balance_storage")
+        lp_file = lp_temp_path / "balance_storage.lp"
+        build_lp_file(model, custom_math, lp_file)
+        compare_lps_new(lp_file)
 
     @pytest.mark.parametrize("with_export", [True, False])
-    def test_cost_operation_variable(self, compare_lps, with_export):
+    def test_cost_operation_variable(self, lp_temp_path, init_math_config, with_export):
         """Test variable costs in the objective."""
         self.TEST_REGISTER.add("global_expressions.cost_operation_variable")
         override = {
@@ -203,8 +293,10 @@ class TestBaseMath:
                     },
                 }
             )
-        model = build_test_model(
-            override, "conversion_and_conversion_plus,var_costs,two_hours"
+        model = util.build_test_model(
+            override,
+            "conversion_and_conversion_plus,var_costs,two_hours",
+            **init_math_config,
         )
         custom_math = {
             # need the expression defined in a constraint/objective for it to appear in the LP file bounds
@@ -220,14 +312,17 @@ class TestBaseMath:
             }
         }
         suffix = "_with_export" if with_export else ""
-        compare_lps(model, custom_math, f"cost_operation_variable{suffix}")
+        lp_file = lp_temp_path / f"cost_operation_variable{suffix}.lp"
+        build_lp_file(model, custom_math, lp_file, objective="foo")
+        compare_lps_new(lp_file)
 
     @pytest.mark.xfail(reason="not all base math is in the test config dict yet")
-    def test_all_math_registered(self, base_math):
+    def test_all_math_registered(self):
         """After running all the previous tests in the class, the base_math dict should be empty, i.e. all math has been tested"""
+        plan_math = model_math._load_internal_math("plan")
         for key in self.TEST_REGISTER:
-            base_math.del_key(key)
-        assert not base_math
+            plan_math.del_key(key)
+        assert not plan_math
 
 
 class CustomMathExamples(ABC):
@@ -249,7 +344,7 @@ class CustomMathExamples(ABC):
 
     @pytest.fixture(scope="class")
     def custom_math(self):
-        return read_rich_yaml(self.CUSTOM_MATH_DIR / self.YAML_FILEPATH)
+        return io.read_rich_yaml(self.CUSTOM_MATH_DIR / self.YAML_FILEPATH)
 
     @pytest.fixture
     def build_and_compare(self, abs_filepath, compare_lps):
@@ -276,7 +371,7 @@ class CustomMathExamples(ABC):
             if overrides is None:
                 overrides = {}
 
-            model = build_test_model(
+            model = util.build_test_model(
                 {
                     "config.init.math.extra": {"user_math": abs_filepath},
                     "config.build.extra_math": ["user_math"],

--- a/tests/test_preprocess/test_model_math.py
+++ b/tests/test_preprocess/test_model_math.py
@@ -107,7 +107,8 @@ class TestMathLoading:
     @pytest.fixture(scope="class")
     def predefined_mode_data(self, pre_defined_mode):
         path = Path(calliope.__file__).parent / "math" / f"{pre_defined_mode}.yaml"
-        math = read_rich_yaml(path)
+        # TODO-Ivan: consider disallowing overrides once math can be layered
+        math = read_rich_yaml(path, allow_override=True)
         return math
 
     def test_predefined_add(self, model_math_w_mode, predefined_mode_data):
@@ -147,11 +148,11 @@ class TestMathLoading:
 
     def test_repr(self, model_math_w_mode):
         expected_repr_content = """Calliope math definition dictionary with:
-    4 decision variable(s)
-    0 global expression(s)
-    9 constraint(s)
+    19 decision variable(s)
+    12 global expression(s)
+    54 constraint(s)
     0 piecewise constraint(s)
-    0 objective(s)
+    1 objective(s)
         """
         assert expected_repr_content == str(model_math_w_mode)
 

--- a/tests/test_preprocess/test_model_math.py
+++ b/tests/test_preprocess/test_model_math.py
@@ -50,12 +50,12 @@ class TestInitMath:
     def test_loaded_internal(self, math_data, math_config):
         """Loaded math should contain both user defined and internal files."""
         assert not math_data.keys() - (
-            set(math_config.pre_defined) | math_config.extra.keys()
+            set(model_math.PRE_DEFINED_MATH) | math_config.extra.keys()
         )
 
-    def test_pre_defined_load(self, math_data, math_config):
+    def test_pre_defined_load(self, math_data):
         """Internal files should be loaded correctly."""
-        for filename in math_config.pre_defined:
+        for filename in model_math.PRE_DEFINED_MATH:
             expected = model_math._load_internal_math(filename)
             math_data[filename] == expected
 
@@ -63,6 +63,15 @@ class TestInitMath:
         """Extra math should be loaded with no alterations."""
         if math_config.extra:
             assert math_data["user_math"] == user_math
+
+    def test_overwrite_warning(self, user_math_path, def_path):
+        """Users should be warned when overwritting pre-defined math."""
+        config = config_schema.InitMath()
+        config = config.update({"extra": {"plan": user_math_path}})
+        with pytest.raises(
+            exceptions.ModelWarning, match="Overwritting pre-defined 'plan' math."
+        ):
+            model_math.initialise_math(config, def_path)
 
 
 class TestBuildMath:
@@ -78,7 +87,6 @@ class TestBuildMath:
                 "config": {
                     "init.math": {
                         "base": "plan",
-                        "pre_defined": ["plan", "operate"],
                         "extra": {
                             "additional_math": str(additional.absolute()),
                             "alternative_base": str(alternative_base.absolute()),

--- a/tests/test_preprocess/test_model_math.py
+++ b/tests/test_preprocess/test_model_math.py
@@ -69,7 +69,7 @@ class TestInitMath:
         config = config_schema.InitMath()
         config = config.update({"extra": {"plan": user_math_path}})
         with pytest.raises(
-            exceptions.ModelWarning, match="Overwritting pre-defined 'plan' math."
+            exceptions.ModelWarning, match="Overwriting pre-defined 'plan' math."
         ):
             model_math.initialise_math(config, def_path)
 

--- a/tests/test_preprocess/test_model_math.py
+++ b/tests/test_preprocess/test_model_math.py
@@ -1,23 +1,11 @@
 """Test the model math handler."""
 
-import logging
-from copy import deepcopy
-from pathlib import Path
-from random import shuffle
-
 import pytest
-from pydantic import ValidationError
 
 import calliope
-from calliope.exceptions import ModelError
-from calliope.io import read_rich_yaml, to_yaml
-from calliope.preprocess import CalliopeMath, model_math
+from calliope.io import to_yaml
+from calliope.preprocess import model_math
 from calliope.schemas import config_schema
-
-
-@pytest.fixture
-def model_math_default():
-    return CalliopeMath([])
 
 
 @pytest.fixture(scope="module")
@@ -41,153 +29,6 @@ def user_math_path(def_path, user_math):
     file_path = def_path / "custom-math.yaml"
     to_yaml(user_math, path=def_path / file_path)
     return "custom-math.yaml"
-
-
-@pytest.mark.parametrize("invalid_obj", [1, "foo", {"foo": "bar"}, True, CalliopeMath])
-def test_invalid_eq(model_math_default, invalid_obj):
-    """Comparisons should not work with invalid objects."""
-    assert not model_math_default == invalid_obj
-
-
-@pytest.mark.parametrize("modes", [[], ["storage_inter_cluster"]])
-class TestInit:
-    def test_init_order(self, caplog, modes, model_math_default):
-        """Math should be added in order, keeping defaults."""
-        with caplog.at_level(logging.INFO):
-            model_math = CalliopeMath(modes)
-        assert all(
-            f"Math preprocessing | added file '{i}'." in caplog.messages for i in modes
-        )
-        assert model_math_default.history + modes == model_math.history
-
-    def test_init_order_user_math(
-        self, modes, user_math_path, def_path, model_math_default
-    ):
-        """User math order should be respected."""
-        modes = modes + [user_math_path]
-        shuffle(modes)
-        model_math = CalliopeMath(modes, def_path)
-        assert model_math_default.history + modes == model_math.history
-
-    def test_init_user_math_invalid_relative(self, modes, user_math_path):
-        """Init with user math should fail if model definition path is not given for a relative path."""
-        with pytest.raises(ModelError):
-            CalliopeMath(modes + [user_math_path])
-
-    def test_init_user_math_valid_absolute(self, modes, def_path, user_math_path):
-        """Init with user math should succeed if user math is an absolute path."""
-        abs_path = str((def_path / user_math_path).absolute())
-        model_math = CalliopeMath(modes + [abs_path])
-        assert model_math.in_history(abs_path)
-
-    def test_init_dict(self, modes, user_math_path, def_path):
-        """Math dictionary reload should lead to no alterations."""
-        modes = modes + [user_math_path]
-        shuffle(modes)
-        model_math = CalliopeMath(modes, def_path)
-        saved = dict(model_math)
-        reloaded = CalliopeMath.from_dict(saved)
-        assert model_math == reloaded
-
-
-class TestMathLoading:
-    @pytest.fixture(scope="class")
-    def pre_defined_mode(self):
-        return "storage_inter_cluster"
-
-    @pytest.fixture
-    def model_math_w_mode(self, model_math_default, pre_defined_mode):
-        model_math_default._add_pre_defined_file(pre_defined_mode)
-        return model_math_default
-
-    @pytest.fixture
-    def model_math_w_mode_user(self, model_math_w_mode, user_math_path, def_path):
-        model_math_w_mode._add_user_defined_file(user_math_path, def_path)
-        return model_math_w_mode
-
-    @pytest.fixture(scope="class")
-    def predefined_mode_data(self, pre_defined_mode):
-        path = Path(calliope.__file__).parent / "math" / f"{pre_defined_mode}.yaml"
-        # TODO-Ivan: consider disallowing overrides once math can be layered
-        math = read_rich_yaml(path, allow_override=True)
-        return math
-
-    def test_predefined_add(self, model_math_w_mode, predefined_mode_data):
-        """Added mode should be in data."""
-        flat = predefined_mode_data.as_dict_flat()
-        assert all(model_math_w_mode.data.get_key(i) == flat[i] for i in flat.keys())
-
-    def test_predefined_add_history(self, pre_defined_mode, model_math_w_mode):
-        """Added modes should be recorded."""
-        assert model_math_w_mode.in_history(pre_defined_mode)
-
-    def test_predefined_add_duplicate(self, pre_defined_mode, model_math_w_mode):
-        """Adding the same mode twice is invalid."""
-        with pytest.raises(ModelError):
-            model_math_w_mode._add_pre_defined_file(pre_defined_mode)
-
-    @pytest.mark.parametrize("invalid_mode", ["foobar", "foobar.yaml", "operate.yaml"])
-    def test_predefined_add_fail(self, invalid_mode, model_math_w_mode):
-        """Requesting inexistent modes or modes with suffixes should fail."""
-        with pytest.raises(ModelError):
-            model_math_w_mode._add_pre_defined_file(invalid_mode)
-
-    def test_user_math_add(
-        self, model_math_w_mode_user, predefined_mode_data, user_math
-    ):
-        """Added user math should be in data."""
-        expected_math = deepcopy(predefined_mode_data)
-        expected_math.union(user_math, allow_override=True)
-        flat = expected_math.as_dict_flat()
-        assert all(
-            model_math_w_mode_user.data.get_key(i) == flat[i] for i in flat.keys()
-        )
-
-    def test_user_math_add_history(self, model_math_w_mode_user, user_math_path):
-        """Added user math should be recorded."""
-        assert model_math_w_mode_user.in_history(user_math_path)
-
-    def test_repr(self, model_math_w_mode):
-        expected_repr_content = """Calliope math definition dictionary with:
-    19 decision variable(s)
-    12 global expression(s)
-    54 constraint(s)
-    0 piecewise constraint(s)
-    1 objective(s)
-        """
-        assert expected_repr_content == str(model_math_w_mode)
-
-    def test_add_dict(self, model_math_w_mode, model_math_w_mode_user, user_math):
-        model_math_w_mode.add(user_math)
-        assert model_math_w_mode_user == model_math_w_mode
-
-    def test_user_math_add_duplicate(
-        self, model_math_w_mode_user, user_math_path, def_path
-    ):
-        """Adding the same user math file twice should fail."""
-        with pytest.raises(ModelError):
-            model_math_w_mode_user._add_user_defined_file(user_math_path, def_path)
-
-    @pytest.mark.parametrize("invalid_mode", ["foobar", "foobar.yaml", "operate.yaml"])
-    def test_user_math_add_fail(self, invalid_mode, model_math_w_mode_user, def_path):
-        """Requesting inexistent user modes should fail."""
-        with pytest.raises(ModelError):
-            model_math_w_mode_user._add_user_defined_file(invalid_mode, def_path)
-
-
-class TestValidate:
-    def test_validate_math_fail(self):
-        """Invalid math keys must trigger a failure."""
-        model_math = CalliopeMath([{"foo": "bar"}])
-        with pytest.raises(
-            ValidationError, match="validation error for Model math schema"
-        ):
-            model_math.validate()
-
-    def test_math_default(self, caplog, model_math_default):
-        with caplog.at_level(logging.INFO):
-            model_math_default.validate()
-        assert "Math preprocessing | validated math against schema." in caplog.messages
 
 
 class TestLoadMathModes:


### PR DESCRIPTION
Fixes #739, #763, #740

Based on the design given in [this comment](https://github.com/calliope-project/calliope/issues/642#issuecomment-2465389387) by @brynpickering, except that _all_ math files are loaded during init, not just external ones, to enable more consistency.

This is an attempt to make calliope's math handling more flexible _AND_ able to support knowing parameters / dimension indexes during init.

## Summary of changes in this pull request

* All math is now loaded during init, specified in a new section (`config.init.math`).
    * `config.init.math.base` specifies the 'foundation' of the model (`plan.yaml` in most cases). It is _unmodifiable_ after being set (changing it essentially means a new model / data anyway).
    * `config.init.math.pre_defined` contains a list of standard files to load (`plan`, `operate`, `spores`).
    * `config.init.math.extra` can be used to specify new math, which can be mix and matched later on top of the base math.
* All loaded math is saved in the model definition object (which also contains config, data tables, etc) in `model._def.math` for easy serialisation and re-loading. No more broken model path references!
* Math modes and extras can be loaded during `build` in any combination by just referencing names.
    * `config.build.mode` works the same, and is used to trigger code / functions within calliope code (e.g., spores, operation mode reloads, etc).
    * `config.build.extra_math` can have additional math references. These only affect the formulation solved by the backend.
    * The order is: **base math** -> **mode** -> **extra math**

**Example 1: plan math with operate and extra**

```yaml
config:
  init:
    math:
      base: "plan"  # This is the default. Any other name in pre_defined or extra is possible!
      pre_defined: ["plan", "operate", "spores"]  # The default. Stuff most people will need.
      extra:  # User files!
        test_formulation1: "relative/path/to/file.yaml"
        test_formulation2: "/absolute/path/also/works.yaml"

  # Run base math + operate + test_formulation1
  build:
    ignore_base_math: False  # The default. You can still turn off the base math in fringe cases.
    mode: "operate"   # for math that affects calliope code operation
    extra_math: ["test_formulation1"]  # only affects backend optimisation
```

**Example 1: pathways math with different formulations**

```yaml
config:
  init:
    math:
      base: "pathways"  # You can also use any name in 'extra'
      pre_defined: []  # Do not load stuff you won't use!
      extra:  # 
        pathways: "math/pathways_perfect_foresight.yaml"
        salvage_values: "math/salvage_values.yaml"
        wacc: "math/wacc.yaml"
        vintaging: "math/powerplant_vintage_efficiency.yaml"

  # Run pathways using salvage values and vintaging
  # Order: pathways -> salvage_values -> vintaging
  build:
    ignore_base_math: False  # Still false! The base is now pathways
    mode: "base"
    extra_math: ["salvage_values", "vintaging"]
```

Other stuff:
- Math defaults set in `math_schema` are respected by ensuring we use the type-casted object produced when validating files. Similar to fixes introdued in  #754.
- `CalliopeMath` has been completely removed in favour of a `pydantic` approach.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved