### PR TITLE
Postprocess: prevent exception when flow_cap lacks nodes dim

### DIFF
--- a/src/calliope/postprocess/postprocess.py
+++ b/src/calliope/postprocess/postprocess.py
@@ -67,7 +67,9 @@ def capacity_factor(
             dim=["timesteps", "nodes"], min_count=1
         )
 
-        cap_sum = flow_cap.where(lambda x: x > 0).sum(dim="nodes", min_count=1)
+        cap_sum = flow_cap.where(lambda x: x > 0)
+        if "nodes" in cap_sum.dims:
+            cap_sum = cap_sum.sum(dim="nodes", min_count=1)
         time_sum = (model_data.timestep_resolution * model_data.timestep_weights).sum()
 
         capacity_factors = (prod_sum / (cap_sum * time_sum)).fillna(0)


### PR DESCRIPTION
This solves a rare edge case: when making a single-node model where operate mode math is added to the base math and `flow_cap` is defined directly in-YAML, `cap_sum` ends up having no "nodes" dimension, leading to an exception in postprocessing.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved