### PR TITLE
Add `group_datetime` and `sum_next_n` helper functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### User-facing changes
 
+|new| helper functions to enable periodic and rolling window summations of decision variables (#777).
+
 |fixed| Timeseries capacity factor accounts for time resolution (#762).
 
 |fixed| Levelised cost accounts for energy that is generated and exported (`flow_export`) (#767).

--- a/docs/user_defined_math/helper_functions.md
+++ b/docs/user_defined_math/helper_functions.md
@@ -96,3 +96,24 @@ If the `<condition>` has any dimensions not present in `<math_component>`, `<mat
 !!! note
     `Where` gets referred to a lot in Calliope math.
     It always means the same thing: applying [xarray.DataArray.where][].
+
+## group_datetime
+
+When working with timeseries data, you may need to constrain a variable over a time period (e.g. hours, days, weeks).
+For instance, a demand may be flexible to be met at any point in a day provided the total daily demand is met.
+Or, you may need to constrain the amount of resource a thermal power plant can use each month.
+To achieve this, you can use the `group_datetime(<math_component>, <datetime_dimension>, <grouping_period>)` helper function.
+
+For example, `group_datetime(flow_in, timesteps, date)` will return the `flow_in` decision variable summed over dates.
+It will therefore be indexed over `[techs, nodes, carriers, date]` instead of `[techs, nodes, carriers, timesteps]` and you will need to account for this accordingly in your math expression.
+
+!!! note
+    Only a summation over the given period is possible with this helper function.
+    If you want to get e.g., a maximum value per month then you will need to create a new decision variable indexed over `months` and then create a constraint per timestep per month that will effectively set that decision variable to the maximum value over all timesteps in the month.
+    This can be quite memory intensive if you want to achieve it for days/weeks as you will be indexing over timesteps * days / weeks, which is a very large array.
+
+## sum_next_n
+
+Use the `sum_next_n(<math_component>, <dimension>, <rolling_horizon_window>)` to sum over a rolling window in a given dimension.
+This can be useful in demand-side management constraints, where demand can be shifted within a limited window, e.g. 4 hours.
+It can also be useful in tracking startup/shutdown periods when optimising with unit commitment.

--- a/src/calliope/backend/helper_functions.py
+++ b/src/calliope/backend/helper_functions.py
@@ -13,6 +13,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numpy as np
+import pandas as pd
 import xarray as xr
 
 from calliope.exceptions import BackendError
@@ -105,7 +106,11 @@ class ParsingHelperFunction(ABC):
             _registry[allowed][cls.NAME] = cls
 
     @staticmethod
-    def _add_to_iterator(instring: str, iterator_converter: dict[str, str]) -> str:
+    def _update_iterator(
+        instring: str,
+        iterator_converter: dict[str, str],
+        method: Literal["add", "replace"],
+    ) -> str:
         r"""Utility function for generating latex strings in multiple helper functions.
 
         Find an iterator in the iterator substring of the component string
@@ -117,8 +122,8 @@ class ParsingHelperFunction(ABC):
             instring (str): String in which the iterator substring can be found.
             iterator_converter (dict[str, str]):
                 key: the iterator to search for.
-                val: The new string to **append** to the iterator name.
-
+                val: The new string to **append** to the iterator name (if method = add) or **replace**.
+            method (Literal[add, replace]): Whether to add to the iterator or replace it entirely
         Returns:
             str: `instring`, but with `iterator` replaced with `iterator + new_string`
         """
@@ -128,7 +133,11 @@ class ParsingHelperFunction(ABC):
             new_iterator_list = []
             for it in iterator_list:
                 if it in iterator_converter:
-                    it += iterator_converter[it]
+                    it = (
+                        it + iterator_converter[it]
+                        if method == "add"
+                        else iterator_converter[it]
+                    )
                 new_iterator_list.append(it)
 
             return matched.group(1) + ",".join(new_iterator_list) + matched.group(3)
@@ -415,7 +424,7 @@ class SelectFromLookupArrays(ParsingHelperFunction):
             (iterator := dim.removesuffix("s")): rf"={array}[{iterator}]"
             for dim, array in lookup_arrays.items()
         }
-        array = self._add_to_iterator(array, new_strings)
+        array = self._update_iterator(array, new_strings, "add")
         return array
 
     def as_array(
@@ -580,7 +589,7 @@ class Roll(ParsingHelperFunction):
         new_strings = {
             k.removesuffix("s"): f"{-1 * int(v):+d}" for k, v in roll_kwargs.items()
         }
-        component = self._add_to_iterator(array, new_strings)
+        component = self._update_iterator(array, new_strings, "add")
         return component
 
     def as_array(self, array: xr.DataArray, **roll_kwargs: int) -> xr.DataArray:
@@ -707,3 +716,145 @@ class Where(ParsingHelperFunction):
             condition = self._input_data[condition.name]
 
         return array.where(condition.fillna(False).astype(bool))
+
+
+class GroupDatetime(ParsingHelperFunction):
+    """Apply a summation over a datetime group on a datetime dimension in math expressions."""
+
+    NAME = "group_datetime"
+    #:
+    ALLOWED_IN = ["expression"]
+
+    ignore_where = True
+
+    def as_math_string(self, array: str, over: str, group: str) -> str:  # noqa: D102, override
+        overstring = self._instr(over)
+        foreach_string = rf"{overstring} \text{{ if }} \text{{{group}}}(\text{{{over.removesuffix('s')}}}) = \text{{{group[0]}}}"
+        overstring = rf"\substack{{{foreach_string}}}"
+
+        return rf"\sum\limits_{{{overstring}}} ({array})"
+
+    def as_array(self, array: xr.DataArray, over: str, group: str) -> xr.DataArray:
+        """Sum an expression array over the given dimension(s).
+
+        Args:
+            array (xr.DataArray): expression array
+            over (str): dimension name over which to group
+            group (str): datetime grouper.
+                Any xarray/pandas datetime grouper options
+                datetime grouper options include 'date', 'day', 'dayofweek', 'dayofyear', 'hour', 'month', 'week', 'weekday', 'weekofyear', 'year'.
+
+
+        Returns:
+            xr.DataArray:
+                Array with datetime dimension aggregated over the grouper.
+
+        Note:
+            - The array is returned with the `over` dimension replaced by the name of the grouper.
+              So, if you select to resample to monthly, the returned array will include the `month` dimension.
+            - the `date` grouper will return the date as a string in ISO8601 format (e.g. "2025-01-01").
+              All other groupers will return integer values (e.g. month 1, 2, 3, etc.).
+
+        Examples:
+            One common use-case is to set a collate N timesteps beyond a given timestep to apply a constraint to it
+            (e.g., demand must be less than X in the next 24 hours):
+
+            For such a demand tech, the portion of its demand that is flexible should be separated from `sink_use_equals` to e.g.,
+            a `sink_use_flexible` timeseries parameter which we will use in the DSR constraint:
+
+            ```yaml
+            constraints:
+                4hr_demand_side_response:
+                    foreach: ["nodes", "techs", "carriers", "timesteps"]
+                    where: "carrier_in AND sink_use_flexible AND timesteps<=get_val_at_index(timesteps=-24)"
+                    equations:
+                        - expression: sum_next_n(flow_in, timesteps, 4) == sum_next_n(sink_use_flexible, timesteps, 4)"
+            ```
+        """
+        # We can't apply typical xarray rolling window functionality
+        grouped: dict[str | int, xr.DataArray] = {}
+        grouper = array[over].groupby(getattr(array[over].dt, group))
+        for group_name, group_items in grouper:
+            if group == "date":
+                group_name = str(group_name)
+            else:
+                group_name = int(group_name)
+            grouped[group_name] = array.sel(**{over: group_items}).sum(
+                over, min_count=1, skipna=True
+            )
+        array = xr.concat(grouped.values(), dim=pd.Index(grouped.keys(), name=group))
+        return array
+
+
+class SumNextN(ParsingHelperFunction):
+    """Sum the next N items in an array.
+
+    Works best for ordered arrays (datetime, integer) and is equivalent to a summation over a rolling window.
+    """
+
+    #:
+    NAME = "sum_next_n"
+    #:
+    ALLOWED_IN = ["expression"]
+
+    def as_math_string(self, array: str, over: str, N: int) -> str:  # noqa: D102, override
+        over_singular = rf"\text{{{over.removesuffix('s')}}}"
+        new_iterator = over[0]
+        updated_iterator_array = self._update_iterator(
+            array, {over.removesuffix("s"): new_iterator}, "replace"
+        )
+
+        return rf"\sum\limits_{{\text{{{new_iterator}}}={over_singular}}}^{{{over_singular}+{N}}} ({updated_iterator_array})"
+
+    def as_array(self, array: xr.DataArray, over: str, N: int) -> xr.DataArray:
+        """Sum values from current up to N from current on the dimension `over`.
+
+        Works best for ordered arrays (datetime, integer).
+
+
+        Args:
+            array (xr.DataArray): Math component array.
+            over (str): Dimension over which to sum
+            N (int): number of items beyond the current value to sum from
+
+        Returns:
+            xr.DataArray:
+                Returns the input array with the condition applied,
+                including having been broadcast across any new dimensions provided by the condition.
+
+        Note:
+            - The rolling window does not wrap around to the start of the set when reaching the end.
+              That is, if you have N = 4 then for a dimension of length T, at T - 1 it will sum over dimension positions (T - 1, T), not (T - 1, T, 0, 1).
+            - You will find that this over-constrains the model unless you limit the constraint (using the `where` string) to only apply over `len(over) - N`.
+              This is linked to the abovementioned lack of wrapping.
+              E.g. `where: timesteps<=get_val_at_index(timesteps=-24)` if N == 24.
+            - This function is based on an integer number of steps from the current step.
+              For datetime dimensions like `timesteps`, you will (a) need to be using a regular time frequency (e.g. hourly) and (b) update `N` to reflect the resolution of your time dimension
+              (N = 4 in if time_resample=`1h` -> N = 2 if time_resample=`2h`).
+
+        Examples:
+            One common use-case is to collate N timesteps beyond a given timestep to apply a constraint to it
+            (e.g., demand must be less than X in the next 24 hours):
+
+            For such a demand tech, the portion of its demand that is flexible should be separated from `sink_use_equals` to e.g.,
+            a `sink_use_flexible` timeseries parameter which we will use in the DSR constraint:
+
+            ```yaml
+            constraints:
+                4hr_demand_side_response:
+                    foreach: ["nodes", "techs", "carriers", "timesteps"]
+                    where: "carrier_in AND sink_use_flexible AND timesteps<=get_val_at_index(timesteps=-24)"
+                    equations:
+                        - expression: sum_next_n(flow_in, timesteps, 4) == sum_next_n(sink_use_flexible, timesteps, 4)"
+            ```
+        """
+        # We cannot use the xarray rolling window method as it doesn't like operating on Python objects, which our optimisation problem components are.
+        results: list[xr.DataArray] = []
+        for i in range(len(self._input_data.coords[over])):
+            results.append(
+                array.isel(**{over: slice(i, i + int(N))}).sum(over, min_count=1)
+            )
+        final_array = xr.concat(
+            results, dim=self._input_data.coords[over]
+        ).broadcast_like(array)
+        return final_array

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from itertools import chain, combinations
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pytest
 import xarray as xr
 
@@ -166,7 +167,16 @@ def dummy_model_math():
 def dummy_model_data(model_defaults):
     coords = {
         dim: (
-            ["foo", "bar"]
+            pd.to_datetime(
+                [
+                    "2000-01-01 00:00",
+                    "2000-01-01 01:00",
+                    "2000-01-01 02:00",
+                    "2000-01-01 03:00",
+                ]
+            )
+            if dim == "timesteps"
+            else ["foo", "bar"]
             if dim != "techs"
             else ["foobar", "foobaz", "barfoo", "bazfoo"]
         )
@@ -261,6 +271,8 @@ def dummy_model_data(model_defaults):
                     ["bazfoo", np.nan, np.nan, np.nan],
                 ],
             ),
+            "timeseries_data": (["timesteps"], [1, 1, 1, 1]),
+            "timeseries_nodes_data": (["nodes", "timesteps"], np.ones((2, 4))),
         },
         attrs={"scenarios": ["foo"]},
     )

--- a/tests/test_backend_helper_functions.py
+++ b/tests/test_backend_helper_functions.py
@@ -393,6 +393,18 @@ class TestAsArray:
         )
         assert result.equals(expected)
 
+    def test_expression_group_datetime_time(
+        self, expression_group_datetime, dummy_model_data
+    ):
+        expected = xr.DataArray(
+            [1, 1, 1, 1],
+            coords={"time": ["00:00:00", "01:00:00", "02:00:00", "03:00:00"]},
+        )
+        result = expression_group_datetime(
+            dummy_model_data.timeseries_data, "timesteps", "time"
+        )
+        assert result.equals(expected)
+
     def test_expression_group_datetime_hour(
         self, expression_group_datetime, dummy_model_data
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,21 +1,19 @@
+import importlib.resources
 import os
 import subprocess
 import tempfile
 from pathlib import Path
 
-import importlib_resources
 import pytest  # noqa: F401
 from click.testing import CliRunner
 
 import calliope
 from calliope import cli, io
 
-_MODEL_NATIONAL = (
-    importlib_resources.files("calliope")
-    / "example_models"
-    / "national_scale"
-    / "model.yaml"
-).as_posix()
+with importlib.resources.as_file(importlib.resources.files("calliope")) as f:
+    _MODEL_NATIONAL = (
+        f / "example_models" / "national_scale" / "model.yaml"
+    ).as_posix()
 
 _MINIMAL_TEST_MODEL = (
     Path(__file__).parent / "common" / "test_model" / "model.yaml"

--- a/tests/test_core_util.py
+++ b/tests/test_core_util.py
@@ -1,9 +1,9 @@
 import datetime
 import glob
+import importlib.resources
 import logging
 from pathlib import Path
 
-import importlib_resources
 import jsonschema
 import numpy as np
 import pandas as pd
@@ -18,9 +18,11 @@ from calliope.util.logging import log_time
 
 from .common.util import check_error_or_warning
 
-_EXAMPLES_DIR = importlib_resources.files("calliope") / "example_models"
-_MODEL_NATIONAL = (_EXAMPLES_DIR / "national_scale" / "model.yaml").as_posix()
-_MODEL_URBAN = (_EXAMPLES_DIR / "urban_scale" / "model.yaml").as_posix()
+with importlib.resources.as_file(importlib.resources.files("calliope")) as f:
+    _MODEL_NATIONAL = (
+        f / "example_models" / "national_scale" / "model.yaml"
+    ).as_posix()
+    _MODEL_URBAN = (f / "example_models" / "urban_scale" / "model.yaml").as_posix()
 
 
 class TestLogging:


### PR DESCRIPTION
Fixes #777

I had implemented these ad-hoc for other modelling efforts but since @fvandebeek brought it up in an issue I decided to formalise it in the core code.

The helper func names and docstrings might need more work to add clarity. I'd welcome ideas!

## Summary of changes in this pull request

* `group_datetime` to sum over a time dimension in a math component using pre-defined datetime periods (date, hour, weekofyear, month, etc.)
* `sum_next_n` to apply a rolling summation over a time/ordered dimension of a math component.


## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved