### PR TITLE
Fix tracking set objective in the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### User-facing changes
 
+|fixed| Updates to the expression underlying the Gurobi backend objective function make their way through to the objective function before solving (#797).
+
 |changed| |backwards-incompatible| `where:` now uses `==` for equality comparisons (previously `=`).
 
 |changed| |backwards-incompatible| YAML files are loaded with `calliope.read_yaml(...)` instead of `calliope.Model(...)`.

--- a/src/calliope/backend/gurobi_backend_model.py
+++ b/src/calliope/backend/gurobi_backend_model.py
@@ -158,7 +158,7 @@ class GurobiBackendModel(backend_model.BackendModel):
         ) -> xr.DataArray:
             expr = element.evaluate_expression(self, references=references)
 
-            if name == self.config.objective:
+            if name == self.objective:
                 self._instance.setObjective(expr.item(), sense=sense)
                 self.objective = name
                 self.log("objectives", name, "Objective activated.")
@@ -171,6 +171,7 @@ class GurobiBackendModel(backend_model.BackendModel):
         to_set = self.objectives[name]
         sense = self.OBJECTIVE_SENSE_DICT[to_set.attrs["sense"]]
         self._instance.setObjective(to_set.item(), sense=sense)
+        self._instance.update()
         self.objective = name
         self.log("objectives", name, "Objective activated.", level="info")
 

--- a/src/calliope/backend/latex_backend_model.py
+++ b/src/calliope/backend/latex_backend_model.py
@@ -479,8 +479,6 @@ class LatexBackendModel(backend_model.BackendModelGenerator):
             equations=equation_strings,
             sense=sense_dict[objective_dict["sense"]],
         )
-        if name == self.config.objective:
-            self.objective = name
 
     def set_objective(self, name: str):  # noqa: D102, override
         self.objective = name

--- a/src/calliope/backend/pyomo_backend_model.py
+++ b/src/calliope/backend/pyomo_backend_model.py
@@ -184,10 +184,9 @@ class PyomoBackendModel(backend_model.BackendModel):
         ) -> xr.DataArray:
             expr = element.evaluate_expression(self, references=references)
             objective = pmo.objective(expr.item(), sense=sense)
-            if name == self.config.objective:
+            if name == self.objective:
                 text = "activated"
                 objective.activate()
-                self.objective = name
             else:
                 text = "deactivated"
                 objective.deactivate()

--- a/tests/test_backend_latex_backend.py
+++ b/tests/test_backend_latex_backend.py
@@ -213,8 +213,7 @@ class TestLatexBackendModel:
         assert len(dummy_latex_backend_model.objectives.data_vars) == 1
 
     def test_default_objective_set(self, dummy_latex_backend_model):
-        # Dummy backend model has no objective initially
-        assert not hasattr(dummy_latex_backend_model, "objective")
+        assert dummy_latex_backend_model.objective == "min_cost_optimisation"
 
     def test_new_objective_set(self, dummy_latex_backend_model):
         dummy_latex_backend_model.add_objective(


### PR DESCRIPTION
Fixes #797 

## Summary of changes in this pull request

* Current objective hangs around more explicitly in the backend (need to work out a way to store the active objective linked to a set of results - #798)
* On recreating backend components completely, changes to math made with `model.backend.add_[component](...)` are passed.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved