### PR TITLE
Update to inputs/results; separate attrs and store as pydantic model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,14 @@
 
 - `model.definition` = the loaded model data definition
 - `model.config` = the loaded model configuration
-- `model.runtime`  =runtime attributes, like timing logs
-- `model.math` initialised and applied math
+- `model.runtime` = runtime attributes, like timing logs
+- `model.math` = initialised and applied math
 
 They can all be dumped to a single attribute dictionary with `calliope.Model.dump_all_attrs()`
 
 |new| Model attributes are saved to a `attrs.yaml` YAML file when storing data using `calliope.Model.to_csv`.
 
 |new| helper functions to enable summation over single-/multi-dimension groups and rolling window summations of math expression components (#735, #777).
-
 
 |fixed| Evaluating results of Gurobi global expressions containing pure decision variables / parameters (#780).
 
@@ -48,12 +47,15 @@ E.g., `model.results.min_cost_optimisation` will give the objective function val
 
 |fixed| Randomly failing tests that rely on random sampling from the core code, by setting a global test suite random seed (#789).
 
-|new| pydantic.RootModel used for storing model definition dictionaries with arbitrary keys (`techs`, `nodes`, etc.).
+|new| `pydantic.RootModel` used for storing model definition dictionaries with arbitrary keys (`techs`, `nodes`, etc.).
 
 |new| Add `rich` as a dev dependency for much more readable repr strings of our pydantic models.
 
-|changed| Separate `inputs` and `results` into separate datasets rather than filtered views on the same, private dataset.
-Accordingly, Remove `is_result` array attribute.
+|changed| Separate `inputs` and `results` into separate datasets rather than filtered views on the same `_model_data`, private dataset.
+Accordingly, Remove `is_result` array attribute and save to separate NetCDF "groups"
+
+|changed| Removed all `attributes` from `_model_data.attrs`, storing them instead in pydantic model objects attached to the main calliope model object.
+On saving to file, attributes are stored in the `attrs` of an empty dataset as a distinct NetCDF "group".
 
 ## 0.7.0.dev6 (2025-03-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ### User-facing changes
 
+|changed| |backwards-incompatible| YAML files are loaded with `calliope.read_yaml(...)` instead of `calliope.Model(...)`.
+
+|changed| |backwards-incompatible| In-memory dictionaries are loaded with `calliope.Model.from_dict(...)` instead of `calliope.Model(...)`.
+
+|new| In-memory xarray datasets are loaded with `calliope.Model(...)`, e.g. `calliope.Model(inputs=input_array, attrs=attributes)`.
+
+|changed| Model attributes are _not_ stored in the input/results arrays (e.g. `model.inputs.attrs`) but are available directly from the model object:
+
+- `model.definition` = the loaded model data definition
+- `model.config` = the loaded model configuration
+- `model.runtime`  =runtime attributes, like timing logs
+- `model.math` initialised and applied math
+
+They can all be dumped to a single attribute dictionary with `calliope.Model.dump_all_attrs()`
+
+|new| Model attributes are saved to a `attrs.yaml` YAML file when storing data using `calliope.Model.to_csv`.
+
 |fixed| Evaluating results of Gurobi global expressions containing pure decision variables / parameters (#780).
 
 |changed| SOS2 piecewise cost example in docs to explicitly include the new decision variable in the investment cost `where` string (see #525).
@@ -29,6 +46,13 @@ E.g., `model.results.min_cost_optimisation` will give the objective function val
 |fixed| SPORES tests to vary capacities of costed technologies rather than be able to simply vary the capacity of a free heat transmission technology between SPORES (#782).
 
 |fixed| Randomly failing tests that rely on random sampling from the core code, by setting a global test suite random seed (#789).
+
+|new| pydantic.RootModel used for storing model definition dictionaries with arbitrary keys (`techs`, `nodes`, etc.).
+
+|new| Add `rich` as a dev dependency for much more readable repr strings of our pydantic models.
+
+|changed| Separate `inputs` and `results` into separate datasets rather than filtered views on the same, private dataset.
+Accordingly, Remove `is_result` array attribute.
 
 ## 0.7.0.dev6 (2025-03-24)
 

--- a/docs/examples/calliope_model_object.py
+++ b/docs/examples/calliope_model_object.py
@@ -39,22 +39,16 @@ print(m.info())
 # %% [markdown]
 # ## Model data
 #
-# `m._model_data` is an xarray Dataset, a hidden property of the Model as you are expected to access the data via the public property `inputs`
+# `m.inputs` and `m.results` are xarray Datasets.
 
 # %%
 m.inputs
 
 # %% [markdown]
-# Until we solve the model, `inputs` is the same as `_model_data`
+# Until we solve the model, `results` is empty.
 
 # %%
-m._model_data
-
-# %% [markdown]
-# We can find the same PV `flow_cap_max` data as seen in `m._model_run`
-
-# %%
-m._model_data.flow_cap_max.sel(techs="pv").to_series().dropna()
+m.results
 
 # %% [markdown]
 # # Building and checking the optimisation problem
@@ -120,7 +114,7 @@ m.backend.get_parameter("flow_cap_max", as_backend_objs=False).sel(
 m.solve()
 
 # %% [markdown]
-# The results are stored in `m._model_data` and can be accessed by the public property `m.results`
+# The results can now be accessed by the public property `m.results`
 
 # %%
 m.results
@@ -142,7 +136,9 @@ m.backend.get_variable("flow_cap", as_backend_objs=False).to_series().dropna()
 output_path = Path(".") / "outputs" / "4_calliope_model_object"
 output_path.mkdir(parents=True, exist_ok=True)
 
-m.to_netcdf(output_path / "example.nc")  # Saves a single file
+m.to_netcdf(
+    output_path / "example.nc"
+)  # Saves a single file with two groups: `inputs` and `results`
 m.to_csv(
     output_path / "csv_files", allow_overwrite=True
 )  # Saves a file for each xarray DataArray

--- a/docs/examples/loading_tabular_data.py
+++ b/docs/examples/loading_tabular_data.py
@@ -147,7 +147,7 @@ nodes:
     demand_tech:
 """
 )
-model_from_yaml = calliope.Model(model_def)
+model_from_yaml = calliope.Model.from_dict(model_def)
 
 # %% [markdown]
 # We can look at some of the tabular data we have ended up with.
@@ -354,7 +354,7 @@ nodes:
   B.techs: {supply_tech, demand_tech}
 """
 )
-model_from_data_tables = calliope.Model(model_def)
+model_from_data_tables = calliope.Model.from_dict(model_def)
 
 # %% [markdown]
 # ### Loading directly from in-memory dataframes
@@ -392,7 +392,7 @@ nodes:
   B.techs: {supply_tech, demand_tech}
 """
 )
-model_from_data_tables = calliope.Model(
+model_from_data_tables = calliope.Model.from_dict(
     model_def,
     data_table_dfs={
         "tech_data_df": tech_data,
@@ -626,7 +626,7 @@ nodes:
   B.techs: {supply_tech, demand_tech}
 """
 )
-model_from_data_tables_w_override = calliope.Model(model_def)
+model_from_data_tables_w_override = calliope.Model.from_dict(model_def)
 
 # Let's compare the two after overriding `flow_cap_max`
 flow_cap_old = model_from_data_tables.inputs.flow_cap_max.to_series().dropna()
@@ -712,7 +712,7 @@ nodes:
       active: false
 """
 )
-model_from_data_tables_w_deactivations = calliope.Model(model_def)
+model_from_data_tables_w_deactivations = calliope.Model.from_dict(model_def)
 
 # Let's compare the two after overriding `flow_cap_max`
 definition_matrix_old = (

--- a/docs/hooks/generate_math_docs.py
+++ b/docs/hooks/generate_math_docs.py
@@ -149,7 +149,7 @@ def generate_base_math_documentation() -> MathDocumentation:
     Returns:
         MathDocumentation: model math documentation with latex backend.
     """
-    model = calliope.Model(model_definition=MODEL_PATH)
+    model = calliope.read_yaml(model_definition=MODEL_PATH)
     model.build()
     return MathDocumentation(model)
 
@@ -168,7 +168,7 @@ def generate_custom_math_documentation(
     Returns:
         MathDocumentation: model math documentation with latex backend.
     """
-    model = calliope.Model(model_definition=MODEL_PATH, scenario=override)
+    model = calliope.read_yaml(model_definition=MODEL_PATH, scenario=override)
     model.build()
 
     full_del = []

--- a/docs/hooks/generate_math_docs.py
+++ b/docs/hooks/generate_math_docs.py
@@ -149,7 +149,7 @@ def generate_base_math_documentation() -> MathDocumentation:
     Returns:
         MathDocumentation: model math documentation with latex backend.
     """
-    model = calliope.read_yaml(model_definition=MODEL_PATH)
+    model = calliope.read_yaml(file=MODEL_PATH)
     model.build()
     return MathDocumentation(model)
 
@@ -168,12 +168,12 @@ def generate_custom_math_documentation(
     Returns:
         MathDocumentation: model math documentation with latex backend.
     """
-    model = calliope.read_yaml(model_definition=MODEL_PATH, scenario=override)
+    model = calliope.read_yaml(file=MODEL_PATH, scenario=override)
     model.build()
 
     full_del = []
     expr_del = []
-    for component_group, component_group_dict in model.applied_math.items():
+    for component_group, component_group_dict in model.math.build.model_dump().items():
         for name, component_dict in component_group_dict.items():
             if name in base_documentation.math[component_group]:
                 if not component_dict.get("active", True):

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -215,7 +215,7 @@ This will tell you if any of the syntax is malformed, although it cannot tell yo
 
 There are private attributes of the Calliope `Model` object that you can access to gain additional insights into your model runs.
 
-* For all data in one place (i.e., the combination of `inputs` and `results`), the dataset `model._model_data`.
+* For the entire loaded model definition, the pydantic model `model._def`.
 * For the built backend objects (e.g., Pyomo objects) in an array format, the dataset `model.backend._dataset`.
 
 !!! info

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,6 +12,7 @@ numpy >= 1
 pandas >= 2.1.3  # Minimum bound is 2.1.3 because of a regression in v2.1.0/2.1.1 inflating time/memory consumption on groupby operations with MultiIndex
 pyomo >= 6.8.2
 pyparsing >= 3.2
+rich >= 14.0.0
 ruamel.yaml >= 0.18
 typing-extensions >= 4
 xarray >= 2024.1, < 2024.4 # pinned while https://github.com/pydata/xarray/issues/9755 is open

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,6 @@ numpy >= 1
 pandas >= 2.1.3  # Minimum bound is 2.1.3 because of a regression in v2.1.0/2.1.1 inflating time/memory consumption on groupby operations with MultiIndex
 pyomo >= 6.8.2
 pyparsing >= 3.2
-rich >= 14.0.0
 ruamel.yaml >= 0.18
 typing-extensions >= 4
 xarray >= 2024.1, < 2024.4 # pinned while https://github.com/pydata/xarray/issues/9755 is open

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,3 +14,4 @@ pytest >= 8
 pytest-cov >= 4
 pytest-order >= 1
 pytest-xdist >= 3 # pytest distributed testing plugin
+rich >= 14.0.0

--- a/src/calliope/__init__.py
+++ b/src/calliope/__init__.py
@@ -1,10 +1,16 @@
 """Public packaging of Calliope."""
 
+import xarray as xr
+from rich import pretty
+
 from calliope import examples, exceptions
 from calliope._version import __version__
 from calliope.attrdict import AttrDict
-from calliope.model import Model, read_netcdf
+from calliope.model import Model, read_netcdf, read_yaml
 from calliope.util.logging import set_log_verbosity
+
+xr.set_options(display_expand_attrs=False)
+pretty.install(max_depth=1)
 
 __title__ = "Calliope"
 __author__ = "Calliope contributors listed in AUTHORS"

--- a/src/calliope/__init__.py
+++ b/src/calliope/__init__.py
@@ -2,7 +2,7 @@
 
 from rich import pretty
 
-from calliope import examples, exceptions
+from calliope import examples
 from calliope._version import __version__
 from calliope.attrdict import AttrDict
 from calliope.model import Model, read_netcdf, read_yaml

--- a/src/calliope/__init__.py
+++ b/src/calliope/__init__.py
@@ -1,6 +1,5 @@
 """Public packaging of Calliope."""
 
-import xarray as xr
 from rich import pretty
 
 from calliope import examples, exceptions
@@ -9,7 +8,6 @@ from calliope.attrdict import AttrDict
 from calliope.model import Model, read_netcdf, read_yaml
 from calliope.util.logging import set_log_verbosity
 
-xr.set_options(display_expand_attrs=False)
 pretty.install(max_depth=1)
 
 __title__ = "Calliope"

--- a/src/calliope/__init__.py
+++ b/src/calliope/__init__.py
@@ -1,6 +1,6 @@
 """Public packaging of Calliope."""
 
-from rich import pretty
+import importlib
 
 from calliope import examples
 from calliope._version import __version__
@@ -8,7 +8,12 @@ from calliope.attrdict import AttrDict
 from calliope.model import Model, read_netcdf, read_yaml
 from calliope.util.logging import set_log_verbosity
 
-pretty.install(max_depth=1)
+try:
+    from rich import pretty
+
+    pretty.install(max_depth=1)
+except ModuleNotFoundError:
+    pass
 
 __title__ = "Calliope"
 __author__ = "Calliope contributors listed in AUTHORS"

--- a/src/calliope/backend/__init__.py
+++ b/src/calliope/backend/__init__.py
@@ -19,7 +19,10 @@ if TYPE_CHECKING:
 
 
 def get_model_backend(
-    build_config: "config_schema.Build", data: xr.Dataset, math: AttrDict
+    build_config: "config_schema.Build",
+    data: xr.Dataset,
+    math: AttrDict,
+    defaults: dict,
 ) -> "BackendModel":
     """Assign a backend using the given configuration.
 
@@ -27,6 +30,7 @@ def get_model_backend(
         build_config: Build configuration options.
         data (Dataset): model data for the backend.
         math (AttrDict): Calliope math.
+        defaults (dict): Parameter defaults.
 
     Raises:
         exceptions.BackendError: If invalid backend was requested.
@@ -36,8 +40,8 @@ def get_model_backend(
     """
     match build_config.backend:
         case "pyomo":
-            return PyomoBackendModel(data, math, build_config)
+            return PyomoBackendModel(data, math, build_config, defaults)
         case "gurobi":
-            return GurobiBackendModel(data, math, build_config)
+            return GurobiBackendModel(data, math, build_config, defaults)
         case _:
             raise BackendError(f"Incorrect backend '{build_config.backend}' requested.")

--- a/src/calliope/backend/backend_model.py
+++ b/src/calliope/backend/backend_model.py
@@ -365,7 +365,9 @@ class BackendModelGenerator(ABC, metaclass=ABCMeta):
             name, component_da, component_type, component_dict, references
         )
         if name not in self.math[component_type]:
-            self._dataset.attrs["applied_math"].union(component_dict)
+            self._dataset.attrs["applied_math"].union(
+                {f"{component_type}.{name}": component_dict}
+            )
 
         return parsed_component
 

--- a/src/calliope/backend/expression_parser.py
+++ b/src/calliope/backend/expression_parser.py
@@ -902,7 +902,7 @@ def sliced_param_or_var_parser(
 
     E.g. "source_use_max[node, tech]".
 
-    If a parameter, must be a data variable in the Model._model_data xarray dataset.
+    If a parameter, must be a data variable in the Model.inputs xarray dataset.
 
     If a variable, must be an optimisation problem decision variable.
 

--- a/src/calliope/backend/gurobi_backend_model.py
+++ b/src/calliope/backend/gurobi_backend_model.py
@@ -56,20 +56,25 @@ class GurobiBackendModel(backend_model.BackendModel):
         }
 
     def __init__(
-        self, inputs: xr.Dataset, math: AttrDict, build_config: config_schema.Build
+        self,
+        inputs: xr.Dataset,
+        math: AttrDict,
+        build_config: config_schema.Build,
+        defaults: dict,
     ) -> None:
         """Gurobi solver interface class.
 
         Args:
             inputs (xr.Dataset): Calliope model data.
             math (AttrDict): Calliope math.
-            build_config: Build configuration options.
+            build_config (config_schema.Build): Build configuration options.
+            defaults (dict): Parameter defaults.
         """
         if importlib.util.find_spec("gurobipy") is None:
             raise ImportError(
                 "Install the `gurobipy` package to build the optimisation problem with the Gurobi backend."
             )
-        super().__init__(inputs, math, build_config, gurobipy.Model())
+        super().__init__(inputs, math, build_config, defaults, gurobipy.Model())
         self._instance: gurobipy.Model
         self.shadow_prices = GurobiShadowPrices(self)
 
@@ -358,9 +363,7 @@ class GurobiBackendModel(backend_model.BackendModel):
 
         self.delete_component(name, "parameters")
         self.add_parameter(
-            name,
-            new_parameter_da,
-            default=self.inputs.attrs["defaults"].get(name, np.nan),
+            name, new_parameter_da, default=self.defaults.get(name, np.nan)
         )
 
         refs_to_update = self._find_all_references(parameter_da.attrs["references"])

--- a/src/calliope/backend/latex_backend_model.py
+++ b/src/calliope/backend/latex_backend_model.py
@@ -307,6 +307,7 @@ class LatexBackendModel(backend_model.BackendModelGenerator):
         inputs: xr.Dataset,
         math: AttrDict,
         build_config: config_schema.Build,
+        defaults: dict,
         include: Literal["all", "valid"] = "all",
     ) -> None:
         """Interface to build a string representation of the mathematical formulation using LaTeX math notation.
@@ -314,11 +315,12 @@ class LatexBackendModel(backend_model.BackendModelGenerator):
         Args:
             inputs (xr.Dataset): model data.
             math (AttrDict): Calliope math.
-            build_config: Build configuration options.
+            build_config (config_schema.Build): Build configuration options.
+            defaults (dict): Parameter defaults.
             include (Literal["all", "valid"], optional):
                 Defines whether to include all possible math equations ("all") or only those for which at least one index item in the "where" string is valid ("valid"). Defaults to "all".
         """
-        super().__init__(inputs, math, build_config)
+        super().__init__(inputs, math, build_config, defaults)
         self.include = include
 
     def add_parameter(  # noqa: D102, override

--- a/src/calliope/backend/parsing.py
+++ b/src/calliope/backend/parsing.py
@@ -315,6 +315,7 @@ class ParsedBackendEquation:
                 input_data=backend_interface.inputs,
                 backend_interface=backend_interface,
                 build_config=backend_interface.config,
+                defaults=backend_interface.defaults,
                 references=references if references is not None else set(),
                 apply_where=True,
             )

--- a/src/calliope/backend/pyomo_backend_model.py
+++ b/src/calliope/backend/pyomo_backend_model.py
@@ -51,16 +51,21 @@ class PyomoBackendModel(backend_model.BackendModel):
     """Pyomo-specific backend functionality."""
 
     def __init__(
-        self, inputs: xr.Dataset, math: AttrDict, build_config: config_schema.Build
+        self,
+        inputs: xr.Dataset,
+        math: AttrDict,
+        build_config: config_schema.Build,
+        defaults: dict,
     ) -> None:
         """Pyomo solver interface class.
 
         Args:
             inputs (xr.Dataset): Calliope model data.
             math (AttrDict): Calliope math.
-            build_config: Build configuration options.
+            build_config (config_schema.Build): Build configuration options.
+            defaults (dict): Parameter defaults.
         """
-        super().__init__(inputs, math, build_config, pmo.block())
+        super().__init__(inputs, math, build_config, defaults, pmo.block())
 
         self._instance.parameters = pmo.parameter_dict()
         self._instance.variables = pmo.variable_dict()
@@ -429,9 +434,7 @@ class PyomoBackendModel(backend_model.BackendModel):
 
             self.delete_component(name, "parameters")
             self.add_parameter(
-                name,
-                self.inputs[name],
-                default=self.inputs.attrs["defaults"].get(name, np.nan),
+                name, self.inputs[name], default=self.defaults.get(name, np.nan)
             )
             self._rebuild_references(refs_to_update)
             if self._has_verbose_strings:

--- a/src/calliope/backend/where_parser.py
+++ b/src/calliope/backend/where_parser.py
@@ -36,6 +36,7 @@ class EvalAttrs(TypedDict):
     apply_where: NotRequired[bool]
     references: NotRequired[set]
     build_config: config_schema.Build
+    defaults: dict
 
 
 class EvalWhere(expression_parser.EvalToArrayStr):
@@ -201,7 +202,7 @@ class DataVarParser(EvalWhere):
 
         Return default value as an array if var does not exist.
         """
-        default = source_dataset.attrs["defaults"].get(self.data_var)
+        default = self.eval_attrs["defaults"].get(self.data_var)
         var = source_dataset.get(self.data_var, xr.DataArray(default))
         if default is not None:
             var = var.fillna(default)

--- a/src/calliope/cli.py
+++ b/src/calliope/cli.py
@@ -293,7 +293,8 @@ def run(
 
             if (
                 save_netcdf
-                and model.config.solve.spores.save_per_spore_path is not None
+                and model.attrs.model_def.config.solve.spores.save_per_spore_path
+                is not None
             ):
                 # If save_netcdf is used, override the 'save_per_spore_path' to point to
                 # a directory of the same name as the planned netcdf
@@ -301,7 +302,7 @@ def run(
 
             model.build()
             model.solve(**kwargs)
-            termination = model._attrs.termination_condition
+            termination = model.attrs.termination_condition
 
             if save_csv:
                 click.secho(f"Saving CSV results to directory: {save_csv}")

--- a/src/calliope/cli.py
+++ b/src/calliope/cli.py
@@ -293,8 +293,7 @@ def run(
 
             if (
                 save_netcdf
-                and model.attrs.model_def.config.solve.spores.save_per_spore_path
-                is not None
+                and model.config.solve.spores.save_per_spore_path is not None
             ):
                 # If save_netcdf is used, override the 'save_per_spore_path' to point to
                 # a directory of the same name as the planned netcdf

--- a/src/calliope/cli.py
+++ b/src/calliope/cli.py
@@ -301,7 +301,7 @@ def run(
 
             model.build()
             model.solve(**kwargs)
-            termination = model.attrs.get("termination_condition", "unknown")
+            termination = model._attrs.termination_condition
 
             if save_csv:
                 click.secho(f"Saving CSV results to directory: {save_csv}")

--- a/src/calliope/cli.py
+++ b/src/calliope/cli.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import click
 
-from calliope import Model, examples, io, read_netcdf
+from calliope import examples, io, read_netcdf, read_yaml
 from calliope._version import __version__
 from calliope.exceptions import BackendError
 from calliope.util.generate_runs import generate
@@ -198,7 +198,7 @@ def _run_setup_model(model_file, scenario, model_format, override_dict):
         overrides = io.AttrDict()
 
     if model_format == "yaml":
-        model = Model(model_file, scenario=scenario, override_dict=overrides)
+        model = read_yaml(model_file, scenario=scenario, override_dict=overrides)
     elif model_format == "netcdf":
         if scenario is not None or override_dict is not None:
             raise ValueError(
@@ -301,9 +301,7 @@ def run(
 
             model.build()
             model.solve(**kwargs)
-            termination = model._model_data.attrs.get(
-                "termination_condition", "unknown"
-            )
+            termination = model.attrs.get("termination_condition", "unknown")
 
             if save_csv:
                 click.secho(f"Saving CSV results to directory: {save_csv}")

--- a/src/calliope/cli.py
+++ b/src/calliope/cli.py
@@ -301,7 +301,7 @@ def run(
 
             model.build()
             model.solve(**kwargs)
-            termination = model.attrs.termination_condition
+            termination = model.runtime.termination_condition
 
             if save_csv:
                 click.secho(f"Saving CSV results to directory: {save_csv}")

--- a/src/calliope/config/model_data_checks.yaml
+++ b/src/calliope/config/model_data_checks.yaml
@@ -26,7 +26,7 @@ fail:
   - where: carrier_export and not any(carrier_out, over=nodes)
     message: "Export carriers must be one of the technology outflow carriers."
 
-  - where: storage_initial<0 OR storage_initial>1
+  - where: storage_initial and (storage_initial<0 OR storage_initial>1)
     message: "storage_initial is a fraction, requiring values within the interval [0, 1]."
 
   - where: integer_dispatch=True AND NOT cap_method=integer

--- a/src/calliope/config/model_def_schema.yaml
+++ b/src/calliope/config/model_def_schema.yaml
@@ -309,6 +309,7 @@ properties:
               Only `transmission`, `conversion`, `storage`, and `demand` technologies can define this parameter
             x-type: float
             oneOf:
+              - type: "null"
               - type: string
               - type: array
                 uniqueItems: true
@@ -321,6 +322,7 @@ properties:
               Only `transmission`, `conversion`, `storage`, and `supply` technologies can define this parameter
             x-type: float
             oneOf:
+              - type: "null"
               - type: string
               - type: array
                 uniqueItems: true
@@ -334,6 +336,7 @@ properties:
               Must be a subset of `carrier_out`.
             x-type: float
             oneOf:
+              - type: "null"
               - type: string
               - type: array
                 uniqueItems: true

--- a/src/calliope/config/model_def_schema.yaml
+++ b/src/calliope/config/model_def_schema.yaml
@@ -1020,25 +1020,12 @@ properties:
       '^[^_^\d][\w]*$':
         type: object
         title: A named node.
-        dependentRequired": {latitude: ["longitude"], longitude: ["latitude"]}
 
         patternProperties: *pattern_def
         unevaluatedProperties: *uneval_def
         properties:
           active:
             $ref: "#/$defs/ActiveDef"
-          latitude:
-            type: number
-            x-type: float
-            title: Latitude (WGS84 / EPSG4326).
-            minimum: -90
-            maximum: 90
-          longitude:
-            type: number
-            x-type: float
-            title: Longitude (WGS84 / EPSG4326).
-            minimum: -180
-            maximum: 180
           available_area:
             type: number
             x-type: float

--- a/src/calliope/example_models/urban_scale/scenarios.yaml
+++ b/src/calliope/example_models/urban_scale/scenarios.yaml
@@ -52,7 +52,7 @@ overrides:
       build:
         mode: operate
         operate:
-          window: 2h
+          window: 12h
           horizon: 48h
 
     nodes:

--- a/src/calliope/examples.py
+++ b/src/calliope/examples.py
@@ -5,17 +5,15 @@
 import importlib
 from pathlib import Path
 
-from calliope.model import Model
+from calliope.model import read_yaml
 
 _EXAMPLE_MODEL_DIR = Path(importlib.resources.files("calliope") / "example_models")
 
 
 def national_scale(*args, **kwargs):
     """Returns the built-in national-scale example model."""
-    return Model(
-        model_definition=_EXAMPLE_MODEL_DIR / "national_scale" / "model.yaml",
-        *args,
-        **kwargs,
+    return read_yaml(
+        _EXAMPLE_MODEL_DIR / "national_scale" / "model.yaml", *args, **kwargs
     )
 
 
@@ -31,11 +29,7 @@ def time_resampling(*args, **kwargs):
 
 def urban_scale(*args, **kwargs):
     """Returns the built-in urban-scale example model."""
-    return Model(
-        model_definition=_EXAMPLE_MODEL_DIR / "urban_scale" / "model.yaml",
-        *args,
-        **kwargs,
-    )
+    return read_yaml(_EXAMPLE_MODEL_DIR / "urban_scale" / "model.yaml", *args, **kwargs)
 
 
 def milp(*args, **kwargs):

--- a/src/calliope/io.py
+++ b/src/calliope/io.py
@@ -28,7 +28,9 @@ YAML_INDENT = 2
 YAML_BLOCK_SEQUENCE_INDENT = 0
 
 
-def read_netcdf(path: str | Path) -> dict[Literal["inputs", "results"], xr.Dataset]:
+def read_netcdf(
+    path: str | Path,
+) -> dict[Literal["inputs", "results", "attrs"], xr.Dataset]:
     """Read model_data from NetCDF file."""
     datasets: dict[Literal["inputs", "results", "attrs"], xr.Dataset] = {}
     for group in ["inputs", "results", "attrs"]:

--- a/src/calliope/io.py
+++ b/src/calliope/io.py
@@ -8,6 +8,7 @@ import os
 from copy import deepcopy
 from io import StringIO
 from pathlib import Path
+from typing import Literal
 
 # We import netCDF4 before xarray to mitigate a numpy warning:
 # https://github.com/pydata/xarray/issues/7259
@@ -17,7 +18,6 @@ import pandas as pd
 import ruamel.yaml as ruamel_yaml
 import xarray as xr
 
-from calliope import exceptions
 from calliope.attrdict import AttrDict
 from calliope.util.tools import listify, relative_path
 
@@ -28,23 +28,21 @@ YAML_INDENT = 2
 YAML_BLOCK_SEQUENCE_INDENT = 0
 
 
-def read_netcdf(path):
+def read_netcdf(path: str | Path) -> dict[Literal["inputs", "results"], xr.Dataset]:
     """Read model_data from NetCDF file."""
-    with xr.open_dataset(path) as model_data:
-        model_data.load()
-
-    _deserialise(model_data.attrs)
-    for var in model_data.data_vars.values():
-        _deserialise(var.attrs)
-
-    # Convert empty strings back to np.NaN
-    # TODO: revert when this issue is solved: https://github.com/pydata/xarray/issues/1647
-    # which it might be once this is merged: https://github.com/pydata/xarray/pull/7869
-    for var_name, var_array in model_data.data_vars.items():
-        if var_array.dtype.kind in ["U", "O"]:
-            model_data[var_name] = var_array.where(lambda x: x != "")
-
-    return model_data
+    datasets: dict[Literal["inputs", "results", "attrs"], xr.Dataset] = {}
+    for group in ["inputs", "results", "attrs"]:
+        try:
+            with xr.open_dataset(path, group=group) as model_data:
+                model_data.load()
+        except OSError:
+            datasets[group] = xr.Dataset()
+            continue
+        _deserialise(model_data.attrs)
+        for var in model_data.data_vars.values():
+            _deserialise(var.attrs)
+        datasets[group] = model_data
+    return datasets
 
 
 def _pop_serialised_list(
@@ -133,7 +131,13 @@ def _deserialise(attrs: dict) -> None:
         attrs[attr] = set(attrs[attr])
 
 
-def save_netcdf(model_data, path, **kwargs):
+def save_netcdf(
+    model_data: xr.Dataset,
+    group_name: str,
+    mode: Literal["a", "w"],
+    path: str | Path,
+    **kwargs,
+):
     """Save the model to a netCDF file."""
     original_model_data_attrs = deepcopy(model_data.attrs)
     for key, value in kwargs.items():
@@ -151,10 +155,16 @@ def save_netcdf(model_data, path, **kwargs):
         )
         for k, v in model_data.data_vars.items()
     }
-
     try:
-        model_data.to_netcdf(path, format="netCDF4", encoding=encoding)
-        model_data.close()  # Force-close NetCDF file after writing
+        model_data.to_netcdf(
+            path,
+            mode=mode,
+            format="netCDF4",
+            engine="netcdf4",
+            encoding=encoding,
+            group=group_name,
+        )
+        model_data.close()
     finally:  # Revert model_data.attrs back
         model_data.attrs = original_model_data_attrs
         for var in model_data.data_vars.values():
@@ -163,6 +173,7 @@ def save_netcdf(model_data, path, **kwargs):
 
 def save_csv(
     model_data: xr.Dataset,
+    group_name: Literal["inputs", "results"],
     path: str | Path,
     dropna: bool = True,
     allow_overwrite: bool = False,
@@ -175,6 +186,7 @@ def save_csv(
 
     Args:
         model_data (xr.Dataset): Calliope model data.
+        group_name (Literal["inputs", "results"]): which of input or output data the `model_data` represents.
         path (str | Path): Directory to which the CSV files will be saved
         dropna (bool, optional):
             If True, drop all NaN values in the data series before saving to file.
@@ -187,21 +199,8 @@ def save_csv(
     path = Path(path)
     path.mkdir(parents=True, exist_ok=allow_overwrite)
 
-    # a MILP model which optimises to within the MIP gap, but does not fully
-    # converge on the LP relaxation, may return as 'feasible', not 'optimal'
-    if "termination_condition" not in model_data.attrs or model_data.attrs[
-        "termination_condition"
-    ] in ["optimal", "feasible"]:
-        data_vars = model_data.data_vars
-    else:
-        data_vars = model_data.filter_by_attrs(is_result=0).data_vars
-        exceptions.warn(
-            "Model termination condition was not optimal, saving inputs only."
-        )
-
-    for var_name, var in data_vars.items():
-        in_out = "results" if var.attrs["is_result"] else "inputs"
-        out_path = path / f"{in_out}_{var_name}.csv"
+    for var_name, var in model_data.items():
+        out_path = path / f"{group_name}_{var_name}.csv"
         if not var.shape:
             series = pd.Series(var.item())
             keep_index = False
@@ -309,6 +308,8 @@ def to_yaml(data: AttrDict | dict, path: None | str | Path = None) -> str:
         # Lists are turned into seqs so that they are formatted nicely
         elif isinstance(v, list):
             result.set_key(k, yaml_.seq(v))
+        elif isinstance(v, Path):
+            result.set_key(k, str(v))
 
     result = result.as_dict()
 

--- a/src/calliope/math/plan.yaml
+++ b/src/calliope/math/plan.yaml
@@ -654,7 +654,7 @@ variables:
 
   purchased_units:
     title: Number of purchased units
-    description: |
+    description: >-
       Integer number of a technology that has been purchased,
       for any technology set to require integer capacity purchasing.
       This is used to allow installation of fixed capacity units of technologies (

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -114,12 +114,16 @@ class Model:
         self.inputs = inputs
         self.results = xr.Dataset() if results is None else results
         self.backend: BackendModel
-        self.definition = model_def_schema.CalliopeModelDef(
-            **kwargs.get("definition", {})
+        self.definition = model_def_schema.CalliopeModelDef.model_validate(
+            kwargs.get("definition", {})
         )
-        self.config = config_schema.CalliopeConfig(**kwargs.get("config", {}))
-        self.math = math_schema.CalliopeMath(**kwargs.get("math", {}))
-        self.runtime = runtime_attrs_schema.CalliopeRuntime(**kwargs.get("runtime", {}))
+        self.config = config_schema.CalliopeConfig.model_validate(
+            kwargs.get("config", {})
+        )
+        self.math = math_schema.CalliopeMath.model_validate(kwargs.get("math", {}))
+        self.runtime = runtime_attrs_schema.CalliopeRuntime.model_validate(
+            kwargs.get("runtime", {})
+        )
 
         self._start_window_idx: int = 0
         self._is_built: bool = False

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -241,7 +241,7 @@ class Model:
         names += self.config.build.extra_math
         return names
 
-    def _dump_all_attrs(self) -> dict:
+    def dump_all_attrs(self) -> dict:
         """Dump of all class pydantic model attributes as a single dictionary."""
         return {k: getattr(self, k).model_dump() for k in get_args(self._SAVE_ATTRS_T)}
 
@@ -411,7 +411,7 @@ class Model:
         """Save complete model data (inputs and, if available, results) to a NetCDF file at the given `path`."""
         io.save_netcdf(self.inputs, "inputs", "w", path)
         io.save_netcdf(self.results, "results", "a", path)
-        io.save_netcdf(xr.Dataset(attrs=self._dump_all_attrs()), "attrs", "a", path)
+        io.save_netcdf(xr.Dataset(attrs=self.dump_all_attrs()), "attrs", "a", path)
 
     def to_csv(
         self, path: str | Path, dropna: bool = True, allow_overwrite: bool = False
@@ -436,7 +436,7 @@ class Model:
         else:
             exceptions.warn("No results available, saving inputs only.")
 
-        io.to_yaml(self._dump_all_attrs(), path=Path(path) / "attrs.yaml")
+        io.to_yaml(self.dump_all_attrs(), path=Path(path) / "attrs.yaml")
 
     def info(self) -> str:
         """Generate basic description of the model, combining its name and a rough indication of the model size.
@@ -694,7 +694,7 @@ class Model:
 
             io.save_netcdf(results.expand_dims(spores=[spore]), "results", "w", outpath)
             io.save_netcdf(
-                xr.Dataset(attrs=self._dump_all_attrs()), "attrs", "a", outpath
+                xr.Dataset(attrs=self.dump_all_attrs()), "attrs", "a", outpath
             )
 
         else:

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -7,18 +7,16 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 import numpy as np
 import pandas as pd
 import xarray as xr
 
-import calliope
 from calliope import backend, exceptions, io, preprocess
-from calliope.attrdict import AttrDict
 from calliope.postprocess import postprocess as postprocess_results
 from calliope.preprocess.model_data import ModelDataFactory
-from calliope.schemas import config_schema, model_def_schema
+from calliope.schemas import attributes, config_schema
 from calliope.util.logging import log_time
 from calliope.util.schema import MODEL_SCHEMA, extract_from_schema
 
@@ -28,212 +26,208 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
-def read_netcdf(path):
-    """Return a Model object reconstructed from model data in a NetCDF file."""
+def read_netcdf(path: str | Path) -> Model:
+    """Return a Model object reconstructed from model data in a NetCDF file.
+
+    Args:
+        path (str | Path): Path to Calliope model NetCDF file.
+
+    Returns:
+        Model: Calliope Model instance.
+    """
     model_data = io.read_netcdf(path)
-    return Model(model_definition=model_data)
+    return Model.from_datasets(
+        model_data["inputs"], model_data["attrs"].attrs, model_data["results"]
+    )
+
+
+def read_yaml(
+    file: str | Path,
+    scenario: str | None = None,
+    override_dict: dict | None = None,
+    data_table_dfs: dict[str, pd.DataFrame] | None = None,
+    **kwargs,
+) -> Model:
+    """Return a Model object reconstructed from a model defined in YAML + CSV files.
+
+    Args:
+        file (str | Path):
+            Path to core model YAML file.
+            If defining your model in multiple YAML files, they should be listed in the core model YAML file `import` list.
+        scenario (str | None, optional):
+            Comma delimited string of pre-defined `scenarios` to apply to the model.
+            Defaults to None.
+        override_dict (dict | None, optional):
+            Additional overrides to apply to `config`.
+            These will be applied *after* applying any defined `scenario` overrides.
+            Defaults to None.
+        data_table_dfs (dict[str, pd.DataFrame] | None, optional):
+            Model definition `data_table` entries can reference in-memory pandas DataFrames.
+            The referenced data must be supplied here as a dictionary of those DataFrames.
+            Defaults to None.None.
+        **kwargs: initialisation overrides.
+
+    Returns:
+        Model: Calliope Model instance.
+    """
+    raw_data = io.read_rich_yaml(file)
+    definition_path = Path(file)
+    return Model.from_dict(
+        raw_data, scenario, override_dict, data_table_dfs, definition_path, **kwargs
+    )
 
 
 class Model:
     """A Calliope Model."""
 
     _TS_OFFSET = pd.Timedelta(1, unit="nanoseconds")
-    ATTRS_SAVED = ("applied_math", "_def")
 
-    def __init__(
-        self,
-        model_definition: str | Path | dict | xr.Dataset,
-        scenario: str | None = None,
-        override_dict: dict | None = None,
-        data_table_dfs: dict[str, pd.DataFrame] | None = None,
-        **kwargs,
-    ):
-        """Returns a new Model from YAML model configuration files or a fully specified dictionary.
+    def __init__(self) -> None:
+        """Returns an empty Model.
 
-        Args:
-            model_definition (str | Path | dict | xr.Dataset):
-                If str or Path, must be the path to a model configuration file.
-                If dict or AttrDict, must fully specify the model.
-                If an xarray dataset, must be a valid calliope model.
-            scenario (str | None, optional):
-                Comma delimited string of pre-defined `scenarios` to apply to the model.
-                Defaults to None.
-            override_dict (dict | None, optional):
-                Additional overrides to apply to `config`.
-                These will be applied *after* applying any defined `scenario` overrides.
-                Defaults to None.
-            data_table_dfs (dict[str, pd.DataFrame] | None, optional):
-                Model definition `data_table` entries can reference in-memory pandas DataFrames.
-                The referenced data must be supplied here as a dictionary of those DataFrames.
-                Defaults to None.
-            **kwargs: initialisation overrides.
+        See Also:
+        `calliope.Model.from_dict`: Initialise from a model YAML loaded into memory.
+        `calliope.Model.from_datasets`: Initialise from model data loaded into memory.
+        `calliope.read_yaml`: Read from YAML definition.
+        `calliope.read_netcdf`: Read from a calliope model saved to NetCDF.
         """
-        self._timings: dict = {}
-        self.defaults: AttrDict
-        self.applied_math: AttrDict
+        self.inputs = xr.Dataset()
+        self.results = xr.Dataset()
         self.backend: BackendModel
-        self._def: model_def_schema.CalliopeModelDef
+        self.attrs = attributes.CalliopeModelAttrs()
         self._start_window_idx: int = 0
         self._is_built: bool = False
         self._is_solved: bool = False
 
-        # try to set logging output format assuming python interactive. Will
-        # use CLI logging format if model called from CLI
-        timestamp_model_creation = log_time(
-            LOGGER, self._timings, "model_creation", comment="Model: initialising"
+        log_time(
+            LOGGER, self.attrs.timings, "model_creation", comment="Model: initialising"
         )
-        if isinstance(model_definition, xr.Dataset):
-            if kwargs:
-                raise exceptions.ModelError(
-                    "Cannot apply initialisation configuration overrides when loading data from an xarray Dataset."
-                )
-            self._init_from_model_data(model_definition)
-        else:
-            self._init_from_model_definition(
-                model_definition, scenario, override_dict, data_table_dfs, **kwargs
-            )
-        if "timestamp_model_creation" not in self._model_data.attrs:
-            self._model_data.attrs["timestamp_model_creation"] = (
-                timestamp_model_creation
-            )
-        version_def = self._model_data.attrs["calliope_version_defined"]
-        version_init = self._model_data.attrs["calliope_version_initialised"]
-        if version_def is not None and not version_init.startswith(version_def):
-            exceptions.warn(
-                f"Model configuration specifies calliope version {version_def}, "
-                f"but you are running {version_init}. Proceed with caution!"
-            )
+
+    @classmethod
+    def from_datasets(
+        cls, inputs: xr.Dataset, attrs: dict, results: xr.Dataset | None = None
+    ) -> Self:
+        """Return a Model object reconstructed from model data in a NetCDF file.
+
+        Args:
+            inputs (xr.Dataset): Input dataset.
+            attrs (dict):
+                Model attribute dictionary.
+                The result of calling `calliope.Model.attrs.model_dump()` on a built model.
+            results (xr.Dataset | None, optional):
+                If given, the results dataset. Defaults to None.
+
+        Returns:
+            Self: Initialised Calliope Model.
+        """
+        model = cls()
+        model.attrs = model.attrs.update(attrs)
+
+        model.inputs = inputs
+
+        if results is not None and results:
+            model.results = results
+            model._is_solved = True
+
+        log_time(
+            LOGGER,
+            model.attrs.timings,
+            "model_data_loaded",
+            comment="Model: loaded model_data",
+        )
+        return model
+
+    @classmethod
+    def from_dict(
+        cls,
+        model_definition: dict,
+        scenario: str | None = None,
+        override_dict: dict | None = None,
+        data_table_dfs: dict[str, pd.DataFrame] | None = None,
+        definition_path: Path | None = None,
+        **kwargs,
+    ):
+        """Return a Model object reconstructed from model data in a NetCDF file."""
+        model = cls()
+        log_time(
+            LOGGER,
+            model.attrs.timings,
+            "model_run_creation",
+            comment="Model: preprocessing stage 1 (definition)",
+        )
+        (model_def_full, applied_overrides) = preprocess.prepare_model_definition(
+            model_definition, scenario, override_dict, definition_path, **kwargs
+        )
+
+        model.attrs = model.attrs.update({"model_def": model_def_full})
+
+        log_time(
+            LOGGER,
+            model.attrs.timings,
+            "model_data_creation",
+            comment="Model: preprocessing stage 2 (data)",
+        )
+        param_metadata = {"default": extract_from_schema(MODEL_SCHEMA, "default")}
+        attributes = {
+            "applied_overrides": applied_overrides,
+            "scenario": scenario,
+            "defaults": param_metadata["default"],
+        }
+        model.attrs = model.attrs.update(attributes)
+
+        def_path = str(definition_path)
+        model_data_factory = ModelDataFactory(
+            model.attrs.model_def.config.init,
+            model_def_full,
+            def_path,
+            data_table_dfs,
+            param_metadata,
+        )
+        model_data_factory.build()
+
+        model.inputs = model_data_factory.dataset
+
+        attrs = list(model_data_factory.dataset.attrs.keys())
+        model.attrs = model.attrs.update(
+            {k: model_data_factory.dataset.attrs.pop(k) for k in attrs}
+        )
+
+        log_time(
+            LOGGER,
+            model.attrs.timings,
+            "model_preprocessing_complete",
+            comment="Model: preprocessing complete",
+        )
+        return model
 
     @property
-    def name(self):
+    def name(self) -> str | None:
         """Get the model name."""
-        return self._def.config.init.name
+        return self.attrs.model_def.config.init.name
 
     @property
     def config(self) -> config_schema.CalliopeConfig:
         """Get model configuration values."""
-        return self._def.config
+        return self.attrs.model_def.config
 
     @property
-    def inputs(self):
-        """Get model input data."""
-        return self._model_data.filter_by_attrs(is_result=0)
-
-    @property
-    def results(self):
-        """Get model result data."""
-        return self._model_data.filter_by_attrs(is_result=1)
-
-    @property
-    def is_built(self):
+    def is_built(self) -> bool:
         """Get built status."""
         return self._is_built
 
     @property
-    def is_solved(self):
+    def is_solved(self) -> bool:
         """Get solved status."""
         return self._is_solved
 
     @property
-    def math_priority(self):
+    def math_priority(self) -> list[str]:
         """Order of math formulations, with the last overwriting previous ones."""
         names = [self.config.init.base_math]
         if self.config.build.mode != "base":
             names.append(self.config.build.mode)
         names += self.config.build.extra_math
         return names
-
-    def _init_from_model_definition(
-        self,
-        model_definition: dict | str | Path,
-        scenario: str | None,
-        override_dict: dict | None,
-        data_table_dfs: dict[str, pd.DataFrame] | None,
-        **kwargs,
-    ) -> None:
-        """Initialise the model using pre-processed YAML files and optional dataframes/dicts.
-
-        Args:
-            model_definition (dict | str | Path): preprocessed model configuration.
-            scenario (str | None): scenario specified by users
-            override_dict (dict | None): overrides to apply after scenarios.
-            data_table_dfs (dict[str, pd.DataFrame] | None): files with additional model information.
-            **kwargs: initialisation overrides.
-        """
-        log_time(
-            LOGGER,
-            self._timings,
-            "model_run_creation",
-            comment="Model: preprocessing stage 1 (definition)",
-        )
-        (model_def_full, applied_overrides) = preprocess.prepare_model_definition(
-            model_definition, scenario, override_dict, **kwargs
-        )
-
-        self._def = model_def_schema.CalliopeModelDef(**model_def_full)
-
-        log_time(
-            LOGGER,
-            self._timings,
-            "model_data_creation",
-            comment="Model: preprocessing stage 2 (data)",
-        )
-        param_metadata = {"default": extract_from_schema(MODEL_SCHEMA, "default")}
-        attributes = {
-            "calliope_version_defined": self._def.config.init.calliope_version,
-            "calliope_version_initialised": calliope.__version__,
-            "applied_overrides": applied_overrides,
-            "scenario": scenario,
-            "defaults": param_metadata["default"],
-        }
-
-        def_path = None if isinstance(model_definition, dict) else str(model_definition)
-        model_data_factory = ModelDataFactory(
-            self._def.config.init,
-            model_def_full,
-            def_path,
-            data_table_dfs,
-            attributes,
-            param_metadata,
-        )
-        model_data_factory.build()
-
-        self._model_data = model_data_factory.dataset
-
-        log_time(
-            LOGGER,
-            self._timings,
-            "model_preprocessing_complete",
-            comment="Model: preprocessing complete",
-        )
-
-    def _init_from_model_data(self, model_data: xr.Dataset) -> None:
-        """Initialise the model using a pre-built xarray dataset.
-
-        This must be a Calliope-compatible dataset, usually a dataset from another Calliope model.
-
-        Args:
-            model_data (xr.Dataset):
-                Model dataset with input parameters as arrays and configuration stored in the dataset attributes dictionary.
-        """
-        if "applied_math" in model_data.attrs:
-            self.applied_math = AttrDict(model_data.attrs.pop("applied_math"))
-        if "_def" in model_data.attrs:
-            self._def = model_def_schema.CalliopeModelDef(
-                **model_data.attrs.pop("_def")
-            )
-
-        self._model_data = model_data
-
-        if self.results:
-            self._is_solved = True
-
-        log_time(
-            LOGGER,
-            self._timings,
-            "model_data_loaded",
-            comment="Model: loaded model_data",
-        )
 
     def build(
         self, force: bool = False, add_math_dict: dict | None = None, **kwargs
@@ -254,40 +248,42 @@ class Model:
                 "This model object already has a built optimisation problem. Use model.build(force=True) "
                 "to force the existing optimisation problem to be overwritten with a new one."
             )
-        self._model_data.attrs["timestamp_build_start"] = log_time(
+        log_time(
             LOGGER,
-            self._timings,
+            self.attrs.timings,
             "build_start",
             comment="Model: backend build starting",
         )
 
-        self._def = self._def.update({"config.build": kwargs})
+        self.attrs = self.attrs.update({"model_def": {"config.build": kwargs}})
+
         mode = self.config.build.mode
         if mode == "operate":
-            if not self._model_data.attrs["allow_operate_mode"]:
+            if not self.attrs.allow_operate_mode:
                 raise exceptions.ModelError(
                     "Unable to run this model in operate (i.e. dispatch) mode, probably because "
                     "there exist non-uniform timesteps (e.g. from time clustering)"
                 )
             backend_input = self._prepare_operate_mode_inputs(self.config.build.operate)
         else:
-            backend_input = self._model_data
+            backend_input = self.inputs
 
         applied_math = preprocess.build_applied_math(
-            self.math_priority, self._def.math, add_math_dict
+            self.math_priority, self.attrs.model_def.math, add_math_dict
         )
         self.backend = backend.get_model_backend(
-            self.config.build, backend_input, applied_math
+            self.config.build, backend_input, applied_math, self.attrs.defaults
         )
         self.backend.add_optimisation_components()
+        self.attrs = self.attrs.update({"applied_math": applied_math})
 
-        self._model_data.attrs["timestamp_build_complete"] = log_time(
+        log_time(
             LOGGER,
-            self._timings,
+            self.attrs.timings,
             "build_complete",
             comment="Model: backend build complete",
         )
-        self.applied_math = applied_math
+
         self._is_built = True
 
     def solve(self, force: bool = False, warmstart: bool = False, **kwargs) -> None:
@@ -318,25 +314,25 @@ class Model:
                 "before you can run it."
             )
 
-        to_drop = []
-        if hasattr(self, "results"):  # Check that results exist and are non-empty
-            if self.results.data_vars and not force:
-                raise exceptions.ModelError(
-                    "This model object already has results. "
-                    "Use model.solve(force=True) to force"
-                    "the results to be overwritten with a new run."
-                )
-            else:
-                to_drop = self.results.data_vars
+        # Check that results exist and are non-empty
+        if self.results.data_vars and not force:
+            raise exceptions.ModelError(
+                "This model object already has results. "
+                "Use model.solve(force=True) to force"
+                "the results to be overwritten with a new run."
+            )
 
-        self._def = self._def.update({"config.solve": kwargs})
+        self.attrs = self.attrs.update({"model_def": {"config.solve": kwargs}})
+        self.inputs = self.inputs.assign_attrs(
+            model_def=self.attrs.model_def.model_dump()
+        )
 
         self.backend.shadow_prices.track_constraints(self.config.solve.shadow_prices)
 
         mode = self.config.build.mode
-        self._model_data.attrs["timestamp_solve_start"] = log_time(
+        log_time(
             LOGGER,
-            self._timings,
+            self.attrs.timings,
             "solve_start",
             comment=f"Optimisation model | starting model in {mode} mode.",
         )
@@ -349,7 +345,7 @@ class Model:
 
         log_time(
             LOGGER,
-            self._timings,
+            self.attrs.timings,
             "solver_exit",
             time_since_solve_start=True,
             comment="Backend: solver finished running",
@@ -358,31 +354,27 @@ class Model:
         # Add additional post-processed result variables to results
         if results.attrs["termination_condition"] in ["optimal", "feasible"]:
             results = postprocess_results.postprocess_model_results(
-                results, self._model_data, self.config.solve.zero_threshold
+                results, self.inputs, self.config.solve.zero_threshold
             )
+        attrs = list(results.attrs.keys())
+        self.attrs = self.attrs.update({k: results.attrs.pop(k) for k in attrs})
 
         log_time(
             LOGGER,
-            self._timings,
+            self.attrs.timings,
             "postprocess_complete",
             time_since_solve_start=True,
             comment="Postprocessing: ended",
         )
 
-        self._model_data = self._model_data.drop_vars(to_drop)
-
-        self._model_data.attrs.update(results.attrs)
-        self._model_data = xr.merge(
-            [results, self._model_data], compat="override", combine_attrs="no_conflicts"
-        )
-
-        self._model_data.attrs["timestamp_solve_complete"] = log_time(
+        log_time(
             LOGGER,
-            self._timings,
+            self.attrs.timings,
             "solve_complete",
             time_since_solve_start=True,
             comment="Backend: model solve completed",
         )
+        self.results = results
 
         self._is_solved = True
 
@@ -401,16 +393,9 @@ class Model:
 
     def to_netcdf(self, path):
         """Save complete model data (inputs and, if available, results) to a NetCDF file at the given `path`."""
-        saved_attrs = {}
-        for attr in set(self.ATTRS_SAVED) & set(self.__dict__.keys()):
-            if attr == "_def":
-                saved_attrs[attr] = self._def.model_dump()
-            elif not isinstance(getattr(self, attr), str | list | None):
-                saved_attrs[attr] = dict(getattr(self, attr))
-            else:
-                saved_attrs[attr] = getattr(self, attr)
-
-        io.save_netcdf(self._model_data, path, **saved_attrs)
+        io.save_netcdf(self.inputs, "inputs", "w", path)
+        io.save_netcdf(self.results, "results", "a", path)
+        io.save_netcdf(xr.Dataset(attrs=self.attrs.model_dump()), "attrs", "a", path)
 
     def to_csv(
         self, path: str | Path, dropna: bool = True, allow_overwrite: bool = False
@@ -428,7 +413,14 @@ class Model:
                 Defaults to False.
 
         """
-        io.save_csv(self._model_data, path, dropna, allow_overwrite)
+        io.save_csv(self.inputs, "inputs", path, dropna, allow_overwrite)
+
+        if self.results:
+            io.save_csv(self.results, "results", path, dropna, allow_overwrite=True)
+        else:
+            exceptions.warn("No results available, saving inputs only.")
+
+        io.to_yaml(self.attrs.model_dump(), path=Path(path) / "attrs.yaml")
 
     def info(self) -> str:
         """Generate basic description of the model, combining its name and a rough indication of the model size.
@@ -439,8 +431,8 @@ class Model:
         info_strings = []
         model_name = self.name
         info_strings.append(f"Model name:   {model_name}")
-        msize = dict(self._model_data.dims)
-        msize_exists = self._model_data.definition_matrix.sum()
+        msize = dict(self.inputs.dims)
+        msize_exists = self.inputs.definition_matrix.sum()
         info_strings.append(
             f"Model size:   {msize} ({msize_exists.item()} valid node:tech:carrier combinations)"
         )
@@ -457,25 +449,25 @@ class Model:
         Returns:
             xr.Dataset: Slice of input data.
         """
-        self._model_data.coords["windowsteps"] = pd.date_range(
+        self.inputs.coords["windowsteps"] = pd.date_range(
             self.inputs.timesteps[0].item(),
             self.inputs.timesteps[-1].item(),
             freq=operate_config.window,
         )
-        horizonsteps = self._model_data.coords["windowsteps"] + pd.Timedelta(
+        horizonsteps = self.inputs.coords["windowsteps"] + pd.Timedelta(
             operate_config.horizon
         )
         # We require an offset because pandas / xarray slicing is _inclusive_ of both endpoints
         # where we only want it to be inclusive of the left endpoint.
         # Except in the last time horizon, where we want it to include the right endpoint.
         clipped_horizonsteps = horizonsteps.clip(
-            max=self._model_data.timesteps[-1] + self._TS_OFFSET
+            max=self.inputs.timesteps[-1] + self._TS_OFFSET
         ).drop_vars("timesteps")
-        self._model_data.coords["horizonsteps"] = clipped_horizonsteps - self._TS_OFFSET
-        sliced_inputs = self._model_data.sel(
+        self.inputs.coords["horizonsteps"] = clipped_horizonsteps - self._TS_OFFSET
+        sliced_inputs = self.inputs.sel(
             timesteps=slice(
-                self._model_data.windowsteps[self._start_window_idx],
-                self._model_data.horizonsteps[self._start_window_idx],
+                self.inputs.windowsteps[self._start_window_idx],
+                self.inputs.horizonsteps[self._start_window_idx],
             )
         )
         if operate_config.use_cap_results:
@@ -485,8 +477,8 @@ class Model:
                     "Cannot use base mode capacity results in operate mode if a solution does not yet exist for the model."
                 )
             for parameter in to_parameterise.keys():
-                if parameter in self._model_data:
-                    self._model_data[parameter].attrs["is_result"] = 0
+                if parameter in self.results:
+                    self.inputs[parameter] = self.results[parameter]
 
         return sliced_inputs
 
@@ -502,7 +494,7 @@ class Model:
         Returns:
             xr.Dataset: Results dataset.
         """
-        if self.backend.inputs.timesteps[0] != self._model_data.timesteps[0]:
+        if self.backend.inputs.timesteps[0] != self.inputs.timesteps[0]:
             LOGGER.info("Optimisation model | Resetting model to first time window.")
             self.build(force=True)
 
@@ -512,7 +504,7 @@ class Model:
 
         results_list = []
 
-        for idx, windowstep in enumerate(self._model_data.windowsteps[1:]):
+        for idx, windowstep in enumerate(self.inputs.windowsteps[1:]):
             windowstep_as_string = windowstep.dt.strftime("%Y-%m-%d %H:%M:%S").item()
             LOGGER.info(
                 f"Optimisation model | Running time window starting at {windowstep_as_string}."
@@ -523,7 +515,7 @@ class Model:
                 )
             )
             previous_iteration_results = results_list[-1]
-            horizonstep = self._model_data.horizonsteps.sel(windowsteps=windowstep)
+            horizonstep = self.inputs.horizonsteps.sel(windowsteps=windowstep)
             new_inputs = self.inputs.sel(
                 timesteps=slice(windowstep, horizonstep)
             ).drop_vars(["horizonsteps", "windowsteps"], errors="ignore")
@@ -586,7 +578,7 @@ class Model:
         """
         LOGGER.info("Optimisation model | Resetting SPORES parameters.")
         for init_param in ["spores_score", "spores_baseline_cost"]:
-            default = xr.DataArray(self.inputs.attrs["defaults"][init_param])
+            default = xr.DataArray(self.attrs["defaults"][init_param])
             self.backend.update_parameter(
                 init_param, self.inputs.get(init_param, default)
             )
@@ -663,13 +655,13 @@ class Model:
         if results.attrs["termination_condition"] in ["optimal", "feasible"]:
             timestamp_solve_complete = log_time(
                 LOGGER,
-                self._timings,
+                self.attrs.timings,
                 "solve_complete",
                 time_since_solve_start=True,
                 comment=f"Optimisation model | SPORE {spore} complete",
             )
             results = postprocess_results.postprocess_model_results(
-                results, self._model_data, self.config.solve.zero_threshold
+                results, self.inputs, self.config.solve.zero_threshold
             )
 
             spores_config.save_per_spore_path.mkdir(parents=True, exist_ok=True)
@@ -677,8 +669,10 @@ class Model:
 
             io.save_netcdf(
                 results.expand_dims(spores=[spore])
-                .assign_attrs(**self._model_data.attrs)
+                .assign_attrs(**self.attrs)
                 .assign_attrs(timestamp_solve_complete=timestamp_solve_complete),
+                "results",
+                "w",
                 spores_config.save_per_spore_path / f"spore_{spore}.nc",
             )
         else:

--- a/src/calliope/postprocess/math_documentation.py
+++ b/src/calliope/postprocess/math_documentation.py
@@ -5,6 +5,7 @@ import typing
 from pathlib import Path
 from typing import Literal, overload
 
+from calliope import AttrDict
 from calliope.backend import ALLOWED_MATH_FILE_FORMATS, LatexBackendModel
 from calliope.model import Model
 
@@ -28,12 +29,12 @@ class MathDocumentation:
                 which at least one "where" case is valid ("valid"). Defaults to "all".
             **kwargs: kwargs for the LaTeX backend.
         """
-        self.name: str = model.name + " math"
+        self.name: str = "math" if model.name is None else model.name + " math"
         self.backend: LatexBackendModel = LatexBackendModel(
             model.inputs,
-            model.attrs.applied_math.model_dump(),
+            AttrDict(model.applied_math.model_dump()),
             model.config.build,
-            model.attrs.defaults,
+            model._attrs.defaults,
             include,
         )
         self.backend.add_optimisation_components()

--- a/src/calliope/postprocess/math_documentation.py
+++ b/src/calliope/postprocess/math_documentation.py
@@ -32,9 +32,9 @@ class MathDocumentation:
         self.name: str = "math" if model.name is None else model.name + " math"
         self.backend: LatexBackendModel = LatexBackendModel(
             model.inputs,
-            AttrDict(model.applied_math.model_dump()),
-            model.config.build,
-            model._attrs.defaults,
+            AttrDict(model.attrs.applied_math.model_dump()),
+            model.attrs.model_def.config.build,
+            model.attrs.defaults,
             include,
         )
         self.backend.add_optimisation_components()

--- a/src/calliope/postprocess/math_documentation.py
+++ b/src/calliope/postprocess/math_documentation.py
@@ -32,9 +32,9 @@ class MathDocumentation:
         self.name: str = "math" if model.name is None else model.name + " math"
         self.backend: LatexBackendModel = LatexBackendModel(
             model.inputs,
-            AttrDict(model.applied_math.model_dump()),
+            AttrDict(model.math.build.model_dump()),
             model.config.build,
-            model.attrs.defaults,
+            model.runtime.defaults,
             include,
         )
         self.backend.add_optimisation_components()

--- a/src/calliope/postprocess/math_documentation.py
+++ b/src/calliope/postprocess/math_documentation.py
@@ -5,7 +5,7 @@ import typing
 from pathlib import Path
 from typing import Literal, overload
 
-from calliope import AttrDict
+from calliope.attrdict import AttrDict
 from calliope.backend import ALLOWED_MATH_FILE_FORMATS, LatexBackendModel
 from calliope.model import Model
 
@@ -32,8 +32,8 @@ class MathDocumentation:
         self.name: str = "math" if model.name is None else model.name + " math"
         self.backend: LatexBackendModel = LatexBackendModel(
             model.inputs,
-            AttrDict(model.attrs.applied_math.model_dump()),
-            model.attrs.model_def.config.build,
+            AttrDict(model.applied_math.model_dump()),
+            model.config.build,
             model.attrs.defaults,
             include,
         )

--- a/src/calliope/postprocess/math_documentation.py
+++ b/src/calliope/postprocess/math_documentation.py
@@ -30,7 +30,11 @@ class MathDocumentation:
         """
         self.name: str = model.name + " math"
         self.backend: LatexBackendModel = LatexBackendModel(
-            model._model_data, model.applied_math, model.config.build, include
+            model.inputs,
+            model.attrs.applied_math.model_dump(),
+            model.config.build,
+            model.attrs.defaults,
+            include,
         )
         self.backend.add_optimisation_components()
 

--- a/src/calliope/postprocess/postprocess.py
+++ b/src/calliope/postprocess/postprocess.py
@@ -40,10 +40,6 @@ def postprocess_model_results(
 
     results = clean_results(results, zero_threshold)
 
-    for var_data in results.data_vars.values():
-        if "is_result" not in var_data.attrs.keys():
-            var_data.attrs["is_result"] = 1
-
     return results
 
 

--- a/src/calliope/preprocess/data_tables.py
+++ b/src/calliope/preprocess/data_tables.py
@@ -292,7 +292,7 @@ class DataTable:
         else:
             tdf = df
 
-        if "select" in self.input.keys():
+        if self.input["select"] is not None:
             selector = tuple(
                 (
                     listify(self.input["select"][name])
@@ -303,10 +303,10 @@ class DataTable:
             )
             tdf = tdf.loc[selector]
 
-        if "drop" in self.input.keys():
+        if self.input["drop"] is not None:
             tdf = tdf.droplevel(self.input["drop"])
 
-        if "add_dims" in self.input.keys():
+        if self.input["add_dims"] is not None:
             for dim_name, index_items in self.input["add_dims"].items():
                 index_items = listify(index_items)
                 tdf = pd.concat(

--- a/src/calliope/preprocess/data_tables.py
+++ b/src/calliope/preprocess/data_tables.py
@@ -292,7 +292,7 @@ class DataTable:
         else:
             tdf = df
 
-        if self.input["select"] is not None:
+        if self.input.get("select", None) is not None:
             selector = tuple(
                 (
                     listify(self.input["select"][name])
@@ -303,10 +303,10 @@ class DataTable:
             )
             tdf = tdf.loc[selector]
 
-        if self.input["drop"] is not None:
+        if self.input.get("drop", None) is not None:
             tdf = tdf.droplevel(self.input["drop"])
 
-        if self.input["add_dims"] is not None:
+        if self.input.get("add_dims", None) is not None:
             for dim_name, index_items in self.input["add_dims"].items():
                 index_items = listify(index_items)
                 tdf = pd.concat(

--- a/src/calliope/preprocess/model_data.py
+++ b/src/calliope/preprocess/model_data.py
@@ -150,8 +150,7 @@ class ModelDataFactory:
             for param, lookup_dim in self.LOOKUP_PARAMS.items():
                 lookup_dict = data_table.lookup_dict_from_param(param, lookup_dim)
                 self.tech_data_from_tables.union(lookup_dict)
-                if lookup_dict:
-                    data_table.drop(param)
+                data_table.drop(param)
 
         for data_table in data_tables:
             self._add_to_dataset(
@@ -507,7 +506,7 @@ class ModelDataFactory:
                     "Check lengths of arrays or set `config.init.broadcast_param_data` to True "
                     "to allow single data entries to be broadcast across all parameter index items."
                 )
-        elif param_name in self.LOOKUP_PARAMS.keys():
+        elif param_name in self.LOOKUP_PARAMS.keys() and param_data is not None:
             data = True
             index_items = [[i] for i in listify(param_data)]
             dims = [self.LOOKUP_PARAMS[param_name]]

--- a/src/calliope/preprocess/model_data.py
+++ b/src/calliope/preprocess/model_data.py
@@ -379,10 +379,10 @@ class ModelDataFactory:
             self.dataset["color"] = self.dataset["color"].fillna(new_color_array)
 
     def assign_input_attr(self):
-        """All input parameters need to be assigned the `is_result=False` attribute to be able to filter the arrays in the calliope.Model object."""
+        """Assign the the available parameter metadata as attributes to each input parameter array."""
         for var_name, var_data in self.dataset.data_vars.items():
             self.dataset[var_name] = var_data.assign_attrs(
-                is_result=False, **self.param_attrs.get(var_name, {})
+                **self.param_attrs.get(var_name, {})
             )
 
     def _get_relevant_node_refs(self, techs_dict: AttrDict, node: str) -> list[str]:

--- a/src/calliope/preprocess/model_data.py
+++ b/src/calliope/preprocess/model_data.py
@@ -76,7 +76,6 @@ class ModelDataFactory:
         model_definition: AttrDict,
         definition_path: str | Path | None,
         data_table_dfs: dict[str, pd.DataFrame] | None,
-        attributes: dict,
         param_attributes: dict[str, dict],
     ):
         """Take a Calliope model definition dictionary and convert it into an xarray Dataset, ready for constraint generation.
@@ -93,7 +92,7 @@ class ModelDataFactory:
         """
         self.config: Init = init_config
         self.model_definition: ModelDefinition = model_definition.copy()
-        self.dataset = xr.Dataset(attrs=AttrDict(attributes))
+        self.dataset = xr.Dataset()
         self.tech_data_from_tables = AttrDict()
         self.definition_path: str | Path | None = definition_path
         tables = []

--- a/src/calliope/preprocess/model_definition.py
+++ b/src/calliope/preprocess/model_definition.py
@@ -21,7 +21,7 @@ def prepare_model_definition(
     override_dict: dict | None = None,
     definition_path: Path | None = None,
     **kwargs,
-) -> tuple[AttrDict, str]:
+) -> tuple[model_def_schema.CalliopeModelDef, str]:
     """Arrange model definition data following our standardised order of priority.
 
     Should always be called when defining calliope models from configuration files.
@@ -51,8 +51,7 @@ def prepare_model_definition(
     model_def["math"] = initialise_math(config.init.extra_math, definition_path)
 
     # Validate
-    # TODO: returned object should be CalliopeModelDef
-    model_def_schema.CalliopeModelDef(**model_def)
+    model_def = model_def_schema.CalliopeModelDef(**model_def)
 
     return model_def, applied_overrides
 

--- a/src/calliope/preprocess/model_definition.py
+++ b/src/calliope/preprocess/model_definition.py
@@ -16,9 +16,10 @@ LOGGER = logging.getLogger(__name__)
 
 
 def prepare_model_definition(
-    model_definition: str | Path | dict,
+    model_definition: dict,
     scenario: str | None = None,
     override_dict: dict | None = None,
+    definition_path: Path | None = None,
     **kwargs,
 ) -> tuple[AttrDict, str]:
     """Arrange model definition data following our standardised order of priority.
@@ -32,22 +33,15 @@ def prepare_model_definition(
         model_definition (str | Path | dict): model data file or dictionary.
         scenario (str | None, optional): scenario to run. Defaults to None.
         override_dict (dict | None, optional): additional overrides. Defaults to None.
+        definition_path (Path | None): If given, path relative to which referenced files will be loaded.
         **kwargs: Initialisation overrides.
 
     Returns:
         tuple[AttrDict, str]: fully defined setup
     """
-    # Identify the instantiation case
-    if isinstance(model_definition, dict):
-        raw_data = AttrDict(model_definition)
-        definition_path = None
-    else:
-        raw_data = read_rich_yaml(model_definition)
-        definition_path = model_definition
-
     # Apply overrides and similar modifications 'on top' of the given definition
     model_def, applied_overrides = _load_scenario_overrides(
-        raw_data, scenario, override_dict
+        model_definition, scenario, override_dict
     )
     model_def = TemplateSolver(model_def).resolved_data
     model_def.union({"config.init": kwargs}, allow_override=True)

--- a/src/calliope/preprocess/model_definition.py
+++ b/src/calliope/preprocess/model_definition.py
@@ -9,11 +9,27 @@ from calliope import exceptions
 from calliope.attrdict import AttrDict
 from calliope.io import read_rich_yaml, to_yaml
 from calliope.preprocess.model_math import initialise_math
-from calliope.schemas import attrs_schema
+from calliope.schemas import (
+    attrs_schema,
+    config_schema,
+    general,
+    math_schema,
+    model_def_schema,
+)
 from calliope.util.schema import MODEL_SCHEMA, extract_from_schema
 from calliope.util.tools import listify
 
 LOGGER = logging.getLogger(__name__)
+
+
+class CalliopeInputs(general.CalliopeBaseModel):
+    """All Calliope attributes."""
+
+    model_config = {"frozen": False}
+    definition: model_def_schema.CalliopeModelDef = model_def_schema.CalliopeModelDef()
+    config: config_schema.CalliopeConfig = config_schema.CalliopeConfig()
+    math: math_schema.CalliopeInputMath = math_schema.CalliopeInputMath()
+    attrs: attrs_schema.CalliopeAttrs = attrs_schema.CalliopeAttrs()
 
 
 def prepare_model_definition(
@@ -22,7 +38,7 @@ def prepare_model_definition(
     override_dict: dict | None = None,
     definition_path: Path | None = None,
     **kwargs,
-) -> attrs_schema.CalliopeModelAttrs:
+) -> CalliopeInputs:
     """Arrange model definition data following our standardised order of priority.
 
     Should always be called when defining calliope models from configuration files.
@@ -58,9 +74,7 @@ def prepare_model_definition(
         "defaults": extract_from_schema(MODEL_SCHEMA, "default"),
     }
 
-    return attrs_schema.CalliopeModelAttrs(
-        config=config, definition=definition, math=math, attrs=attrs
-    )
+    return CalliopeInputs(config=config, definition=definition, math=math, attrs=attrs)
 
 
 def _load_scenario_overrides(

--- a/src/calliope/preprocess/model_definition.py
+++ b/src/calliope/preprocess/model_definition.py
@@ -40,18 +40,18 @@ def prepare_model_definition(
         tuple[AttrDict, str]: fully defined setup
     """
     # Apply overrides and similar modifications 'on top' of the given definition
-    model_def, applied_overrides = _load_scenario_overrides(
+    model_def_dict, applied_overrides = _load_scenario_overrides(
         model_definition, scenario, override_dict
     )
-    model_def = TemplateSolver(model_def).resolved_data
-    model_def.union({"config.init": kwargs}, allow_override=True)
+    model_def_dict = TemplateSolver(model_def_dict).resolved_data
+    model_def_dict.union({"config.init": kwargs}, allow_override=True)
 
     # Pre-fill config. defaults and fetch the math definition
-    config = config_schema.CalliopeConfig(**model_def["config"])
-    model_def["math"] = initialise_math(config.init.extra_math, definition_path)
+    config = config_schema.CalliopeConfig(**model_def_dict["config"])
+    model_def_dict["math"] = initialise_math(config.init.extra_math, definition_path)
 
     # Validate
-    model_def = model_def_schema.CalliopeModelDef(**model_def)
+    model_def = model_def_schema.CalliopeModelDef(**model_def_dict)
 
     return model_def, applied_overrides
 

--- a/src/calliope/preprocess/model_math.py
+++ b/src/calliope/preprocess/model_math.py
@@ -81,7 +81,7 @@ def build_applied_math(
         ModelError: a given name was not found in the math dictionary.
 
     Returns:
-        MathSchema: constructed and validated math dataset.
+        AttrDict: constructed and validated math dataset.
     """
     LOGGER.info(f"Math build | building applied math with {priority}.")
     math = AttrDict()

--- a/src/calliope/preprocess/model_math.py
+++ b/src/calliope/preprocess/model_math.py
@@ -81,7 +81,7 @@ def build_applied_math(
         ModelError: a given name was not found in the math dictionary.
 
     Returns:
-        AttrDict: constructed and validated math dataset.
+        MathSchema: constructed and validated math dataset.
     """
     LOGGER.info(f"Math build | building applied math with {priority}.")
     math = AttrDict()

--- a/src/calliope/schemas/__init__.py
+++ b/src/calliope/schemas/__init__.py
@@ -1,0 +1,18 @@
+from calliope.schemas import (
+    config_schema,
+    general,
+    math_schema,
+    model_def_schema,
+    runtime_attrs_schema,
+)
+
+
+class CalliopeInputs(general.CalliopeBaseModel):
+    """All Calliope attributes."""
+
+    definition: model_def_schema.CalliopeModelDef = model_def_schema.CalliopeModelDef()
+    config: config_schema.CalliopeConfig = config_schema.CalliopeConfig()
+    math: math_schema.CalliopeMath = math_schema.CalliopeMath()
+    runtime: runtime_attrs_schema.CalliopeRuntime = (
+        runtime_attrs_schema.CalliopeRuntime()
+    )

--- a/src/calliope/schemas/attributes.py
+++ b/src/calliope/schemas/attributes.py
@@ -1,0 +1,73 @@
+# Copyright (C) since 2013 Calliope contributors listed in AUTHORS.
+# Licensed under the Apache 2.0 License (see LICENSE file).
+"""Schema for Calliope model attributes."""
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from calliope import _version, exceptions
+from calliope.schemas.general import CalliopeBaseModel
+from calliope.schemas.math_schema import MathSchema
+from calliope.schemas.model_def_schema import CalliopeModelDef
+
+
+class CalliopeModelAttrs(CalliopeBaseModel):
+    """Calliope model definition."""
+
+    model_config = {"title": "Calliope Model Attributes"}
+
+    model_def: CalliopeModelDef = CalliopeModelDef()
+    """Full model definition (except any data table contents)"""
+
+    applied_math: MathSchema = MathSchema()
+    """Math applied when building or updating the optimisation problem."""
+
+    applied_overrides: str | None = None
+    """Overrides applied when initialising the model."""
+
+    allow_operate_mode: bool = True
+    """If False, building in `operate` mode will not be allowed."""
+
+    calliope_version_initialised: str = _version.__version__
+    """The calliope version this model was initialised with."""
+
+    defaults: dict = Field(default_factory=dict)
+    """Dictionary of parameter defaults from the calliope model definition schema."""
+
+    scenario: str | None = None
+    """Scenario applied on initialising the model."""
+
+    timings: dict[str, float] = Field(default_factory=dict)
+    """Dictionary of timings that is updated as the model is initialised/built/solved."""
+
+    termination_condition: str | None = None
+    """Indicates whether the optimisation problem solved to optimality (`optimal`) or not (e.g. `unbounded`, `infeasible`)."""
+
+    @property
+    def calliope_version_defined(self) -> str | None:
+        """Calliope version defined for this model."""
+        return self.model_def.config.init.calliope_version
+
+    @model_validator(mode="after")
+    def check_versions(self) -> Self:
+        """Check the initialised and defined calliope version.
+
+        Returns:
+            Self: unchanged pydantic model.
+        """
+        version_def = self.calliope_version_defined
+        version_init = self.calliope_version_initialised
+
+        if not _version.__version__.startswith(version_init):
+            exceptions.warn(
+                f"Model was initialised with calliope version {version_init}, "
+                f"but you are running {_version.__version__}. Proceed with caution!"
+            )
+
+        if version_def is not None and not version_init.startswith(version_def):
+            exceptions.warn(
+                f"Model configuration specifies calliope version {version_def}, "
+                f"but you are running {version_init}. Proceed with caution!"
+            )
+        return self

--- a/src/calliope/schemas/attrs_schema.py
+++ b/src/calliope/schemas/attrs_schema.py
@@ -5,13 +5,6 @@
 from pydantic import Field
 
 from calliope import _version
-from calliope.schemas import (
-    attrs_schema,
-    config_schema,
-    general,
-    math_schema,
-    model_def_schema,
-)
 from calliope.schemas.general import CalliopeBaseModel
 
 
@@ -40,14 +33,3 @@ class CalliopeAttrs(CalliopeBaseModel):
 
     termination_condition: str | None = None
     """Indicates whether the optimisation problem solved to optimality (`optimal`) or not (e.g. `unbounded`, `infeasible`)."""
-
-
-class CalliopeModelAttrs(general.CalliopeBaseModel):
-    """All Calliope attributes."""
-
-    model_config = {"frozen": False}
-    definition: model_def_schema.CalliopeModelDef = model_def_schema.CalliopeModelDef()
-    config: config_schema.CalliopeConfig = config_schema.CalliopeConfig()
-    math: math_schema.CalliopeInputMath = math_schema.CalliopeInputMath()
-    attrs: attrs_schema.CalliopeAttrs = attrs_schema.CalliopeAttrs()
-    applied_math: math_schema.MathSchema = math_schema.MathSchema()

--- a/src/calliope/schemas/attrs_schema.py
+++ b/src/calliope/schemas/attrs_schema.py
@@ -5,21 +5,20 @@
 from pydantic import Field
 
 from calliope import _version
+from calliope.schemas import (
+    attrs_schema,
+    config_schema,
+    general,
+    math_schema,
+    model_def_schema,
+)
 from calliope.schemas.general import CalliopeBaseModel
-from calliope.schemas.math_schema import MathSchema
-from calliope.schemas.model_def_schema import CalliopeModelDef
 
 
 class CalliopeAttrs(CalliopeBaseModel):
     """Calliope model definition."""
 
     model_config = {"title": "Calliope Model Attributes"}
-
-    model_def: CalliopeModelDef = CalliopeModelDef()
-    """Full model definition (except any data table contents)"""
-
-    applied_math: MathSchema = MathSchema()
-    """Math applied when building or updating the optimisation problem."""
 
     applied_overrides: str | None = None
     """Overrides applied when initialising the model."""
@@ -41,3 +40,14 @@ class CalliopeAttrs(CalliopeBaseModel):
 
     termination_condition: str | None = None
     """Indicates whether the optimisation problem solved to optimality (`optimal`) or not (e.g. `unbounded`, `infeasible`)."""
+
+
+class CalliopeModelAttrs(general.CalliopeBaseModel):
+    """All Calliope attributes."""
+
+    model_config = {"frozen": False}
+    definition: model_def_schema.CalliopeModelDef = model_def_schema.CalliopeModelDef()
+    config: config_schema.CalliopeConfig = config_schema.CalliopeConfig()
+    math: math_schema.CalliopeInputMath = math_schema.CalliopeInputMath()
+    attrs: attrs_schema.CalliopeAttrs = attrs_schema.CalliopeAttrs()
+    applied_math: math_schema.MathSchema = math_schema.MathSchema()

--- a/src/calliope/schemas/attrs_schema.py
+++ b/src/calliope/schemas/attrs_schema.py
@@ -2,17 +2,15 @@
 # Licensed under the Apache 2.0 License (see LICENSE file).
 """Schema for Calliope model attributes."""
 
-from typing import Self
+from pydantic import Field
 
-from pydantic import Field, model_validator
-
-from calliope import _version, exceptions
+from calliope import _version
 from calliope.schemas.general import CalliopeBaseModel
 from calliope.schemas.math_schema import MathSchema
 from calliope.schemas.model_def_schema import CalliopeModelDef
 
 
-class CalliopeModelAttrs(CalliopeBaseModel):
+class CalliopeAttrs(CalliopeBaseModel):
     """Calliope model definition."""
 
     model_config = {"title": "Calliope Model Attributes"}
@@ -43,31 +41,3 @@ class CalliopeModelAttrs(CalliopeBaseModel):
 
     termination_condition: str | None = None
     """Indicates whether the optimisation problem solved to optimality (`optimal`) or not (e.g. `unbounded`, `infeasible`)."""
-
-    @property
-    def calliope_version_defined(self) -> str | None:
-        """Calliope version defined for this model."""
-        return self.model_def.config.init.calliope_version
-
-    @model_validator(mode="after")
-    def check_versions(self) -> Self:
-        """Check the initialised and defined calliope version.
-
-        Returns:
-            Self: unchanged pydantic model.
-        """
-        version_def = self.calliope_version_defined
-        version_init = self.calliope_version_initialised
-
-        if not _version.__version__.startswith(version_init):
-            exceptions.warn(
-                f"Model was initialised with calliope version {version_init}, "
-                f"but you are running {_version.__version__}. Proceed with caution!"
-            )
-
-        if version_def is not None and not version_init.startswith(version_def):
-            exceptions.warn(
-                f"Model configuration specifies calliope version {version_def}, "
-                f"but you are running {version_init}. Proceed with caution!"
-            )
-        return self

--- a/src/calliope/schemas/data_table_schema.py
+++ b/src/calliope/schemas/data_table_schema.py
@@ -2,10 +2,15 @@
 # Licensed under the Apache 2.0 License (see LICENSE file).
 """Schema for data table definition."""
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 from typing_extensions import Self
 
-from calliope.schemas.general import AttrStr, CalliopeBaseModel, UniqueList
+from calliope.schemas.general import (
+    AttrStr,
+    CalliopeBaseModel,
+    CalliopeDictModel,
+    UniqueList,
+)
 from calliope.util.tools import listify
 
 
@@ -79,3 +84,9 @@ class CalliopeDataTable(CalliopeBaseModel):
                     "Renamed dimensions must be in either rows or columns."
                 )
         return self
+
+
+class CalliopeDataTables(CalliopeDictModel):
+    """Calliope input data table dictionary."""
+
+    root: dict[AttrStr, CalliopeDataTable] = Field(default_factory=dict)

--- a/src/calliope/schemas/dimension_data_schema.py
+++ b/src/calliope/schemas/dimension_data_schema.py
@@ -81,26 +81,6 @@ class CalliopeTech(DimensionData):
     One of the abstract base classes, used to derive specific parameter defaults and
     to activate technology-specific constraints.
     """
-    carrier_in: AttrStr | NonEmptyUniqueList[AttrStr] | None = None
-    """
-    Carrier(s) consumed by this technology.
-    Only for `transmission`, `conversion`, `storage`, and `demand` technologies.
-    """
-    carrier_out: AttrStr | NonEmptyUniqueList[AttrStr] | None = None
-    """
-    Carrier(s) produced by this technology.
-    Only for `transmission`, `conversion`, `storage`, and `supply` technologies.
-    """
-    carrier_export: AttrStr | NonEmptyUniqueList[AttrStr] | None = None
-    """
-    Carrier(s) produced by this technology that can be exported out of the system
-    without having to go to a pre-defined `sink` (i.e., via a `demand` technology).
-    Must be a subset of `carrier_out`.
-    """
-    link_from: AttrStr | NonEmptyUniqueList[AttrStr] | None = None
-    """Connected start point. Only for `transmission` technologies."""
-    link_to: AttrStr | NonEmptyUniqueList[AttrStr] | None = None
-    """Connected end point. Only for `transmission` technologies."""
 
 
 class CalliopeNode(DimensionData):

--- a/src/calliope/schemas/dimension_data_schema.py
+++ b/src/calliope/schemas/dimension_data_schema.py
@@ -10,6 +10,7 @@ from typing_extensions import Self
 from calliope.schemas.general import (
     AttrStr,
     CalliopeBaseModel,
+    CalliopeDictModel,
     NonEmptyList,
     NonEmptyUniqueList,
     NumericVal,
@@ -68,7 +69,9 @@ class DimensionData(CalliopeBaseModel):
     model_config = {"title": "Generic dimension data", "extra": "allow"}
 
     active: bool = True
-    __pydantic_extra__: dict[AttrStr, IndexedTechNodeParam | DataValue]
+    __pydantic_extra__: dict[
+        AttrStr, IndexedTechNodeParam | DataValue | NonEmptyList[DataValue]
+    ]
 
 
 class CalliopeTech(DimensionData):
@@ -105,3 +108,21 @@ class CalliopeNode(DimensionData):
                 f"Invalid latitude/longitude definition. Types must match, found ({self.latitude}, {self.longitude})."
             )
         return self
+
+
+class CalliopeParams(CalliopeDictModel):
+    """Calliope Parameters dictionary."""
+
+    root: dict[AttrStr, DataValue | IndexedParam] = Field(default_factory=dict)
+
+
+class CalliopeTechs(CalliopeDictModel):
+    """Calliope Techs dictionary."""
+
+    root: dict[AttrStr, CalliopeTech | None] = Field(default_factory=dict)
+
+
+class CalliopeNodes(CalliopeDictModel):
+    """Calliope Nodes dictionary."""
+
+    root: dict[AttrStr, CalliopeNode] = Field(default_factory=dict)

--- a/src/calliope/schemas/math_schema.py
+++ b/src/calliope/schemas/math_schema.py
@@ -82,13 +82,13 @@ class PiecewiseConstraint(MathIndexedComponent):
     values at specified breakpoints.
     """
 
-    x_expression: str = ""
+    x_expression: str
     """X variable name whose values are assigned at each breakpoint."""
-    y_expression: str = ""
+    y_expression: str
     """Y variable name whose values are assigned at each breakpoint."""
-    x_values: str = ""
+    x_values: str
     """X parameter name containing data, indexed over the `breakpoints` dimension."""
-    y_values: str = ""
+    y_values: str
     """Y parameter name containing data, indexed over the `breakpoints` dimension."""
 
 

--- a/src/calliope/schemas/math_schema.py
+++ b/src/calliope/schemas/math_schema.py
@@ -154,13 +154,15 @@ class MathSchema(CalliopeBaseModel):
 
     model_config = {"title": "Model math schema"}
 
-    variables: dict[AttrStr, Variable] = Field(default={})
+    variables: dict[AttrStr, Variable] = Field(default_factory=dict)
     """All decision variables to include in the optimisation problem."""
-    global_expressions: dict[AttrStr, GlobalExpression] = Field(default={})
+    global_expressions: dict[AttrStr, GlobalExpression] = Field(default_factory=dict)
     """All global expressions that can be applied to the optimisation problem."""
-    constraints: dict[AttrStr, Constraint] = Field(default={})
+    constraints: dict[AttrStr, Constraint] = Field(default_factory=dict)
     """All constraints to apply to the optimisation problem."""
-    piecewise_constraints: dict[AttrStr, PiecewiseConstraint] = Field(default={})
+    piecewise_constraints: dict[AttrStr, PiecewiseConstraint] = Field(
+        default_factory=dict
+    )
     """All _piecewise_ constraints to apply to the optimisation problem."""
-    objectives: dict[AttrStr, Objective] = Field(default={})
+    objectives: dict[AttrStr, Objective] = Field(default_factory=dict)
     """Possible objectives to apply to the optimisation problem."""

--- a/src/calliope/schemas/math_schema.py
+++ b/src/calliope/schemas/math_schema.py
@@ -219,3 +219,10 @@ class CalliopeInputMath(CalliopeDictModel):
     """Calliope input math dictionary."""
 
     root: dict[AttrStr, CalliopeDictModel] = Field(default_factory=dict)
+
+
+class CalliopeMath(CalliopeBaseModel):
+    """Calliope math attribute container."""
+
+    init: CalliopeInputMath = CalliopeInputMath()
+    build: MathSchema = MathSchema()

--- a/src/calliope/schemas/model_def_schema.py
+++ b/src/calliope/schemas/model_def_schema.py
@@ -2,6 +2,8 @@
 # Licensed under the Apache 2.0 License (see LICENSE file).
 """Schema for Calliope model definition."""
 
+from pydantic import Field
+
 from calliope.schemas.config_schema import CalliopeConfig
 from calliope.schemas.data_table_schema import CalliopeDataTable
 from calliope.schemas.dimension_data_schema import (
@@ -18,9 +20,9 @@ class CalliopeModelDef(CalliopeBaseModel):
 
     model_config = {"title": "Calliope Model Definition"}
 
-    parameters: dict[AttrStr, DataValue | IndexedParam] | None = None
-    config: CalliopeConfig
-    data_tables: dict[AttrStr, CalliopeDataTable] | None = None
-    nodes: dict[AttrStr, CalliopeNode] | None = None
-    techs: dict[AttrStr, CalliopeTech] | None = None
-    math: dict[AttrStr, dict]
+    parameters: dict[AttrStr, DataValue | IndexedParam] = Field(default_factory=dict)
+    config: CalliopeConfig = CalliopeConfig()
+    data_tables: dict[AttrStr, CalliopeDataTable] = Field(default_factory=dict)
+    nodes: dict[AttrStr, CalliopeNode] = Field(default_factory=dict)
+    techs: dict[AttrStr, CalliopeTech] = Field(default_factory=dict)
+    math: dict[AttrStr, dict] = Field(default_factory=dict)

--- a/src/calliope/schemas/model_def_schema.py
+++ b/src/calliope/schemas/model_def_schema.py
@@ -2,17 +2,15 @@
 # Licensed under the Apache 2.0 License (see LICENSE file).
 """Schema for Calliope model definition."""
 
-from pydantic import Field
-
 from calliope.schemas.config_schema import CalliopeConfig
-from calliope.schemas.data_table_schema import CalliopeDataTable
+from calliope.schemas.data_table_schema import CalliopeDataTables
 from calliope.schemas.dimension_data_schema import (
-    CalliopeNode,
-    CalliopeTech,
-    DataValue,
-    IndexedParam,
+    CalliopeNodes,
+    CalliopeParams,
+    CalliopeTechs,
 )
-from calliope.schemas.general import AttrStr, CalliopeBaseModel
+from calliope.schemas.general import CalliopeBaseModel
+from calliope.schemas.math_schema import CalliopeInputMath
 
 
 class CalliopeModelDef(CalliopeBaseModel):
@@ -20,9 +18,9 @@ class CalliopeModelDef(CalliopeBaseModel):
 
     model_config = {"title": "Calliope Model Definition"}
 
-    parameters: dict[AttrStr, DataValue | IndexedParam] = Field(default_factory=dict)
+    parameters: CalliopeParams = CalliopeParams()
     config: CalliopeConfig = CalliopeConfig()
-    data_tables: dict[AttrStr, CalliopeDataTable] = Field(default_factory=dict)
-    nodes: dict[AttrStr, CalliopeNode] = Field(default_factory=dict)
-    techs: dict[AttrStr, CalliopeTech] = Field(default_factory=dict)
-    math: dict[AttrStr, dict] = Field(default_factory=dict)
+    data_tables: CalliopeDataTables = CalliopeDataTables()
+    nodes: CalliopeNodes = CalliopeNodes()
+    techs: CalliopeTechs = CalliopeTechs()
+    math: CalliopeInputMath = CalliopeInputMath()

--- a/src/calliope/schemas/model_def_schema.py
+++ b/src/calliope/schemas/model_def_schema.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache 2.0 License (see LICENSE file).
 """Schema for Calliope model definition."""
 
-from calliope.schemas.config_schema import CalliopeConfig
 from calliope.schemas.data_table_schema import CalliopeDataTables
 from calliope.schemas.dimension_data_schema import (
     CalliopeNodes,
@@ -10,7 +9,6 @@ from calliope.schemas.dimension_data_schema import (
     CalliopeTechs,
 )
 from calliope.schemas.general import CalliopeBaseModel
-from calliope.schemas.math_schema import CalliopeInputMath
 
 
 class CalliopeModelDef(CalliopeBaseModel):
@@ -19,8 +17,6 @@ class CalliopeModelDef(CalliopeBaseModel):
     model_config = {"title": "Calliope Model Definition"}
 
     parameters: CalliopeParams = CalliopeParams()
-    config: CalliopeConfig = CalliopeConfig()
     data_tables: CalliopeDataTables = CalliopeDataTables()
     nodes: CalliopeNodes = CalliopeNodes()
     techs: CalliopeTechs = CalliopeTechs()
-    math: CalliopeInputMath = CalliopeInputMath()

--- a/src/calliope/schemas/runtime_attrs_schema.py
+++ b/src/calliope/schemas/runtime_attrs_schema.py
@@ -8,8 +8,8 @@ from calliope import _version
 from calliope.schemas.general import CalliopeBaseModel
 
 
-class CalliopeAttrs(CalliopeBaseModel):
-    """Calliope model definition."""
+class CalliopeRuntime(CalliopeBaseModel):
+    """Calliope runtime model attributes."""
 
     model_config = {"title": "Calliope Model Attributes"}
 

--- a/src/calliope/util/logging.py
+++ b/src/calliope/util/logging.py
@@ -122,14 +122,14 @@ def log_time(
     if comment is None:
         comment = identifier
 
-    timings[identifier] = now = datetime.datetime.now()
+    timings[identifier] = now = datetime.datetime.now().timestamp()
 
     if time_since_solve_start and "solve_start" in timings:
-        time_diff = now - timings["solve_start"]
+        time_diff = datetime.timedelta(seconds=now - timings["solve_start"])
         comment += f". Time since start of solving optimisation problem: {time_diff}"
 
     getattr(logger, level.lower())(comment)
-    return now.timestamp()
+    return now
 
 
 class LogWriter:

--- a/tests/common/util.py
+++ b/tests/common/util.py
@@ -13,7 +13,7 @@ def build_test_model(
     **init_kwargs,
 ):
     """Get the Calliope model object of a test model."""
-    return calliope.Model(
+    return calliope.read_yaml(
         os.path.join(os.path.dirname(__file__), "test_model", model_file),
         override_dict=override_dict,
         scenario=scenario,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,18 @@ def default_config():
 
 @pytest.fixture(scope="session")
 def model_defaults():
-    return AttrDict(extract_from_schema(MODEL_SCHEMA, "default"))
+    inbuilt_defaults = extract_from_schema(MODEL_SCHEMA, "default")
+
+    return AttrDict(
+        {
+            "all_inf": np.inf,
+            "all_nan": np.nan,
+            "with_inf": 100,
+            "only_techs": 5,
+            "no_dims": 0,
+            **inbuilt_defaults,
+        }
+    )
 
 
 @pytest.fixture(scope="session")
@@ -163,7 +174,7 @@ def dummy_model_math():
 
 
 @pytest.fixture(scope="module")
-def dummy_model_data(model_defaults):
+def dummy_model_data():
     coords = {
         dim: (
             ["foo", "bar"]
@@ -268,19 +279,6 @@ def dummy_model_data(model_defaults):
     for k in ["lookup_multi_dim_nodes", "lookup_multi_dim_techs", "lookup_techs"]:
         model_data[k] = model_data[k].where(model_data[k] != "nan")
 
-    for param in model_data.data_vars.values():
-        param.attrs["is_result"] = 0
-
-    model_data.attrs["defaults"] = AttrDict(
-        {
-            "all_inf": np.inf,
-            "all_nan": np.nan,
-            "with_inf": 100,
-            "only_techs": 5,
-            "no_dims": 0,
-            **model_defaults,
-        }
-    )
     # This value is set on the parameter directly to ensure it finds its way through to the LaTex math.
     model_data.no_dims.attrs["default"] = 0
 
@@ -328,34 +326,40 @@ def populate_backend_model(backend):
 
 
 @pytest.fixture(scope="module")
-def dummy_pyomo_backend_model(dummy_model_data, dummy_model_math, default_config):
+def dummy_pyomo_backend_model(
+    dummy_model_data, dummy_model_math, default_config, model_defaults
+):
     backend = pyomo_backend_model.PyomoBackendModel(
         dummy_model_data,
         dummy_model_math,
         default_config.build,
-        defaults=dummy_model_data.attrs["defaults"],
+        defaults=model_defaults,
     )
     return populate_backend_model(backend)
 
 
 @pytest.fixture(scope="module")
-def dummy_latex_backend_model(dummy_model_data, dummy_model_math, default_config):
+def dummy_latex_backend_model(
+    dummy_model_data, dummy_model_math, default_config, model_defaults
+):
     backend = latex_backend_model.LatexBackendModel(
         dummy_model_data,
         dummy_model_math,
         default_config.build,
-        defaults=dummy_model_data.attrs["defaults"],
+        defaults=model_defaults,
     )
     return populate_backend_model(backend)
 
 
 @pytest.fixture(scope="class")
-def valid_latex_backend(dummy_model_data, dummy_model_math, default_config):
+def valid_latex_backend(
+    dummy_model_data, dummy_model_math, default_config, model_defaults
+):
     backend = latex_backend_model.LatexBackendModel(
         dummy_model_data,
         dummy_model_math,
         default_config.build,
-        defaults=dummy_model_data.attrs["defaults"],
+        defaults=model_defaults,
         include="valid",
     )
     return populate_backend_model(backend)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,11 @@ def dummy_int() -> int:
     return 0xDEADBEEF
 
 
+@pytest.fixture(scope="session")
+def minimal_test_model_path():
+    return (Path(__file__).parent / "common" / "test_model" / "model.yaml").as_posix()
+
+
 @pytest.fixture(
     scope="session",
     params=set(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -330,7 +330,10 @@ def populate_backend_model(backend):
 @pytest.fixture(scope="module")
 def dummy_pyomo_backend_model(dummy_model_data, dummy_model_math, default_config):
     backend = pyomo_backend_model.PyomoBackendModel(
-        dummy_model_data, dummy_model_math, default_config.build
+        dummy_model_data,
+        dummy_model_math,
+        default_config.build,
+        defaults=dummy_model_data.attrs["defaults"],
     )
     return populate_backend_model(backend)
 
@@ -338,7 +341,10 @@ def dummy_pyomo_backend_model(dummy_model_data, dummy_model_math, default_config
 @pytest.fixture(scope="module")
 def dummy_latex_backend_model(dummy_model_data, dummy_model_math, default_config):
     backend = latex_backend_model.LatexBackendModel(
-        dummy_model_data, dummy_model_math, default_config.build
+        dummy_model_data,
+        dummy_model_math,
+        default_config.build,
+        defaults=dummy_model_data.attrs["defaults"],
     )
     return populate_backend_model(backend)
 
@@ -346,6 +352,10 @@ def dummy_latex_backend_model(dummy_model_data, dummy_model_math, default_config
 @pytest.fixture(scope="class")
 def valid_latex_backend(dummy_model_data, dummy_model_math, default_config):
     backend = latex_backend_model.LatexBackendModel(
-        dummy_model_data, dummy_model_math, default_config.build, include="valid"
+        dummy_model_data,
+        dummy_model_math,
+        default_config.build,
+        defaults=dummy_model_data.attrs["defaults"],
+        include="valid",
     )
     return populate_backend_model(backend)

--- a/tests/test_backend_general.py
+++ b/tests/test_backend_general.py
@@ -99,11 +99,11 @@ class TestOptimality:
     def test_optimal(self, solved_model_cls):
         """Solved model is optimal."""
         assert hasattr(solved_model_cls, "results")
-        assert solved_model_cls.attrs.termination_condition == "optimal"
+        assert solved_model_cls.runtime.termination_condition == "optimal"
 
     def test_solve_non_optimal(self, infeasible_model_cls):
         """Infeasible models have no results"""
-        assert infeasible_model_cls.attrs.termination_condition == "infeasible"
+        assert infeasible_model_cls.runtime.termination_condition == "infeasible"
         assert not infeasible_model_cls.results.data_vars
 
 

--- a/tests/test_backend_general.py
+++ b/tests/test_backend_general.py
@@ -99,11 +99,11 @@ class TestOptimality:
     def test_optimal(self, solved_model_cls):
         """Solved model is optimal."""
         assert hasattr(solved_model_cls, "results")
-        assert solved_model_cls.attrs["termination_condition"] == "optimal"
+        assert solved_model_cls.attrs.termination_condition == "optimal"
 
     def test_solve_non_optimal(self, infeasible_model_cls):
         """Infeasible models have no results"""
-        assert infeasible_model_cls.attrs["termination_condition"] == "infeasible"
+        assert infeasible_model_cls.attrs.termination_condition == "infeasible"
         assert not infeasible_model_cls.results.data_vars
 
 
@@ -171,7 +171,6 @@ class TestGetters:
         """Check a parameter has all expected attributes."""
         assert parameter.attrs == {
             "obj_type": "parameters",
-            "is_result": 0,
             "original_dtype": "float64",
             "references": {"flow_in_inc_eff"},
             "coords_in_name": False,

--- a/tests/test_backend_general.py
+++ b/tests/test_backend_general.py
@@ -99,14 +99,11 @@ class TestOptimality:
     def test_optimal(self, solved_model_cls):
         """Solved model is optimal."""
         assert hasattr(solved_model_cls, "results")
-        assert solved_model_cls._model_data.attrs["termination_condition"] == "optimal"
+        assert solved_model_cls.attrs["termination_condition"] == "optimal"
 
     def test_solve_non_optimal(self, infeasible_model_cls):
         """Infeasible models have no results"""
-        assert (
-            infeasible_model_cls._model_data.attrs["termination_condition"]
-            == "infeasible"
-        )
+        assert infeasible_model_cls.attrs["termination_condition"] == "infeasible"
         assert not infeasible_model_cls.results.data_vars
 
 
@@ -462,7 +459,7 @@ class TestAdders:
 
     def test_add_allnull_param_with_shape(self, solved_model_func):
         """If parameter is Null in all array elements, the component will still be added to the backend dataset in case it is filled by another parameter later."""
-        nan_array = solved_model_func._model_data.flow_cap_max.where(lambda x: x < 0)
+        nan_array = solved_model_func.inputs.flow_cap_max.where(lambda x: x < 0)
         solved_model_func.backend.add_parameter("foo", nan_array)
 
         # We keep it in the dataset since it might be fillna'd by another param later.

--- a/tests/test_backend_gurobi.py
+++ b/tests/test_backend_gurobi.py
@@ -234,7 +234,7 @@ class TestNewBackend:
             "flow_cap_max", xr.DataArray(0)
         )
         simple_supply_gurobi_func.solve(force=True)
-        assert simple_supply_gurobi_func.attrs.termination_condition != "optimal"
+        assert simple_supply_gurobi_func.runtime.termination_condition != "optimal"
         with pytest.raises(exceptions.BackendError) as excinfo:
             simple_supply_gurobi_func.backend.fix_variable("flow_cap")
 

--- a/tests/test_backend_gurobi.py
+++ b/tests/test_backend_gurobi.py
@@ -92,7 +92,7 @@ class TestNewBackend:
         )
 
     def test_add_valid_obj(self, simple_supply_gurobi):
-        eq = {"expression": "bigM", "where": "True", "active": True}
+        eq = {"expression": "bigM", "where": "True"}
         simple_supply_gurobi.backend.add_objective(
             "foo", {"equations": [eq], "sense": "minimise", "active": True}
         )
@@ -234,7 +234,7 @@ class TestNewBackend:
             "flow_cap_max", xr.DataArray(0)
         )
         simple_supply_gurobi_func.solve(force=True)
-        assert simple_supply_gurobi_func.results.termination_condition != "optimal"
+        assert simple_supply_gurobi_func.attrs.termination_condition != "optimal"
         with pytest.raises(exceptions.BackendError) as excinfo:
             simple_supply_gurobi_func.backend.fix_variable("flow_cap")
 

--- a/tests/test_backend_latex_backend.py
+++ b/tests/test_backend_latex_backend.py
@@ -14,7 +14,10 @@ from .common.util import check_error_or_warning
 def temp_dummy_latex_backend_model(dummy_model_data, dummy_model_math, default_config):
     """Function scoped model definition to avoid cross-test contamination."""
     return latex_backend_model.LatexBackendModel(
-        dummy_model_data, dummy_model_math, default_config.build
+        dummy_model_data,
+        dummy_model_math,
+        default_config.build,
+        dummy_model_data.attrs["defaults"],
     )
 
 

--- a/tests/test_backend_latex_backend.py
+++ b/tests/test_backend_latex_backend.py
@@ -11,13 +11,12 @@ from .common.util import check_error_or_warning
 
 
 @pytest.fixture
-def temp_dummy_latex_backend_model(dummy_model_data, dummy_model_math, default_config):
+def temp_dummy_latex_backend_model(
+    dummy_model_data, dummy_model_math, default_config, model_defaults
+):
     """Function scoped model definition to avoid cross-test contamination."""
     return latex_backend_model.LatexBackendModel(
-        dummy_model_data,
-        dummy_model_math,
-        default_config.build,
-        dummy_model_data.attrs["defaults"],
+        dummy_model_data, dummy_model_math, default_config.build, model_defaults
     )
 
 

--- a/tests/test_backend_module.py
+++ b/tests/test_backend_module.py
@@ -10,12 +10,14 @@ from calliope.exceptions import BackendError
 @pytest.mark.parametrize("valid_backend", ["pyomo", "gurobi"])
 def test_valid_model_backend(simple_supply, valid_backend):
     """Requesting a valid model backend must result in a backend instance."""
-    build_config = simple_supply.config.build.update({"backend": valid_backend})
+    build_config = simple_supply.attrs.model_def.config.build.update(
+        {"backend": valid_backend}
+    )
     backend_obj = backend.get_model_backend(
         build_config,
         simple_supply.inputs,
-        AttrDict(simple_supply.applied_math.model_dump()),
-        simple_supply._attrs.defaults,
+        AttrDict(simple_supply.attrs.applied_math.model_dump()),
+        simple_supply.attrs.defaults,
     )
     assert isinstance(backend_obj, BackendModel)
 
@@ -28,6 +30,6 @@ def test_invalid_model_backend(spam, simple_supply):
         backend.get_model_backend(
             invalid_config,
             simple_supply.inputs,
-            AttrDict(simple_supply.applied_math.model_dump()),
-            simple_supply._attrs.defaults,
+            AttrDict(simple_supply.attrs.applied_math.model_dump()),
+            simple_supply.attrs.defaults,
         )

--- a/tests/test_backend_module.py
+++ b/tests/test_backend_module.py
@@ -10,13 +10,11 @@ from calliope.exceptions import BackendError
 @pytest.mark.parametrize("valid_backend", ["pyomo", "gurobi"])
 def test_valid_model_backend(simple_supply, valid_backend):
     """Requesting a valid model backend must result in a backend instance."""
-    build_config = simple_supply.attrs.model_def.config.build.update(
-        {"backend": valid_backend}
-    )
+    build_config = simple_supply.config.build.update({"backend": valid_backend})
     backend_obj = backend.get_model_backend(
         build_config,
         simple_supply.inputs,
-        AttrDict(simple_supply.attrs.applied_math.model_dump()),
+        AttrDict(simple_supply.applied_math.model_dump()),
         simple_supply.attrs.defaults,
     )
     assert isinstance(backend_obj, BackendModel)
@@ -30,6 +28,6 @@ def test_invalid_model_backend(spam, simple_supply):
         backend.get_model_backend(
             invalid_config,
             simple_supply.inputs,
-            AttrDict(simple_supply.attrs.applied_math.model_dump()),
+            AttrDict(simple_supply.applied_math.model_dump()),
             simple_supply.attrs.defaults,
         )

--- a/tests/test_backend_module.py
+++ b/tests/test_backend_module.py
@@ -12,7 +12,10 @@ def test_valid_model_backend(simple_supply, valid_backend):
     """Requesting a valid model backend must result in a backend instance."""
     build_config = simple_supply.config.build.update({"backend": valid_backend})
     backend_obj = backend.get_model_backend(
-        build_config, simple_supply._model_data, simple_supply.applied_math
+        build_config,
+        simple_supply.inputs,
+        AttrDict(simple_supply.attrs.applied_math.model_dump()),
+        simple_supply.attrs.defaults,
     )
     assert isinstance(backend_obj, BackendModel)
 
@@ -23,5 +26,8 @@ def test_invalid_model_backend(spam, simple_supply):
     invalid_config = AttrDict({"backend": spam})
     with pytest.raises(BackendError):
         backend.get_model_backend(
-            invalid_config, simple_supply._model_data, simple_supply.applied_math
+            invalid_config,
+            simple_supply.inputs,
+            AttrDict(simple_supply.attrs.applied_math.model_dump()),
+            simple_supply.attrs.defaults,
         )

--- a/tests/test_backend_module.py
+++ b/tests/test_backend_module.py
@@ -14,8 +14,8 @@ def test_valid_model_backend(simple_supply, valid_backend):
     backend_obj = backend.get_model_backend(
         build_config,
         simple_supply.inputs,
-        AttrDict(simple_supply.attrs.applied_math.model_dump()),
-        simple_supply.attrs.defaults,
+        AttrDict(simple_supply.applied_math.model_dump()),
+        simple_supply._attrs.defaults,
     )
     assert isinstance(backend_obj, BackendModel)
 
@@ -28,6 +28,6 @@ def test_invalid_model_backend(spam, simple_supply):
         backend.get_model_backend(
             invalid_config,
             simple_supply.inputs,
-            AttrDict(simple_supply.attrs.applied_math.model_dump()),
-            simple_supply.attrs.defaults,
+            AttrDict(simple_supply.applied_math.model_dump()),
+            simple_supply._attrs.defaults,
         )

--- a/tests/test_backend_module.py
+++ b/tests/test_backend_module.py
@@ -14,8 +14,8 @@ def test_valid_model_backend(simple_supply, valid_backend):
     backend_obj = backend.get_model_backend(
         build_config,
         simple_supply.inputs,
-        AttrDict(simple_supply.applied_math.model_dump()),
-        simple_supply.attrs.defaults,
+        AttrDict(simple_supply.math.build.model_dump()),
+        simple_supply.runtime.defaults,
     )
     assert isinstance(backend_obj, BackendModel)
 
@@ -28,6 +28,6 @@ def test_invalid_model_backend(spam, simple_supply):
         backend.get_model_backend(
             invalid_config,
             simple_supply.inputs,
-            AttrDict(simple_supply.applied_math.model_dump()),
-            simple_supply.attrs.defaults,
+            AttrDict(simple_supply.math.build.model_dump()),
+            simple_supply.runtime.defaults,
         )

--- a/tests/test_backend_parsing.py
+++ b/tests/test_backend_parsing.py
@@ -230,6 +230,7 @@ def dummy_backend_interface(dummy_model_data, dummy_model_math, default_config):
                     dummy_model_data,
                     dummy_model_math,
                     default_config.build,
+                    defaults=dummy_model_data.attrs["defaults"],
                     instance=None,
                 )
 

--- a/tests/test_backend_parsing.py
+++ b/tests/test_backend_parsing.py
@@ -219,7 +219,9 @@ def equation_slice_obj(slice_parser, where_string_parser):
 
 
 @pytest.fixture
-def dummy_backend_interface(dummy_model_data, dummy_model_math, default_config):
+def dummy_backend_interface(
+    dummy_model_data, dummy_model_math, default_config, model_defaults
+):
     # ignore the need to define the abstract methods from backend_model.BackendModel
     with patch.multiple(backend_model.BackendModel, __abstractmethods__=set()):
 
@@ -230,16 +232,16 @@ def dummy_backend_interface(dummy_model_data, dummy_model_math, default_config):
                     dummy_model_data,
                     dummy_model_math,
                     default_config.build,
-                    defaults=dummy_model_data.attrs["defaults"],
+                    defaults=model_defaults,
                     instance=None,
                 )
 
                 self._dataset = dummy_model_data.copy(deep=True)
                 self._dataset["with_inf"] = self._dataset["with_inf"].fillna(
-                    dummy_model_data.attrs["defaults"]["with_inf"]
+                    model_defaults["with_inf"]
                 )
                 self._dataset["only_techs"] = self._dataset["only_techs"].fillna(
-                    dummy_model_data.attrs["defaults"]["only_techs"]
+                    model_defaults["only_techs"]
                 )
 
     return DummyBackendModel()

--- a/tests/test_backend_pyomo.py
+++ b/tests/test_backend_pyomo.py
@@ -2266,10 +2266,10 @@ class TestValidateMathDict:
         def _validate_math(math_dict: dict):
             m = build_model({}, "simple_supply,investment_costs")
             math = preprocess.build_applied_math(
-                m.math_priority, m.attrs.model_def.math, math_dict
+                m.math_priority, m._attrs.model_def.math, math_dict
             )
             backend = calliope.backend.PyomoBackendModel(
-                m.inputs, math, m.config.build, m.attrs.defaults
+                m.inputs, math, m.config.build, m._attrs.defaults
             )
             backend._add_all_inputs_as_parameters()
             backend._validate_math_string_parsing()

--- a/tests/test_backend_pyomo.py
+++ b/tests/test_backend_pyomo.py
@@ -29,13 +29,13 @@ class TestChecks:
             m = build_model(
                 override, "simple_supply_and_supply_plus,operate,investment_costs"
             )
-            assert m.attrs.model_def.config.build["cyclic_storage"] is True
+            assert m.config.build["cyclic_storage"] is True
         elif on is False:
             override = {"config.build.cyclic_storage": False}
             m = build_model(
                 override, "simple_supply_and_supply_plus,operate,investment_costs"
             )
-            assert m.attrs.model_def.config.build["cyclic_storage"] is False
+            assert m.config.build["cyclic_storage"] is False
         with pytest.warns(exceptions.ModelWarning) as warning:
             m.build()
         check_warn = check_error_or_warning(
@@ -1638,9 +1638,9 @@ class TestNewBackend:
         m.build(mode="operate", add_math_dict=custom_math)
 
         # operate mode set it to false, then our math set it back to active
-        assert m.attrs.applied_math.constraints["force_zero_area_use"].active
+        assert m.applied_math.constraints["force_zero_area_use"].active
         # operate mode set it to false and our math did not override that
-        assert not m.attrs.applied_math.variables["storage_cap"].active
+        assert not m.applied_math.variables["storage_cap"].active
 
     def test_new_build_get_variable(self, simple_supply):
         """Check a decision variable has the correct data type and has all expected attributes."""
@@ -2266,10 +2266,10 @@ class TestValidateMathDict:
         def _validate_math(math_dict: dict):
             m = build_model({}, "simple_supply,investment_costs")
             math = preprocess.build_applied_math(
-                m.math_priority, m.attrs.model_def.math.model_dump(), math_dict
+                m.math_priority, m.math.model_dump(), math_dict
             )
             backend = calliope.backend.PyomoBackendModel(
-                m.inputs, math, m.attrs.model_def.config.build, m.attrs.defaults
+                m.inputs, math, m.config.build, m.attrs.defaults
             )
             backend._add_all_inputs_as_parameters()
             backend._validate_math_string_parsing()

--- a/tests/test_backend_pyomo.py
+++ b/tests/test_backend_pyomo.py
@@ -29,13 +29,13 @@ class TestChecks:
             m = build_model(
                 override, "simple_supply_and_supply_plus,operate,investment_costs"
             )
-            assert m.config.build["cyclic_storage"] is True
+            assert m.attrs.model_def.config.build["cyclic_storage"] is True
         elif on is False:
             override = {"config.build.cyclic_storage": False}
             m = build_model(
                 override, "simple_supply_and_supply_plus,operate,investment_costs"
             )
-            assert m.config.build["cyclic_storage"] is False
+            assert m.attrs.model_def.config.build["cyclic_storage"] is False
         with pytest.warns(exceptions.ModelWarning) as warning:
             m.build()
         check_warn = check_error_or_warning(
@@ -1638,9 +1638,9 @@ class TestNewBackend:
         m.build(mode="operate", add_math_dict=custom_math)
 
         # operate mode set it to false, then our math set it back to active
-        assert m.applied_math.constraints.force_zero_area_use.active
+        assert m.attrs.applied_math.constraints["force_zero_area_use"].active
         # operate mode set it to false and our math did not override that
-        assert not m.applied_math.variables.storage_cap.active
+        assert not m.attrs.applied_math.variables["storage_cap"].active
 
     def test_new_build_get_variable(self, simple_supply):
         """Check a decision variable has the correct data type and has all expected attributes."""
@@ -2266,10 +2266,10 @@ class TestValidateMathDict:
         def _validate_math(math_dict: dict):
             m = build_model({}, "simple_supply,investment_costs")
             math = preprocess.build_applied_math(
-                m.math_priority, m._attrs.model_def.math, math_dict
+                m.math_priority, m.attrs.model_def.math.model_dump(), math_dict
             )
             backend = calliope.backend.PyomoBackendModel(
-                m.inputs, math, m.config.build, m._attrs.defaults
+                m.inputs, math, m.attrs.model_def.config.build, m.attrs.defaults
             )
             backend._add_all_inputs_as_parameters()
             backend._validate_math_string_parsing()

--- a/tests/test_backend_pyomo.py
+++ b/tests/test_backend_pyomo.py
@@ -45,7 +45,7 @@ class TestChecks:
             assert check_warn
         elif on is True:
             assert not check_warn
-        assert m._model_data.attrs["config"].build.cyclic_storage is False
+        assert m.attrs["config"].build.cyclic_storage is False
 
     @pytest.mark.parametrize(
         "param", [("flow_eff"), ("source_eff"), ("flow_out_parasitic_eff")]
@@ -58,7 +58,7 @@ class TestChecks:
             },
             "simple_supply_and_supply_plus,operate,investment_costs",
         )
-        assert "timesteps" in m._model_data[param].dims
+        assert "timesteps" in m.inputs[param].dims
 
         with pytest.warns(exceptions.ModelWarning):
             m.build()  # will fail to complete run if there's a problem
@@ -257,14 +257,12 @@ class TestChecks:
             assert check_error_or_warning(
                 warning, "Source capacity constraint defined and set to infinity"
             )
-            assert np.isinf(
-                m._model_data.source_cap.loc["a", "test_supply_plus"].item()
-            )
+            assert np.isinf(m.results.source_cap.loc["a", "test_supply_plus"].item())
         elif on is True:
             assert not check_error_or_warning(
                 warning, "Source capacity constraint defined and set to infinity"
             )
-            assert m._model_data.source_cap.loc["a", "test_supply_plus"].item() == 1e6
+            assert m.results.source_cap.loc["a", "test_supply_plus"].item() == 1e6
 
     @pytest.mark.parametrize("on", [True, False])
     def test_operate_storage_initial(self, on):
@@ -281,16 +279,12 @@ class TestChecks:
             m.build()
         if on is False:
             assert check_error_or_warning(warning, "Initial stored carrier not defined")
-            assert (
-                m._model_data.storage_initial.loc["a", "test_supply_plus"].item() == 0
-            )
+            assert m.results.storage_initial.loc["a", "test_supply_plus"].item() == 0
         elif on is True:
             assert not check_error_or_warning(
                 warning, "Initial stored carrier not defined"
             )
-            assert (
-                m._model_data.storage_initial.loc["a", "test_supply_plus"].item() == 0.5
-            )
+            assert m.results.storage_initial.loc["a", "test_supply_plus"].item() == 0.5
 
 
 @pytest.mark.skip(reason="to be reimplemented by comparison to LP files")
@@ -428,8 +422,8 @@ class TestBalanceConstraints:
         )
         m3.build()
         assert (
-            m3._model_data.storage_initial.to_series().dropna()
-            > m3._model_data.storage_discharge_depth.to_series().dropna()
+            m3.inputs.storage_initial.to_series().dropna()
+            > m3.inputs.storage_discharge_depth.to_series().dropna()
         ).all()
 
     def test_storage_initial_constraint(self, simple_storage):
@@ -1771,7 +1765,7 @@ class TestNewBackend:
         del simple_supply.backend._dataset["foo"]
 
     def test_add_allnull_param_with_shape(self, simple_supply):
-        nan_array = simple_supply._model_data.flow_cap_max.where(lambda x: x < 0)
+        nan_array = simple_supply.inputs.flow_cap_max.where(lambda x: x < 0)
         simple_supply.backend.add_parameter("foo", nan_array)
 
         assert "foo" not in simple_supply.backend._instance.parameters.keys()
@@ -2272,10 +2266,10 @@ class TestValidateMathDict:
         def _validate_math(math_dict: dict):
             m = build_model({}, "simple_supply,investment_costs")
             math = preprocess.build_applied_math(
-                m.math_priority, m._def.math, math_dict
+                m.math_priority, m.attrs.model_def.math, math_dict
             )
             backend = calliope.backend.PyomoBackendModel(
-                m._model_data, math, m.config.build
+                m.inputs, math, m.config.build, m.attrs.defaults
             )
             backend._add_all_inputs_as_parameters()
             backend._validate_math_string_parsing()

--- a/tests/test_backend_pyomo.py
+++ b/tests/test_backend_pyomo.py
@@ -1638,9 +1638,9 @@ class TestNewBackend:
         m.build(mode="operate", add_math_dict=custom_math)
 
         # operate mode set it to false, then our math set it back to active
-        assert m.applied_math.constraints["force_zero_area_use"].active
+        assert m.math.build.constraints["force_zero_area_use"].active
         # operate mode set it to false and our math did not override that
-        assert not m.applied_math.variables["storage_cap"].active
+        assert not m.math.build.variables["storage_cap"].active
 
     def test_new_build_get_variable(self, simple_supply):
         """Check a decision variable has the correct data type and has all expected attributes."""
@@ -2266,10 +2266,10 @@ class TestValidateMathDict:
         def _validate_math(math_dict: dict):
             m = build_model({}, "simple_supply,investment_costs")
             math = preprocess.build_applied_math(
-                m.math_priority, m.math.model_dump(), math_dict
+                m.math_priority, m.math.init.model_dump(), math_dict
             )
             backend = calliope.backend.PyomoBackendModel(
-                m.inputs, math, m.config.build, m.attrs.defaults
+                m.inputs, math, m.config.build, m.runtime.defaults
             )
             backend._add_all_inputs_as_parameters()
             backend._validate_math_string_parsing()

--- a/tests/test_backend_where_parser.py
+++ b/tests/test_backend_where_parser.py
@@ -103,6 +103,7 @@ def eval_kwargs(dummy_pyomo_backend_model, dummy_build_config):
         "equation_name": "foo",
         "return_type": "array",
         "references": set(),
+        "defaults": dummy_pyomo_backend_model.defaults,
         "build_config": dummy_build_config,
     }
 
@@ -125,7 +126,7 @@ class TestParserElements:
         self, data_var, dummy_model_data, data_var_string, expected, eval_kwargs
     ):
         parsed_ = data_var.parse_string(data_var_string, parse_all=True)
-        default = dummy_model_data.attrs["defaults"][expected]
+        default = eval_kwargs["defaults"][expected]
         assert (
             parsed_[0]
             .eval(apply_where=False, **eval_kwargs)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,10 +17,6 @@ _MODEL_NATIONAL = (
     / "model.yaml"
 ).as_posix()
 
-_MINIMAL_TEST_MODEL = (
-    Path(__file__).parent / "common" / "test_model" / "model.yaml"
-).as_posix()
-
 
 class TestCLI:
     def test_new(self):
@@ -235,12 +231,12 @@ class TestCLI:
     @pytest.mark.filterwarnings(
         "ignore:(?s).*Model solution was non-optimal:calliope.exceptions.BackendWarning"
     )
-    def test_no_success_exit_code_when_infeasible(self):
+    def test_no_success_exit_code_when_infeasible(self, minimal_test_model_path):
         runner = CliRunner()
         result = runner.invoke(
             cli.run,
             [
-                _MINIMAL_TEST_MODEL,
+                minimal_test_model_path,
                 "--scenario=simple_supply",  # without these, the model cannot run
                 "--override_dict={techs.test_supply_elec.flow_cap_max: 1}",  # elec supply too low
             ],
@@ -250,12 +246,14 @@ class TestCLI:
     @pytest.mark.filterwarnings(
         "ignore:(?s).*Model solution was non-optimal:calliope.exceptions.BackendWarning"
     )
-    def test_success_exit_code_when_infeasible_and_demanded(self):
+    def test_success_exit_code_when_infeasible_and_demanded(
+        self, minimal_test_model_path
+    ):
         runner = CliRunner()
         result = runner.invoke(
             cli.run,
             [
-                _MINIMAL_TEST_MODEL,
+                minimal_test_model_path,
                 "--no_fail_when_infeasible",
                 "--scenario=simple_supply",  # without these, the model cannot run
                 "--override_dict={techs.test_supply_elec.flow_cap_max: 1}",  # elec supply too low

--- a/tests/test_core_future_warnings.py
+++ b/tests/test_core_future_warnings.py
@@ -22,4 +22,4 @@ class TestFutureWarnings:
             )
 
         assert check_error_or_warning(warning, "`locations` has been renamed")
-        assert set(model._model_data.nodes.values) == {"a", "b"}
+        assert set(model.inputs.nodes.values) == {"a", "b"}

--- a/tests/test_core_model.py
+++ b/tests/test_core_model.py
@@ -94,7 +94,7 @@ class TestOperateMode:
     def test_operate_mode_success(self, operate_model_and_log):
         """Solving in operate mode should lead to an optimal solution."""
         operate_model, _ = operate_model_and_log
-        assert operate_model.attrs.termination_condition == "optimal"
+        assert operate_model.runtime.termination_condition == "optimal"
 
     def test_use_cap_results(self, base_model, operate_model_and_log):
         """Operate mode uses base mode outputs as inputs."""
@@ -146,7 +146,7 @@ class TestOperateMode:
         """Cannot build in operate mode if the `allow_operate_mode` attribute is False"""
 
         m = build_model({}, "simple_supply,two_hours,investment_costs")
-        m.attrs = m.attrs.update({"allow_operate_mode": False})
+        m.runtime = m.runtime.update({"allow_operate_mode": False})
         with pytest.raises(
             calliope.exceptions.ModelError, match="Unable to run this model in op"
         ):
@@ -295,7 +295,7 @@ class TestSporesMode:
     def test_spores_mode_success(self, spores_model_and_log_algorithms):
         """Solving in spores mode should lead to an optimal solution."""
         spores_model, _ = spores_model_and_log_algorithms
-        assert spores_model.attrs.termination_condition == "optimal"
+        assert spores_model.runtime.termination_condition == "optimal"
 
     def test_spores_fail_without_baseline(self):
         """You can't have SPORES without some initial, baseline results to work with."""

--- a/tests/test_core_model.py
+++ b/tests/test_core_model.py
@@ -367,7 +367,7 @@ class TestSporesMode:
         """The scoring algorithm being used should be logged correctly."""
         model, log = spores_model_and_log_algorithms
         assert (
-            f"Running SPORES with `{model.attrs.model_def.config.solve.spores.scoring_algorithm}` scoring algorithm."
+            f"Running SPORES with `{model.config.solve.spores.scoring_algorithm}` scoring algorithm."
             in log
         )
 

--- a/tests/test_core_model.py
+++ b/tests/test_core_model.py
@@ -94,7 +94,7 @@ class TestOperateMode:
     def test_operate_mode_success(self, operate_model_and_log):
         """Solving in operate mode should lead to an optimal solution."""
         operate_model, _ = operate_model_and_log
-        assert operate_model.results.attrs["termination_condition"] == "optimal"
+        assert operate_model.attrs.termination_condition == "optimal"
 
     def test_use_cap_results(self, base_model, operate_model_and_log):
         """Operate mode uses base mode outputs as inputs."""
@@ -146,7 +146,7 @@ class TestOperateMode:
         """Cannot build in operate mode if the `allow_operate_mode` attribute is False"""
 
         m = build_model({}, "simple_supply,two_hours,investment_costs")
-        m._attrs = m._attrs.update({"allow_operate_mode": False})
+        m.attrs = m.attrs.update({"allow_operate_mode": False})
         with pytest.raises(
             calliope.exceptions.ModelError, match="Unable to run this model in op"
         ):
@@ -295,7 +295,7 @@ class TestSporesMode:
     def test_spores_mode_success(self, spores_model_and_log_algorithms):
         """Solving in spores mode should lead to an optimal solution."""
         spores_model, _ = spores_model_and_log_algorithms
-        assert spores_model.results.attrs["termination_condition"] == "optimal"
+        assert spores_model.attrs.termination_condition == "optimal"
 
     def test_spores_fail_without_baseline(self):
         """You can't have SPORES without some initial, baseline results to work with."""
@@ -367,7 +367,7 @@ class TestSporesMode:
         """The scoring algorithm being used should be logged correctly."""
         model, log = spores_model_and_log_algorithms
         assert (
-            f"Running SPORES with `{model.config.solve.spores.scoring_algorithm}` scoring algorithm."
+            f"Running SPORES with `{model.attrs.model_def.config.solve.spores.scoring_algorithm}` scoring algorithm."
             in log
         )
 

--- a/tests/test_core_model.py
+++ b/tests/test_core_model.py
@@ -146,7 +146,7 @@ class TestOperateMode:
         """Cannot build in operate mode if the `allow_operate_mode` attribute is False"""
 
         m = build_model({}, "simple_supply,two_hours,investment_costs")
-        m.attrs = m.attrs.update({"allow_operate_mode": False})
+        m._attrs = m._attrs.update({"allow_operate_mode": False})
         with pytest.raises(
             calliope.exceptions.ModelError, match="Unable to run this model in op"
         ):

--- a/tests/test_core_preprocess.py
+++ b/tests/test_core_preprocess.py
@@ -30,10 +30,10 @@ class TestModelRun:
         for src in model_dict["data_tables"].values():
             src["data"] = (model_dir / src["data"]).as_posix()
         # test as AttrDict
-        calliope.Model(model_dict)
+        calliope.Model.from_dict(model_dict)
 
         # test as dict
-        calliope.Model(model_dict.as_dict())
+        calliope.Model.from_dict(model_dict.as_dict())
 
     def test_undefined_carriers(self):
         """Test that user has input either carrier or carrier_in/_out for each tech"""

--- a/tests/test_core_util.py
+++ b/tests/test_core_util.py
@@ -1,4 +1,3 @@
-import datetime
 import glob
 import logging
 from pathlib import Path
@@ -52,15 +51,15 @@ class TestLogging:
         )
 
     def test_timing_log(self):
-        timings = {"model_creation": datetime.datetime.now()}
+        timings = {}
         logger = logging.getLogger("calliope.testlogger")
 
         # TODO: capture logging output and check that comment is in string
         log_time(logger, timings, "test", comment="test_comment", level="info")
-        assert isinstance(timings["test"], datetime.datetime)
+        assert isinstance(timings["test"], float)
 
         log_time(logger, timings, "test2", comment=None, level="info")
-        assert isinstance(timings["test2"], datetime.datetime)
+        assert isinstance(timings["test2"], float)
 
         # TODO: capture logging output and check that time_since_solve_start is in the string
         log_time(

--- a/tests/test_core_util.py
+++ b/tests/test_core_util.py
@@ -111,19 +111,14 @@ class TestGenerateRuns:
 
 
 class TestPandasExport:
-    @pytest.fixture(scope="module")
-    def model(self):
-        return calliope.examples.national_scale()
+    MODEL = calliope.examples.national_scale()
 
     @pytest.mark.parametrize(
-        "variable_name",
-        sorted(
-            [i for i in calliope.examples.national_scale()._model_data.data_vars.keys()]
-        ),
+        "variable_name", sorted([i for i in MODEL.inputs.data_vars.keys()])
     )
-    def test_data_variables_can_be_exported_to_pandas(self, model, variable_name):
-        if model.inputs[variable_name].shape:
-            model.inputs[variable_name].to_dataframe()
+    def test_data_variables_can_be_exported_to_pandas(self, variable_name):
+        if self.MODEL.inputs[variable_name].shape:
+            self.MODEL.inputs[variable_name].to_dataframe()
         else:
             pass
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -181,10 +181,7 @@ class TestIO:
                 model.to_csv(out_path, dropna=False)
 
     def test_config_reload(self, model_from_file, model):
-        assert (
-            model_from_file.attrs.model_def.config.model_dump()
-            == model.attrs.model_def.config.model_dump()
-        )
+        assert model_from_file.config.model_dump() == model.config.model_dump()
 
     def test_defaults_as_model_attrs_not_property(self, model_from_file):
         assert len(model_from_file.attrs.defaults) > 0

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -17,8 +17,8 @@ from .common.util import check_error_or_warning
 
 class TestIO:
     @pytest.fixture(scope="module")
-    def vars_to_add_attrs(self):
-        return ["source_use_max", "flow_cap"]
+    def vars_to_add_attrs(self) -> dict:
+        return {"inputs": "source_use_max", "results": "flow_cap"}
 
     @pytest.fixture(scope="module")
     def model(self, vars_to_add_attrs):
@@ -34,50 +34,38 @@ class TestIO:
             "foo_list": ["foo", "bar"],
             "foo_list_1_item": ["foo"],
         }
-        model._model_data = model._model_data.assign_attrs(**attrs)
+        model.inputs = model.inputs.assign_attrs(**attrs)
         model.build()
         model.solve()
 
-        for var in vars_to_add_attrs:
-            model._model_data[var] = model._model_data[var].assign_attrs(**attrs)
+        for ds, var in vars_to_add_attrs.items():
+            getattr(model, ds)[var] = getattr(model, ds)[var].assign_attrs(**attrs)
 
         return model
 
-    @pytest.fixture(scope="module")
+    @pytest.fixture(scope="class")
     def model_file(self, tmpdir_factory, model):
         out_path = tmpdir_factory.mktemp("data").join("model.nc")
         model.to_netcdf(out_path)
         return out_path
 
-    @pytest.fixture(scope="module")
+    @pytest.fixture(scope="class")
     def model_from_file(self, model_file):
         return calliope.read_netcdf(model_file)
 
-    @pytest.fixture(scope="module")
+    @pytest.fixture(scope="class")
     def model_from_file_no_processing(self, model_file):
-        return xr.open_dataset(model_file)
+        return xr.open_dataset(model_file, group="inputs")
 
-    @pytest.fixture(scope="module")
+    @pytest.fixture(scope="class")
     def model_csv_dir(self, tmpdir_factory, model):
-        out_path = tmpdir_factory.mktemp("data")
-        model.to_csv(os.path.join(out_path, "csvs"))
-        return os.path.join(out_path, "csvs")
+        parent_path = tmpdir_factory.mktemp("data")
+        out_path = parent_path / "csvs"
+        model.to_csv(out_path)
+        return out_path
 
     def test_save_netcdf(self, model_file):
         assert os.path.isfile(model_file)
-
-    @pytest.mark.parametrize(
-        "kwargs",
-        [{"name": "foobar"}, {"calliope_version": "0.7.0", "time_resample": "2h"}],
-    )
-    def test_model_from_file_kwarg_error(self, model_file, kwargs):
-        """Passing kwargs when reading model dataset files should fail."""
-        model_data = calliope.io.read_netcdf(model_file)
-        with pytest.raises(
-            exceptions.ModelError,
-            match="Cannot apply initialisation configuration overrides when loading data from an xarray Dataset.",
-        ):
-            calliope.Model(model_data, **kwargs)
 
     @pytest.mark.parametrize(
         ("attr", "expected_type", "expected_val"),
@@ -98,8 +86,10 @@ class TestIO:
         self, request, attr, expected_type, expected_val, model_name, vars_to_add_attrs
     ):
         model = request.getfixturevalue(model_name)
-        var_attrs = [model._model_data[var].attrs for var in vars_to_add_attrs]
-        for attrs in [model._model_data.attrs, *var_attrs]:
+        var_attrs = [
+            getattr(model, ds)[var].attrs for ds, var in vars_to_add_attrs.items()
+        ]
+        for attrs in [model.attrs.model_dump(), *var_attrs]:
             assert isinstance(attrs[attr], expected_type)
             if expected_val is None:
                 assert attrs[attr] is None
@@ -113,7 +103,7 @@ class TestIO:
     @pytest.mark.parametrize("model_name", ["model", "model_from_file"])
     def test_serialised_list_popped(self, request, serialised_list, model_name):
         model = request.getfixturevalue(model_name)
-        assert serialised_list not in model._model_data.attrs.keys()
+        assert serialised_list not in model.attrs.keys()
 
     @pytest.mark.parametrize(
         ("serialisation_list_name", "list_elements"),
@@ -153,7 +143,9 @@ class TestIO:
             with pytest.raises(FileExistsError):
                 model.to_csv(out_path)
 
-    def test_save_csv_dir_can_exist_if_overwrite_true(self, model, model_csv_dir):
+    def test_save_csv_dir_can_exist_if_overwrite_true(
+        self, model: calliope.Model, model_csv_dir
+    ):
         model.to_csv(model_csv_dir, allow_overwrite=True)
 
     @pytest.mark.parametrize(
@@ -203,7 +195,7 @@ class TestIO:
         assert model_from_file.config.model_dump() == model.config.model_dump()
 
     def test_defaults_as_model_attrs_not_property(self, model_from_file):
-        assert "defaults" in model_from_file._model_data.attrs.keys()
+        assert "defaults" in model_from_file.attrs.keys()
         assert not hasattr(model_from_file, "defaults")
 
     @pytest.mark.parametrize("attr", ["results", "inputs"])

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -184,7 +184,7 @@ class TestIO:
         assert model_from_file.config.model_dump() == model.config.model_dump()
 
     def test_defaults_as_model_attrs_not_property(self, model_from_file):
-        assert len(model_from_file.attrs.defaults) > 0
+        assert len(model_from_file.runtime.defaults) > 0
         assert not hasattr(model_from_file, "defaults")
 
     @pytest.mark.parametrize("attr", ["results", "inputs"])

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -89,21 +89,12 @@ class TestIO:
         var_attrs = [
             getattr(model, ds)[var].attrs for ds, var in vars_to_add_attrs.items()
         ]
-        for attrs in [model.attrs.model_dump(), *var_attrs]:
+        for attrs in [model._attrs.model_dump(), *var_attrs]:
             assert isinstance(attrs[attr], expected_type)
             if expected_val is None:
                 assert attrs[attr] is None
             else:
                 assert attrs[attr] == expected_val
-
-    @pytest.mark.parametrize(
-        "serialised_list",
-        ["serialised_bools", "serialised_nones", "serialised_dicts", "serialised_sets"],
-    )
-    @pytest.mark.parametrize("model_name", ["model", "model_from_file"])
-    def test_serialised_list_popped(self, request, serialised_list, model_name):
-        model = request.getfixturevalue(model_name)
-        assert serialised_list not in model.attrs.keys()
 
     @pytest.mark.parametrize(
         ("serialisation_list_name", "list_elements"),
@@ -195,7 +186,7 @@ class TestIO:
         assert model_from_file.config.model_dump() == model.config.model_dump()
 
     def test_defaults_as_model_attrs_not_property(self, model_from_file):
-        assert "defaults" in model_from_file.attrs.keys()
+        assert len(model_from_file._attrs.defaults) > 0
         assert not hasattr(model_from_file, "defaults")
 
     @pytest.mark.parametrize("attr", ["results", "inputs"])

--- a/tests/test_preprocess/test_model_math.py
+++ b/tests/test_preprocess/test_model_math.py
@@ -98,11 +98,11 @@ class TestBuildMath:
 
     @pytest.fixture(scope="class")
     def config(self, test_model):
-        return test_model.config
+        return test_model.attrs.model_def.config
 
     @pytest.fixture(scope="class")
-    def math_options(self, test_model):
-        return test_model._def.math
+    def math_options(self, test_model: calliope.Model):
+        return test_model.attrs.model_def.math.model_dump()
 
     @pytest.mark.parametrize(
         "math_order",

--- a/tests/test_preprocess/test_model_math.py
+++ b/tests/test_preprocess/test_model_math.py
@@ -102,7 +102,7 @@ class TestBuildMath:
 
     @pytest.fixture(scope="class")
     def math_options(self, test_model: calliope.Model):
-        return test_model.math.model_dump()
+        return test_model.math.init.model_dump()
 
     @pytest.mark.parametrize(
         "math_order",

--- a/tests/test_preprocess/test_model_math.py
+++ b/tests/test_preprocess/test_model_math.py
@@ -98,11 +98,11 @@ class TestBuildMath:
 
     @pytest.fixture(scope="class")
     def config(self, test_model):
-        return test_model.attrs.model_def.config
+        return test_model.config
 
     @pytest.fixture(scope="class")
     def math_options(self, test_model: calliope.Model):
-        return test_model.attrs.model_def.math.model_dump()
+        return test_model.math.model_dump()
 
     @pytest.mark.parametrize(
         "math_order",

--- a/tests/test_preprocess_model_data.py
+++ b/tests/test_preprocess_model_data.py
@@ -1,5 +1,4 @@
 import logging
-from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -15,16 +14,11 @@ from .common.util import check_error_or_warning
 
 
 @pytest.fixture
-def model_path():
-    return Path(__file__).parent / "common" / "test_model" / "model.yaml"
-
-
-@pytest.fixture
-def model_def(model_path):
+def model_def(minimal_test_model_path):
     model_def_override = prepare_model_definition(
-        io.read_rich_yaml(model_path),
+        io.read_rich_yaml(minimal_test_model_path),
         scenario="simple_supply,empty_tech_node",
-        definition_path=model_path,
+        definition_path=minimal_test_model_path,
     )
     # Erase data tables for simplicity
     # FIXME: previous tests omitted this. Either update tests or remove the data_table from the test model.
@@ -39,9 +33,13 @@ def init_config(default_config, model_def):
 
 
 @pytest.fixture
-def model_data_factory(model_path, model_def, init_config, model_defaults):
+def model_data_factory(minimal_test_model_path, model_def, init_config, model_defaults):
     return ModelDataFactory(
-        init_config, model_def.definition, model_path, [], {"default": model_defaults}
+        init_config,
+        model_def.definition,
+        minimal_test_model_path,
+        [],
+        {"default": model_defaults},
     )
 
 

--- a/tests/test_preprocess_model_data.py
+++ b/tests/test_preprocess_model_data.py
@@ -28,13 +28,13 @@ def model_def(model_path):
     )
     # Erase data tables for simplicity
     # FIXME: previous tests omitted this. Either update tests or remove the data_table from the test model.
-    model_def_override.del_key("data_tables")
-    return model_def_override
+    model_def_override.data_tables.root = {}
+    return AttrDict(model_def_override.model_dump(exclude_defaults=True))
 
 
 @pytest.fixture
 def init_config(default_config, model_def):
-    updated_config = default_config.update(model_def["config"])
+    updated_config = default_config.update(model_def.config)
     return updated_config.init
 
 
@@ -284,10 +284,6 @@ class TestModelData:
 
         model_data_factory.assign_input_attr()
 
-        assert all(
-            var.attrs["is_result"] is False
-            for var in model_data_factory.dataset.data_vars.values()
-        )
         assert model_data_factory.dataset["storage_cap_max"].attrs["default"] == np.inf
         assert "default" not in model_data_factory.dataset["bar"].attrs
 

--- a/tests/test_preprocess_model_data.py
+++ b/tests/test_preprocess_model_data.py
@@ -78,8 +78,6 @@ class TestModelData:
     def test_model_data_init(self, model_data_factory: ModelDataFactory):
         assert model_data_factory.param_attrs["flow_in_eff"] == {"default": 1.0}
 
-        assert model_data_factory.dataset.attrs == {"foo": "bar"}
-
     def test_add_node_tech_data(self, model_data_factory_w_params: ModelDataFactory):
         assert set(model_data_factory_w_params.dataset.nodes.values) == {"a", "b", "c"}
         assert set(model_data_factory_w_params.dataset.techs.values) == {

--- a/tests/test_preprocess_model_data.py
+++ b/tests/test_preprocess_model_data.py
@@ -21,14 +21,14 @@ def model_path():
 
 @pytest.fixture
 def model_def(model_path):
-    model_def_override, _ = prepare_model_definition(
+    model_def_override = prepare_model_definition(
         io.read_rich_yaml(model_path),
         scenario="simple_supply,empty_tech_node",
         definition_path=model_path,
     )
     # Erase data tables for simplicity
     # FIXME: previous tests omitted this. Either update tests or remove the data_table from the test model.
-    model_def_override.data_tables.root = {}
+    model_def_override.definition.data_tables.root = {}
     return AttrDict(model_def_override.model_dump(exclude_defaults=True))
 
 
@@ -41,7 +41,7 @@ def init_config(default_config, model_def):
 @pytest.fixture
 def model_data_factory(model_path, model_def, init_config, model_defaults):
     return ModelDataFactory(
-        init_config, model_def, model_path, [], {"default": model_defaults}
+        init_config, model_def.definition, model_path, [], {"default": model_defaults}
     )
 
 

--- a/tests/test_preprocess_model_data.py
+++ b/tests/test_preprocess_model_data.py
@@ -277,10 +277,6 @@ class TestModelData:
         model_data_factory.dataset["storage_cap_max"] = simple_da
         model_data_factory.dataset["bar"] = timeseries_da
         assert model_data_factory.dataset.data_vars
-        assert not any(
-            "is_result" in var.attrs
-            for var in model_data_factory.dataset.data_vars.values()
-        )
 
         model_data_factory.assign_input_attr()
 

--- a/tests/test_preprocess_model_definition.py
+++ b/tests/test_preprocess_model_definition.py
@@ -35,13 +35,8 @@ class TestScenarioOverrides:
         )
         model = build_model(override_dict=override, scenario="scenario_1")
 
-        assert (
-            model._model_data.sel(techs="test_supply_gas")["flow_cap_max"] == dummy_int
-        )
-        assert (
-            model._model_data.sel(techs="test_supply_elec")["flow_cap_max"]
-            == dummy_int / 2
-        )
+        assert model.inputs.flow_cap_max.sel(techs="test_supply_gas") == dummy_int
+        assert model.inputs.flow_cap_max.sel(techs="test_supply_elec") == dummy_int / 2
 
     def test_valid_scenario_of_scenarios(self, dummy_int):
         """Test that valid scenario definition which groups scenarios and overrides raises
@@ -72,13 +67,8 @@ class TestScenarioOverrides:
         )
         model = build_model(override_dict=override, scenario="scenario_2")
 
-        assert (
-            model._model_data.sel(techs="test_supply_gas")["flow_cap_max"] == dummy_int
-        )
-        assert (
-            model._model_data.sel(techs="test_supply_elec")["flow_cap_max"]
-            == dummy_int / 2
-        )
+        assert model.inputs.flow_cap_max.sel(techs="test_supply_gas") == dummy_int
+        assert model.inputs.flow_cap_max.sel(techs="test_supply_elec") == dummy_int / 2
 
     def test_invalid_scenarios_dict(self):
         """Test that invalid scenario definition raises appropriate error"""

--- a/tests/test_preprocess_time.py
+++ b/tests/test_preprocess_time.py
@@ -77,7 +77,7 @@ class TestClustering:
         return build_test_model(scenario="simple_supply", **cluster_init)
 
     def test_no_operate_mode_allowed(self, clustered_model):
-        assert clustered_model.attrs.allow_operate_mode == 0
+        assert clustered_model.runtime.allow_operate_mode == 0
 
     def test_cluster_numbers(self, clustered_model):
         assert (
@@ -147,7 +147,7 @@ class TestResamplingAndCluster:
         )
 
         assert dtindex.equals(model.inputs.timesteps.to_index())
-        assert model.attrs.allow_operate_mode == 0
+        assert model.runtime.allow_operate_mode == 0
 
 
 class TestResampling:
@@ -174,7 +174,7 @@ class TestResampling:
         )
 
         assert dtindex.equals(model.inputs.timesteps.to_index())
-        assert model.attrs.allow_operate_mode == 1
+        assert model.runtime.allow_operate_mode == 1
 
     def test_15min_to_2h_resampling_to_2h(self):
         """

--- a/tests/test_preprocess_time.py
+++ b/tests/test_preprocess_time.py
@@ -77,11 +77,11 @@ class TestClustering:
         return build_test_model(scenario="simple_supply", **cluster_init)
 
     def test_no_operate_mode_allowed(self, clustered_model):
-        assert clustered_model._model_data.attrs["allow_operate_mode"] == 0
+        assert clustered_model.attrs["allow_operate_mode"] == 0
 
     def test_cluster_numbers(self, clustered_model):
         assert (
-            clustered_model._model_data.clusters.to_index()
+            clustered_model.inputs.clusters.to_index()
             .symmetric_difference([0, 1])
             .empty
         )
@@ -97,7 +97,7 @@ class TestClustering:
         expected.index = pd.to_datetime(expected.index)
 
         pd.testing.assert_series_equal(
-            clustered_model._model_data.timestep_cluster.to_series(),
+            clustered_model.inputs.timestep_cluster.to_series(),
             expected,
             check_names=False,
         )
@@ -108,7 +108,7 @@ class TestClustering:
             name="datesteps",
         )
         pd.testing.assert_index_equal(
-            clustered_model._model_data.datesteps.to_index(), expected
+            clustered_model.inputs.datesteps.to_index(), expected
         )
 
     @pytest.mark.parametrize(
@@ -121,7 +121,7 @@ class TestClustering:
         ],
     )
     def test_cluster_has_lookup_arrays(self, clustered_model, var):
-        assert var in clustered_model._model_data.data_vars
+        assert var in clustered_model.inputs.data_vars
 
 
 class TestResamplingAndCluster:
@@ -146,8 +146,8 @@ class TestResamplingAndCluster:
             ]
         )
 
-        assert dtindex.equals(model._model_data.timesteps.to_index())
-        assert model._model_data.attrs["allow_operate_mode"] == 0
+        assert dtindex.equals(model.inputs.timesteps.to_index())
+        assert model.attrs["allow_operate_mode"] == 0
 
 
 class TestResampling:
@@ -159,7 +159,6 @@ class TestResampling:
         )
 
         model = build_test_model(override, scenario="simple_supply", time_resample="6h")
-        data = model._model_data
 
         dtindex = pd.DatetimeIndex(
             [
@@ -174,8 +173,8 @@ class TestResampling:
             ]
         )
 
-        assert dtindex.equals(data.timesteps.to_index())
-        assert data.attrs["allow_operate_mode"] == 1
+        assert dtindex.equals(model.inputs.timesteps.to_index())
+        assert model.attrs["allow_operate_mode"] == 1
 
     def test_15min_to_2h_resampling_to_2h(self):
         """
@@ -188,7 +187,6 @@ class TestResampling:
         model = build_test_model(
             override, scenario="simple_supply,one_day", time_resample="2h"
         )
-        data = model._model_data
 
         dtindex = pd.DatetimeIndex(
             [
@@ -207,7 +205,7 @@ class TestResampling:
             ]
         )
 
-        assert dtindex.equals(data.timesteps.to_index())
+        assert dtindex.equals(model.inputs.timesteps.to_index())
 
     @pytest.mark.filterwarnings(
         "ignore:(?s).*Possibly missing data on the timesteps dimension*:calliope.exceptions.ModelWarning"

--- a/tests/test_preprocess_time.py
+++ b/tests/test_preprocess_time.py
@@ -77,7 +77,7 @@ class TestClustering:
         return build_test_model(scenario="simple_supply", **cluster_init)
 
     def test_no_operate_mode_allowed(self, clustered_model):
-        assert clustered_model.attrs["allow_operate_mode"] == 0
+        assert clustered_model.attrs.allow_operate_mode == 0
 
     def test_cluster_numbers(self, clustered_model):
         assert (
@@ -147,7 +147,7 @@ class TestResamplingAndCluster:
         )
 
         assert dtindex.equals(model.inputs.timesteps.to_index())
-        assert model.attrs["allow_operate_mode"] == 0
+        assert model.attrs.allow_operate_mode == 0
 
 
 class TestResampling:
@@ -174,7 +174,7 @@ class TestResampling:
         )
 
         assert dtindex.equals(model.inputs.timesteps.to_index())
-        assert model.attrs["allow_operate_mode"] == 1
+        assert model.attrs.allow_operate_mode == 1
 
     def test_15min_to_2h_resampling_to_2h(self):
         """

--- a/tests/test_schemas/conftest.py
+++ b/tests/test_schemas/conftest.py
@@ -2,6 +2,11 @@ import importlib
 import importlib.resources
 from pathlib import Path
 
+import pytest
+
+from calliope.io import read_rich_yaml
+from calliope.preprocess import prepare_model_definition
+
 EXAMPLE_MODEL_DIR = Path(importlib.resources.files("calliope") / "example_models")
 TEST_MODELS_DIR = Path(__file__).parent.parent / "common"
 
@@ -15,3 +20,12 @@ TEST_MODELS = [
         "test_model/model_minimal.yaml",
     ]
 ]
+
+
+@pytest.fixture(scope="module", params=EXAMPLE_MODELS + TEST_MODELS)
+def model_def(request):
+    """Test the node schema against example and test model definitions."""
+    model_def, _ = prepare_model_definition(
+        read_rich_yaml(request.param), definition_path=request.param
+    )
+    return model_def

--- a/tests/test_schemas/test_config_schema.py
+++ b/tests/test_schemas/test_config_schema.py
@@ -1,14 +1,7 @@
-import pytest
-
-from calliope.preprocess import prepare_model_definition
 from calliope.schemas.config_schema import CalliopeConfig
-
-from . import utils
 
 
 class TestCalliopeConfig:
-    @pytest.mark.parametrize("model_path", utils.EXAMPLE_MODELS + utils.TEST_MODELS)
-    def test_example_models(self, model_path):
+    def test_example_models(self, model_def):
         """Test the schema against example and test model definitions."""
-        model_def, _ = prepare_model_definition(model_path)
         CalliopeConfig(**model_def["config"])

--- a/tests/test_schemas/test_config_schema.py
+++ b/tests/test_schemas/test_config_schema.py
@@ -1,7 +1,0 @@
-from calliope.schemas.config_schema import CalliopeConfig
-
-
-class TestCalliopeConfig:
-    def test_example_models(self, model_def):
-        """Test the schema against example and test model definitions."""
-        CalliopeConfig(**model_def.config.model_dump(exclude_defaults=True))

--- a/tests/test_schemas/test_config_schema.py
+++ b/tests/test_schemas/test_config_schema.py
@@ -4,4 +4,4 @@ from calliope.schemas.config_schema import CalliopeConfig
 class TestCalliopeConfig:
     def test_example_models(self, model_def):
         """Test the schema against example and test model definitions."""
-        CalliopeConfig(**model_def["config"])
+        CalliopeConfig(**model_def.config.model_dump(exclude_defaults=True))

--- a/tests/test_schemas/test_data_table_schema.py
+++ b/tests/test_schemas/test_data_table_schema.py
@@ -73,12 +73,6 @@ class TestCalliopeDataTable:
         """Test a fully fledged data table configuration."""
         CalliopeDataTable(**full_data_table_config)
 
-    def test_example_models(self, model_def):
-        """Test the schema against example and test model definitions."""
-        if "data_tables" in model_def:
-            for data_table_def in model_def["data_tables"].values():
-                CalliopeDataTable(**data_table_def)
-
     @pytest.mark.parametrize(
         ("rename_dims", "drop"),
         [({"bar": "foo"}, None), ({"locations": "nodes"}, "nodes")],

--- a/tests/test_schemas/test_data_table_schema.py
+++ b/tests/test_schemas/test_data_table_schema.py
@@ -4,11 +4,9 @@ import pytest
 from pydantic import ValidationError
 
 from calliope.io import read_rich_yaml
-from calliope.preprocess import prepare_model_definition
 from calliope.schemas.data_table_schema import CalliopeDataTable
 
 from ..common.util import check_error_or_warning
-from . import utils
 
 
 class TestCalliopeDataTable:
@@ -75,10 +73,8 @@ class TestCalliopeDataTable:
         """Test a fully fledged data table configuration."""
         CalliopeDataTable(**full_data_table_config)
 
-    @pytest.mark.parametrize("model_path", utils.EXAMPLE_MODELS + utils.TEST_MODELS)
-    def test_example_models(self, model_path):
+    def test_example_models(self, model_def):
         """Test the schema against example and test model definitions."""
-        model_def, _ = prepare_model_definition(model_path)
         if "data_tables" in model_def:
             for data_table_def in model_def["data_tables"].values():
                 CalliopeDataTable(**data_table_def)

--- a/tests/test_schemas/test_dimension_data_schema.py
+++ b/tests/test_schemas/test_dimension_data_schema.py
@@ -52,12 +52,6 @@ class TestIndexedParam:
 
 
 class TestCalliopeTech:
-    def test_example_model_techs(self, model_def):
-        """Test the example model technologies against the schema."""
-        if "techs" in model_def:
-            for tech in model_def["techs"].values():
-                CalliopeTech(**tech)
-
     @pytest.mark.parametrize("dims", ["techs", "nodes"])
     def test_invalid_dims(self, dims):
         """Technologies must not use 'techs' or 'nodes' in their indexed params."""
@@ -94,12 +88,6 @@ class TestCalliopeTech:
 
 
 class TestCalliopeNode:
-    def test_example_models(self, model_def):
-        """Test the node schema against example and test model definitions."""
-        if "nodes" in model_def:
-            for node in model_def["nodes"].values():
-                CalliopeNode(**node)
-
     @pytest.mark.parametrize(("latitude", "longitude"), [(None, 30), (30, None)])
     def test_dependent_definitions(self, latitude, longitude):
         with pytest.raises(

--- a/tests/test_schemas/test_dimension_data_schema.py
+++ b/tests/test_schemas/test_dimension_data_schema.py
@@ -2,7 +2,6 @@ import pydantic
 import pytest
 
 from calliope.io import read_rich_yaml
-from calliope.preprocess import prepare_model_definition
 from calliope.schemas.dimension_data_schema import (
     CalliopeNode,
     CalliopeTech,
@@ -10,7 +9,6 @@ from calliope.schemas.dimension_data_schema import (
 )
 
 from ..test_core_util import check_error_or_warning
-from . import utils
 
 
 class TestIndexedParam:
@@ -54,10 +52,8 @@ class TestIndexedParam:
 
 
 class TestCalliopeTech:
-    @pytest.mark.parametrize("model_path", utils.EXAMPLE_MODELS + utils.TEST_MODELS)
-    def test_example_model_techs(self, model_path):
+    def test_example_model_techs(self, model_def):
         """Test the example model technologies against the schema."""
-        model_def, _ = prepare_model_definition(model_path)
         if "techs" in model_def:
             for tech in model_def["techs"].values():
                 CalliopeTech(**tech)
@@ -98,10 +94,8 @@ class TestCalliopeTech:
 
 
 class TestCalliopeNode:
-    @pytest.mark.parametrize("model_path", utils.EXAMPLE_MODELS + utils.TEST_MODELS)
-    def test_example_models(self, model_path):
+    def test_example_models(self, model_def):
         """Test the node schema against example and test model definitions."""
-        model_def, _ = prepare_model_definition(model_path)
         if "nodes" in model_def:
             for node in model_def["nodes"].values():
                 CalliopeNode(**node)

--- a/tests/test_schemas/test_general.py
+++ b/tests/test_schemas/test_general.py
@@ -104,6 +104,204 @@ class TestNumveriVal:
             pydantic_model(numeric_val=invalid_input)
 
 
+class TestCalliopeDictModel:
+    @pytest.fixture(scope="class")
+    def dict_str_model(self):
+        dict_model = pydantic.create_model(
+            "TestModel", __base__=general.CalliopeDictModel, root=(dict[str, str], {})
+        )
+        return dict_model({"key1": "value1", "key2": "value2"})
+
+    @pytest.fixture(scope="class")
+    def base_model(self):
+        return pydantic.create_model(
+            "TestBaseModel",
+            __base__=general.CalliopeBaseModel,
+            foo=(str, "value1"),
+            bar=(int, ...),
+        )
+
+    @pytest.fixture(scope="class")
+    def dict_base_model(self, base_model):
+        dict_model = pydantic.create_model(
+            "TestModel",
+            __base__=general.CalliopeDictModel,
+            root=(dict[str, base_model], {}),
+        )
+        return dict_model({"key1": {"bar": 2}, "key2": {"foo": "value2", "bar": 3}})
+
+    @pytest.fixture(scope="class")
+    def dict_list_model(self, base_model):
+        list_model = pydantic.create_model(
+            "TestListModel",
+            __base__=general.CalliopeListModel,
+            root=(list[base_model], []),
+        )
+        dict_model = pydantic.create_model(
+            "TestModel",
+            __base__=general.CalliopeDictModel,
+            root=(dict[str, list_model], {}),
+        )
+        return dict_model({"key1": [{"bar": 2}], "key2": [{"foo": "value2", "bar": 3}]})
+
+    def test_no_setitem(self, dict_str_model):
+        """Ensure that we cannot set items directly on the CalliopeDictModel."""
+
+        with pytest.raises(general.PydanticCustomError, match="Cannot set a TestModel"):
+            dict_str_model["new_key"] = "new_value"
+
+    def test_getitem(self, dict_str_model):
+        """Ensure that we can get items from the CalliopeDictModel."""
+        assert dict_str_model["key1"] == dict_str_model.root["key1"] == "value1"
+
+    def test_repr(self, dict_str_model):
+        """Ensure that the __repr__ method returns the root attribute's __repr__."""
+        assert repr(dict_str_model) == repr(dict_str_model.root)
+
+    def test_rich_repr(self, dict_str_model):
+        """Ensure that the __rich_repr__ method yields the root attribute's items."""
+        rich_repr_items = list(dict_str_model.__rich_repr__())
+        assert rich_repr_items == [("key1", "value1"), ("key2", "value2")]
+
+    def test_update(self, dict_str_model):
+        """Ensure that the update method returns a new model with updated fields."""
+        new_model = dict_str_model.update({"key1": "new_value1", "key3": "value3"})
+
+        assert new_model.root == {
+            "key1": "new_value1",
+            "key2": "value2",
+            "key3": "value3",
+        }
+        assert dict_str_model.root == {"key1": "value1", "key2": "value2"}
+
+    def test_update_invalid(self, dict_str_model):
+        """Ensure that the update method raises an error when it won't pass pydantic validation."""
+        with pytest.raises(pydantic.ValidationError, match="1 validation error"):
+            dict_str_model.update({"key1": 123})
+
+    def test_check_base_model(self, dict_base_model):
+        """Ensure that the CalliopeDictModel can pass updates onto a CalliopeBaseModel."""
+        for key in ["key1", "key2"]:
+            assert isinstance(dict_base_model.root[key], general.CalliopeBaseModel)
+        assert dict_base_model.model_dump() == {
+            "key1": {"foo": "value1", "bar": 2},
+            "key2": {"foo": "value2", "bar": 3},
+        }
+
+    def test_update_base_model(self, dict_base_model):
+        """Ensure that the update method works with CalliopeBaseModel values."""
+        new_model = dict_base_model.update(
+            {"key1": {"foo": "new_value1"}, "key2": {"foo": "new_value2", "bar": 6}}
+        )
+        for key in ["key1", "key2"]:
+            assert isinstance(new_model.root[key], general.CalliopeBaseModel)
+
+        assert new_model.model_dump() == {
+            "key1": {"foo": "new_value1", "bar": 2},
+            "key2": {"foo": "new_value2", "bar": 6},
+        }
+        # No change to the original model
+        assert dict_base_model.model_dump() == {
+            "key1": {"foo": "value1", "bar": 2},
+            "key2": {"foo": "value2", "bar": 3},
+        }
+
+    def test_update_list_model(self, dict_list_model):
+        """Ensure that the update method replaces entire list model."""
+        new_model = dict_list_model.update(
+            {"key1": [{"bar": 4}], "key2": [{"foo": "new_value2", "bar": 6}]}
+        )
+        for key in ["key1", "key2"]:
+            assert isinstance(new_model[key], general.CalliopeListModel)
+
+        assert new_model.model_dump() == {
+            "key1": [{"foo": "value1", "bar": 4}],
+            "key2": [{"foo": "new_value2", "bar": 6}],
+        }
+        # No change to the original model
+        assert dict_list_model.model_dump() == {
+            "key1": [{"foo": "value1", "bar": 2}],
+            "key2": [{"foo": "value2", "bar": 3}],
+        }
+
+    def test_log_message_on_adding_dict_entry(self, caplog, dict_str_model):
+        """Ensure that a log message is generated when adding a new entry to the CalliopeDictModel."""
+        with caplog.at_level(logging.DEBUG):
+            updated_model = dict_str_model.update({"key3": "value3"})
+        assert "Adding TestModel entry: `key3`" in caplog.text
+
+        # Ensure that the new entry was added
+        assert updated_model.root["key3"] == "value3"
+
+
+class TestCalliopeListModel:
+    @pytest.fixture(scope="class")
+    def list_str_model(self):
+        list_model = pydantic.create_model(
+            "TestModel", __base__=general.CalliopeListModel, root=(list[str], [])
+        )
+        return list_model(["value1", "value2"])
+
+    @pytest.fixture(scope="class")
+    def list_base_model(self):
+        base_model = pydantic.create_model(
+            "TestBaseModel",
+            __base__=general.CalliopeBaseModel,
+            foo=(str, "value1"),
+            bar=(int, ...),
+        )
+        list_model = pydantic.create_model(
+            "TestListModel",
+            __base__=general.CalliopeListModel,
+            root=(list[base_model], []),
+        )
+        return list_model([{"bar": 2}, {"foo": "value2", "bar": 3}])
+
+    def test_getitem(self, list_str_model):
+        """Ensure that we can get items from the CalliopeListModel."""
+        assert list_str_model[0] == list_str_model.root[0] == "value1"
+        assert list_str_model[1] == list_str_model.root[1] == "value2"
+
+    def test_iter(self, list_str_model):
+        """Ensure that we can iterate over the CalliopeListModel."""
+        items = list(list_str_model)
+        assert items == ["value1", "value2"]
+
+    def test_repr(self, list_str_model):
+        """Ensure that the __repr__ method returns the root attribute's __repr__."""
+        assert repr(list_str_model) == repr(list_str_model.root)
+
+    def test_rich_repr(self, list_str_model):
+        """Ensure that the __rich_repr__ method yields the root attribute's items."""
+        rich_repr_items = list(list_str_model.__rich_repr__())
+        assert rich_repr_items == ["value1", "value2"]
+
+    def test_update(self, list_str_model):
+        """Ensure that the update method returns a new model with updated fields."""
+        new_model = list_str_model.update(["new_value1", "new_value2", "new_value3"])
+
+        assert new_model.root == ["new_value1", "new_value2", "new_value3"]
+        assert list_str_model.root == ["value1", "value2"]
+
+    def test_update_base_model(self, list_base_model):
+        """Ensure that the update method works with CalliopeBaseModel values."""
+        new_model = list_base_model.update(
+            [{"foo": "new_value1", "bar": 1}, {"foo": "new_value2", "bar": 6}]
+        )
+        for item in new_model:
+            assert isinstance(item, general.CalliopeBaseModel)
+
+        assert new_model.model_dump() == [
+            {"foo": "new_value1", "bar": 1},
+            {"foo": "new_value2", "bar": 6},
+        ]
+        # No change to the original model
+        assert list_base_model.model_dump() == [
+            {"foo": "value1", "bar": 2},
+            {"foo": "value2", "bar": 3},
+        ]
+
+
 class TestCalliopeBaseModel:
     @pytest.fixture(scope="module")
     def config_model_flat(self):
@@ -132,6 +330,34 @@ class TestCalliopeBaseModel:
             __base__=general.CalliopeBaseModel,
             __config__={"title": "TITLE 3"},
             extra_nested=(config_model_nested, config_model_nested()),
+        )
+
+    @pytest.fixture(scope="class")
+    def config_model_nested_with_dict_and_list_models(self, config_model_flat):
+        """Fixture for a nested model with CalliopeDictModel and CalliopeListModel."""
+        list_model = pydantic.create_model(
+            "TestListModel",
+            __base__=general.CalliopeListModel,
+            root=(list[config_model_flat], []),
+        )
+        config_model = pydantic.create_model(
+            "TestModel1",
+            __base__=general.CalliopeBaseModel,
+            __config__={"title": "TITLE"},
+            nested_list_field=(list_model, list_model()),
+            other_field=(str, "default_value"),
+        )
+        dict_model = pydantic.create_model(
+            "TestDictModel",
+            __base__=general.CalliopeDictModel,
+            root=(dict[str, config_model], {}),
+        )
+        return pydantic.create_model(
+            "TestNestedModel",
+            __base__=general.CalliopeBaseModel,
+            __config__={"title": "Nested Model"},
+            dict_field=(dict_model, dict_model()),
+            list_field=(list_model, list_model()),
         )
 
     @pytest.mark.parametrize(
@@ -212,6 +438,51 @@ class TestCalliopeBaseModel:
         with pytest.raises(pydantic.ValidationError, match="1 validation error"):
             model.update(to_update)
 
+    def test_update_nested_with_dict_and_list_models(
+        self, config_model_nested_with_dict_and_list_models
+    ):
+        """Test updating a nested model with CalliopeDictModel and CalliopeListModel."""
+        model = config_model_nested_with_dict_and_list_models(
+            dict_field={
+                "key1": {
+                    "nested_list_field": [
+                        {"foo": "value1", "foobar": 2},
+                        {"foo": "value2", "foobar": 4},
+                    ]
+                },
+                "key2": {"other_field": "value3"},
+            },
+            list_field=[{"foo": "value3", "foobar": 6}],
+        )
+        orig_model = model.model_dump()
+        # Update the dict field
+        new_model = model.update(
+            {
+                "dict_field": {
+                    "key1": {"nested_list_field": [{"foo": "new_value1"}]},
+                    "key3": {},
+                },
+                "list_field": [{}, {"foo": "new_value3", "foobar": 8}],
+            }
+        )
+        assert new_model.model_dump() == {
+            "dict_field": {
+                "key1": {
+                    "nested_list_field": [{"foo": "new_value1", "foobar": 1}],
+                    "other_field": "default_value",
+                },
+                "key2": {"nested_list_field": [], "other_field": "value3"},
+                "key3": {"nested_list_field": [], "other_field": "default_value"},
+            },
+            "list_field": [
+                {"foo": "bar", "foobar": 1},
+                {"foo": "new_value3", "foobar": 8},
+            ],
+        }
+
+        # No change in the original model
+        assert model.model_dump() == orig_model
+
     @pytest.mark.parametrize(
         ("to_update", "expected"),
         [
@@ -240,41 +511,24 @@ class TestCalliopeBaseModel:
 
         assert all(log_text in caplog.text for log_text in expected)
 
-    @pytest.fixture(scope="module")
-    def config_model_submodel(self):
-        sub_model = pydantic.create_model(
-            "TestSubModel",
-            __base__=general.CalliopeBaseModel,
-            __config__={"title": "TITLE"},
-            foo=(str, "bar"),
-            foobar=(int, 1),
-        )
-        model = pydantic.create_model(
-            "TestModel",
-            __base__=general.CalliopeBaseModel,
-            __config__={"title": "TITLE 2"},
-            nested=(sub_model, sub_model()),
-        )
-        return model
-
-    def test_config_model_no_defs(self, config_model_submodel):
-        model = config_model_submodel()
+    def test_config_model_no_defs(self, config_model_nested):
+        model = config_model_nested()
         json_schema = model.model_json_schema()
         no_defs_json_schema = model.model_no_ref_schema()
         assert "$defs" in json_schema
         assert "$defs" not in no_defs_json_schema
 
-    def test_config_model_no_resolved_refs(self, config_model_submodel):
-        model = config_model_submodel()
+    def test_config_model_no_resolved_refs(self, config_model_nested):
+        model = config_model_nested()
         json_schema = model.model_json_schema()
         no_defs_json_schema = model.model_no_ref_schema()
         assert json_schema["properties"]["nested"] == {
-            "$ref": "#/$defs/TestSubModel",
+            "$ref": "#/$defs/TestModel1",
             "default": {"foo": "bar", "foobar": 1},
         }
         assert (
             no_defs_json_schema["properties"]["nested"]
-            == json_schema["$defs"]["TestSubModel"]
+            == json_schema["$defs"]["TestModel1"]
         )
 
     def test_config_model_flat_no_defs(self, config_model_flat):

--- a/tests/test_schemas/test_general.py
+++ b/tests/test_schemas/test_general.py
@@ -233,7 +233,7 @@ class TestCalliopeBaseModel:
         ],
     )
     def test_logging(self, caplog, config_model_double_nested, to_update, expected):
-        caplog.set_level(logging.INFO)
+        caplog.set_level(logging.DEBUG)
 
         model = config_model_double_nested()
         model.update(to_update)

--- a/tests/test_schemas/test_input_model_schema.py
+++ b/tests/test_schemas/test_input_model_schema.py
@@ -22,10 +22,7 @@ TEST_MODELS = [
 ]
 
 
-@pytest.fixture(scope="module", params=EXAMPLE_MODELS + TEST_MODELS)
-def model_def(request):
+@pytest.mark.parametrize("model_path", EXAMPLE_MODELS + TEST_MODELS)
+def test_prepare_example_models(model_path):
     """Test the node schema against example and test model definitions."""
-    model_def, _ = prepare_model_definition(
-        read_rich_yaml(request.param), definition_path=request.param
-    )
-    return model_def
+    prepare_model_definition(read_rich_yaml(model_path), definition_path=model_path)

--- a/tests/test_schemas/test_model_def_schema.py
+++ b/tests/test_schemas/test_model_def_schema.py
@@ -1,7 +1,0 @@
-from calliope.schemas.model_def_schema import CalliopeModelDef
-
-
-class TestCalliopeModelDef:
-    def test_example_models(self, model_def):
-        """Test the schema against example and test model definitions."""
-        CalliopeModelDef(**model_def.model_dump(exclude_defaults=True))

--- a/tests/test_schemas/test_model_def_schema.py
+++ b/tests/test_schemas/test_model_def_schema.py
@@ -4,4 +4,4 @@ from calliope.schemas.model_def_schema import CalliopeModelDef
 class TestCalliopeModelDef:
     def test_example_models(self, model_def):
         """Test the schema against example and test model definitions."""
-        CalliopeModelDef(**model_def)
+        CalliopeModelDef(**model_def.model_dump(exclude_defaults=True))

--- a/tests/test_schemas/test_model_def_schema.py
+++ b/tests/test_schemas/test_model_def_schema.py
@@ -1,14 +1,7 @@
-import pytest
-
-from calliope.preprocess import prepare_model_definition
 from calliope.schemas.model_def_schema import CalliopeModelDef
-
-from . import utils
 
 
 class TestCalliopeModelDef:
-    @pytest.mark.parametrize("model_path", utils.EXAMPLE_MODELS + utils.TEST_MODELS)
-    def test_example_models(self, model_path):
+    def test_example_models(self, model_def):
         """Test the schema against example and test model definitions."""
-        model_def, _ = prepare_model_definition(model_path)
         CalliopeModelDef(**model_def)


### PR DESCRIPTION
@irm-codebase in doing the dim/param config work I realised I was bloating it with lots of work to separate out the inputs/results datasets. So, here's a WIP of what I'm thinking for that.



Some tests still fail and I'm working on that but wanted to get your view on it in the meantime!

## Summary of changes in this pull request

- The results and inputs datasets are completely separate and stored as independent "group" in the NetCDF
- The model attributes are never attached to these datasets and are instead a pydantic model attached to the calliope model which is saved into its own NetCDF "group" on saving
- This means that I have to currently pass parameter defaults explictly to the backend (they're not stored in the inputs attrs). This would then go with #712 
- Initialising a model is done with my pandas/xarray-esque command (`read_yaml`, `from_dicts`) to allow loading a model from dataset(s) (`from_datasets`). This removes the messy process we currently have for inferring how to process user inputs when they call `calliope.Model`. I'm not sure I like my current approach of having `calliope.Model()` returning an empty shell though. That needs some thought.
- `model._def` -> `model.model_def` as it is now part of a pydantic model and pydantic doesn't see private attrs as valid fields (so you can't update it). Might need a better name or perhaps even be better exploded out into its constituent parts in `model.attrs`.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved