### PR TITLE
Fix Typos in Docstrings and Comments

### DIFF
--- a/src/calliope/preprocess/model_data.py
+++ b/src/calliope/preprocess/model_data.py
@@ -27,7 +27,7 @@ DATA_T = float | int | bool | str | None | list[float | int | bool | str | None]
 
 
 class Param(TypedDict):
-    """Uniform dictionairy for parameters."""
+    """Uniform dictionary for parameters."""
 
     data: DATA_T
     index: list[list[str]]

--- a/tests/test_schemas/test_dimension_data_schema.py
+++ b/tests/test_schemas/test_dimension_data_schema.py
@@ -30,7 +30,7 @@ class TestIndexedParam:
         IndexedParam(data=data, dims=dims, index=index)
 
     def test_broadcasted_definition(self):
-        """Broadcasted definitons should be possible."""
+        """Broadcasted definitions should be possible."""
         IndexedParam(data=1, dims="my_dim", index=["i1", "i2", "i3", "i4"])
 
     @pytest.mark.parametrize(


### PR DESCRIPTION


Description:  
This pull request corrects minor typographical errors in docstrings and comments across the codebase. Specifically, it fixes the spelling of "dictionary" and "definitions" in the relevant files to improve code readability and maintain consistency in documentation. No functional changes were made to the code.