### PR TITLE
fix equation eq operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### User-facing changes
 
+|changed| `equations: - expression:` now uses `=` for 'equals' cases (#818)
+
 |fixed| `ModelDataFactory` is no longer run twice during startup, resulting in faster initialisation
 
 |changed| `Model.from_dict` has been removed in favor of `calliope.read_dict` (matching `read_netcdf` and `read_yaml`)

--- a/docs/user_defined_math/examples/chp_htp.yaml
+++ b/docs/user_defined_math/examples/chp_htp.yaml
@@ -114,9 +114,9 @@ constraints:
   balance_conversion:
     equations:
       - where: NOT turbine_type
-        expression: sum(flow_out_inc_eff, over=carriers) == sum(flow_in_inc_eff, over=carriers)
+        expression: sum(flow_out_inc_eff, over=carriers) = sum(flow_in_inc_eff, over=carriers)
       - where: turbine_type==backpressure AND NOT boiler_eff
-        expression: flow_out_inc_eff[carriers=electricity] == sum(flow_in_inc_eff, over=carriers)
+        expression: flow_out_inc_eff[carriers=electricity] = sum(flow_in_inc_eff, over=carriers)
 # ~~
 
 # Extraction turbine constraints
@@ -192,5 +192,5 @@ constraints:
     where: turbine_type==backpressure AND NOT boiler_eff
     equations:
       - expression: >
-          flow_out[carriers=electricity] ==
+          flow_out[carriers=electricity] =
           flow_out[carriers=heat] * power_to_heat_ratio

--- a/docs/user_defined_math/examples/demand_share_per_timestep_decision.yaml
+++ b/docs/user_defined_math/examples/demand_share_per_timestep_decision.yaml
@@ -111,4 +111,4 @@ constraints:
     equations:
       - expression: >
           sum(demand_share_per_timestep_decision, over=[techs])
-          == demand_share_limit
+          = demand_share_limit

--- a/docs/user_defined_math/examples/fuel_dist.yaml
+++ b/docs/user_defined_math/examples/fuel_dist.yaml
@@ -61,7 +61,7 @@ constraints:
     equations:
       - expression: >
           sum(flow_out, over=techs) - sum(flow_in, over=techs) - $flow_export
-          + $unmet_demand_and_unused_supply + $fuel_distributor == 0
+          + $unmet_demand_and_unused_supply + $fuel_distributor = 0
     sub_expressions:
       fuel_distributor:
         - where: fuel_distributor
@@ -78,7 +78,7 @@ constraints:
     foreach: [carriers, timesteps]
     where: fuel_distributor
     equations:
-      - expression: sum(fuel_distributor, over=nodes) == 0
+      - expression: sum(fuel_distributor, over=nodes) = 0
 
   # fuel_import_max and fuel_export_max could be defined per node and carrier and
   # could be collapsed into one constraining limit e.g., `fuel_distribution_max`.

--- a/docs/user_defined_math/examples/share_all_timesteps.yaml
+++ b/docs/user_defined_math/examples/share_all_timesteps.yaml
@@ -45,7 +45,7 @@ constraints:
     where: demand_share_equals
     equations:
       - expression: >
-          sum(flow_out, over=[timesteps, carriers]) ==
+          sum(flow_out, over=[timesteps, carriers]) =
           sum(flow_in[techs=$demand_tech], over=[timesteps, carriers])
           * demand_share_equals
     slices:
@@ -61,7 +61,7 @@ constraints:
     where: supply_share_equals
     equations:
       - expression: >
-          sum(flow_out[carriers=$carrier], over=[timesteps]) ==
+          sum(flow_out[carriers=$carrier], over=[timesteps]) =
           sum(flow_out[carriers=$carrier], over=[techs, timesteps])
           * supply_share_equals
     slices:

--- a/docs/user_defined_math/examples/share_per_timestep.yaml
+++ b/docs/user_defined_math/examples/share_per_timestep.yaml
@@ -46,7 +46,7 @@ constraints:
     where: demand_share_per_timestep_equals
     equations:
       - expression: >
-          sum(flow_out, over=carriers) ==
+          sum(flow_out, over=carriers) =
           sum(flow_in[techs=$demand_tech], over=carriers)
           * demand_share_per_timestep_equals
     slices:
@@ -62,7 +62,7 @@ constraints:
     where: supply_share_per_timestep_equals
     equations:
       - expression: >
-          flow_out[carriers=$carrier] ==
+          flow_out[carriers=$carrier] =
           sum(flow_out[carriers=$carrier], over=techs)
           * supply_share_per_timestep_equals
     slices:

--- a/docs/user_defined_math/examples/uptime_downtime_limits.yaml
+++ b/docs/user_defined_math/examples/uptime_downtime_limits.yaml
@@ -73,7 +73,7 @@ constraints:
     foreach: [nodes, techs, timesteps]
     where: downtime_periods
     equations:
-      - expression: sum(flow_out, over=carriers) == 0
+      - expression: sum(flow_out, over=carriers) = 0
 
   downtime_period_decision:
     description: >

--- a/src/calliope/backend/expression_parser.py
+++ b/src/calliope/backend/expression_parser.py
@@ -355,7 +355,7 @@ class EvalSignOp(EvalToArrayStr):
 class EvalComparisonOp(EvalToArrayStr):
     """Class for processing comparison operations."""
 
-    OP_TRANSLATOR = {"<=": r" \leq ", ">=": r" \geq ", "==": " = "}
+    OP_TRANSLATOR = {"<=": r" \leq ", ">=": r" \geq ", "=": " = "}
 
     def __init__(self, instring: str, loc: int, tokens: pp.ParseResults) -> None:
         """Parse action to process successfully parsed equations of the form LHS OPERATOR RHS.
@@ -412,7 +412,7 @@ class EvalComparisonOp(EvalToArrayStr):
         rhs_where = rhs.broadcast_like(where)
 
         match self.op:
-            case "==":
+            case "=":
                 op = np.equal
             case "<=":
                 op = np.less_equal
@@ -1162,9 +1162,9 @@ def arithmetic_parser(*args, arithmetic: pp.Forward | None = None) -> pp.Forward
 
 
 def equation_comparison_parser(arithmetic: pp.ParserElement) -> pp.ParserElement:
-    """Parsing grammar to combine equation elements either side of a comparison operator (<= >= ==).
+    """Parsing grammar to combine equation elements either side of a comparison operator (<= >= =).
 
-    Whitespace is ignored on parsing (i.e., "1+foo==$bar" is equivalent to "1 + 1 == $bar").
+    Whitespace is ignored on parsing (i.e., "1+foo=$bar" is equivalent to "1 + 1 = $bar").
 
     Args:
         arithmetic (pp.ParserElement):
@@ -1174,7 +1174,7 @@ def equation_comparison_parser(arithmetic: pp.ParserElement) -> pp.ParserElement
         pp.ParserElement:
             Parser for strings of the form "LHS OPERATOR RHS".
     """
-    comparison_operators = pp.one_of(["<=", ">=", "=="])
+    comparison_operators = pp.one_of(["<=", ">=", "="])
     equation_comparison = arithmetic + comparison_operators + arithmetic
     equation_comparison.set_parse_action(EvalComparisonOp)
 
@@ -1307,7 +1307,7 @@ def generate_arithmetic_parser(valid_component_names: Iterable) -> pp.ParserElem
 
 
 def generate_equation_parser(valid_component_names: Iterable) -> pp.ParserElement:
-    """Create parser for equation expressions of the form LHS OPERATOR RHS (e.g. `foo == 1 + bar`).
+    """Create parser for equation expressions of the form LHS OPERATOR RHS (e.g. `foo = 1 + bar`).
 
     This parser allows arbitrarily nested arithmetic and function calls (and arithmetic inside function calls)
     and reference to sub-expressions and index slice expressions.

--- a/src/calliope/backend/helper_functions.py
+++ b/src/calliope/backend/helper_functions.py
@@ -904,7 +904,7 @@ class GroupDatetime(ParsingHelperFunction):
                     foreach: [nodes, techs, carriers, date]
                     where: sink_use_equals_daily
                     equations:
-                        - expression: "group_datetime(flow_in, timesteps, date) == sink_use_equals_daily"
+                        - expression: "group_datetime(flow_in, timesteps, date) = sink_use_equals_daily"
             ```
 
             Similarly, a monthly maximum resource to a supply technology might be used, to simulate e.g. biofuel feedstock availability:
@@ -1000,7 +1000,7 @@ class SumNextN(ParsingHelperFunction):
                     foreach: ["nodes", "techs", "carriers", "timesteps"]
                     where: "carrier_in AND sink_use_flexible AND timesteps<=get_val_at_index(timesteps=-24)"
                     equations:
-                        - expression: sum_next_n(flow_in, timesteps, 4) == sum_next_n(sink_use_flexible, timesteps, 4)"
+                        - expression: sum_next_n(flow_in, timesteps, 4) = sum_next_n(sink_use_flexible, timesteps, 4)"
             ```
         """
         # We cannot use the xarray rolling window method as it doesn't like operating on Python objects, which our optimisation problem components are.

--- a/src/calliope/example_models/urban_scale/additional_math.yaml
+++ b/src/calliope/example_models/urban_scale/additional_math.yaml
@@ -10,12 +10,12 @@ constraints:
     foreach: [nodes, techs, timesteps]
     where: "[chp] in techs"
     equations:
-      - expression: flow_out[carriers=electricity] * heat_to_power_ratio == flow_out[carriers=heat]
+      - expression: flow_out[carriers=electricity] * heat_to_power_ratio = flow_out[carriers=heat]
 
   balance_conversion:
     # Remove the link between CHP inflow and heat outflow (now dealt with in `link_chp_outputs`)
     equations:
       - where: "NOT [chp] in techs"
-        expression: sum(flow_out_inc_eff, over=carriers) == sum(flow_in_inc_eff, over=carriers)
+        expression: sum(flow_out_inc_eff, over=carriers) = sum(flow_in_inc_eff, over=carriers)
       - where: "[chp] in techs"
-        expression: flow_out_inc_eff[carriers=electricity] == sum(flow_in_inc_eff, over=carriers)
+        expression: flow_out_inc_eff[carriers=electricity] = sum(flow_in_inc_eff, over=carriers)

--- a/src/calliope/math/base.yaml
+++ b/src/calliope/math/base.yaml
@@ -650,7 +650,7 @@ constraints:
     foreach: [nodes, techs, carriers]
     where: source_cap AND source_cap_equals_flow_cap==True
     equations:
-      - expression: source_cap == flow_cap
+      - expression: source_cap = flow_cap
 
   force_zero_area_use:
     description: >-
@@ -658,7 +658,7 @@ constraints:
     foreach: [nodes, techs]
     where: "area_use AND flow_cap_max==0"
     equations:
-      - expression: area_use == 0
+      - expression: area_use = 0
 
   area_use_per_flow_capacity:
     description: >-
@@ -666,7 +666,7 @@ constraints:
     foreach: [nodes, techs, carriers]
     where: "area_use AND area_use_per_flow_cap"
     equations:
-      - expression: area_use == flow_cap * area_use_per_flow_cap
+      - expression: area_use = flow_cap * area_use_per_flow_cap
 
   area_use_capacity_per_loc:
     description: >-
@@ -698,7 +698,7 @@ constraints:
     foreach: [nodes, techs, timesteps]
     where: base_tech==conversion AND NOT include_storage==true
     equations:
-      - expression: sum(flow_out_inc_eff, over=carriers) == sum(flow_in_inc_eff, over=carriers)
+      - expression: sum(flow_out_inc_eff, over=carriers) = sum(flow_in_inc_eff, over=carriers)
 
   flow_out_max:
     description: >-
@@ -757,7 +757,7 @@ constraints:
       - expression: >-
           sum(flow_out, over=techs) -
           sum(flow_in, over=techs) -
-          $flow_export + $unmet_demand_and_unused_supply == 0
+          $flow_export + $unmet_demand_and_unused_supply = 0
     sub_expressions:
       flow_export:
         - where: "any(carrier_export, over=techs)"
@@ -778,7 +778,7 @@ constraints:
     where: "base_tech==demand"
     equations:
       - where: "sink_use_equals"
-        expression: "flow_in_inc_eff == sink_use_equals * $sink_scaler"
+        expression: "flow_in_inc_eff = sink_use_equals * $sink_scaler"
       - where: "NOT sink_use_equals AND sink_use_max"
         expression: "flow_in_inc_eff <= sink_use_max * $sink_scaler"
     sub_expressions:
@@ -807,7 +807,7 @@ constraints:
     foreach: [nodes, techs, carriers, timesteps]
     where: "base_tech==supply AND NOT include_storage==True"
     equations:
-      - expression: flow_out_inc_eff == source_use * source_eff
+      - expression: flow_out_inc_eff = source_use * source_eff
 
   balance_supply_with_storage:
     description: >-
@@ -816,7 +816,7 @@ constraints:
     foreach: [nodes, techs, carriers, timesteps]
     where: "storage AND base_tech==supply"
     equations:
-      - expression: storage == $storage_previous_step + source_use * source_eff - flow_out_inc_eff
+      - expression: storage = $storage_previous_step + source_use * source_eff - flow_out_inc_eff
     sub_expressions:
       storage_previous_step: &storage_previous_step
         - where: timesteps==get_val_at_index(timesteps=0) AND NOT cyclic_storage==True
@@ -843,7 +843,7 @@ constraints:
     where: "source_use AND (source_use_equals OR source_use_max)"
     equations:
       - where: "source_use_equals"
-        expression: "source_use == source_use_equals * $source_scaler"
+        expression: "source_use = source_use_equals * $source_scaler"
       - where: "NOT source_use_equals AND source_use_max"
         expression: "source_use <= source_use_max * $source_scaler"
     sub_expressions:
@@ -874,7 +874,7 @@ constraints:
     where: (include_storage==true or base_tech==storage) AND NOT (base_tech==supply OR base_tech==demand)
     equations:
       - expression: >-
-          storage == $storage_previous_step -
+          storage = $storage_previous_step -
             sum(flow_out_inc_eff, over=carriers) + sum(flow_in_inc_eff, over=carriers)
     sub_expressions:
       storage_previous_step: *storage_previous_step
@@ -890,7 +890,7 @@ constraints:
       - expression: >-
           storage[timesteps=$final_step] * (
             (1 - storage_loss) ** timestep_resolution[timesteps=$final_step]
-          ) == storage_initial * storage_cap
+          ) = storage_initial * storage_cap
     slices:
       final_step:
         - expression: get_val_at_index(timesteps=-1)
@@ -904,7 +904,7 @@ constraints:
     foreach: [techs, timesteps]
     where: "base_tech==transmission"
     equations:
-      - expression: sum(flow_out_inc_eff, over=[nodes, carriers]) == sum(flow_in_inc_eff, over=[nodes, carriers])
+      - expression: sum(flow_out_inc_eff, over=[nodes, carriers]) = sum(flow_in_inc_eff, over=[nodes, carriers])
 
   symmetric_transmission:
     description: >-
@@ -912,7 +912,7 @@ constraints:
     foreach: [nodes, techs]
     where: "base_tech==transmission"
     equations:
-      - expression: sum(flow_cap, over=carriers) == link_flow_cap
+      - expression: sum(flow_cap, over=carriers) = link_flow_cap
 
   export_balance:
     description: >-

--- a/src/calliope/math/milp.yaml
+++ b/src/calliope/math/milp.yaml
@@ -156,7 +156,7 @@ constraints:
     foreach: [nodes, techs]
     where: "storage AND purchased_units AND storage_cap_per_unit"
     equations:
-      - expression: storage_cap == purchased_units * storage_cap_per_unit
+      - expression: storage_cap = purchased_units * storage_cap_per_unit
 
   flow_capacity_units_milp:
     description: >-
@@ -164,7 +164,7 @@ constraints:
     foreach: [nodes, techs, carriers]
     where: "purchased_units AND flow_cap_per_unit"
     equations:
-      - expression: flow_cap == purchased_units * flow_cap_per_unit
+      - expression: flow_cap = purchased_units * flow_cap_per_unit
 
   flow_capacity_max_purchase_milp:
     description: >-

--- a/src/calliope/math/storage_inter_cluster.yaml
+++ b/src/calliope/math/storage_inter_cluster.yaml
@@ -42,7 +42,7 @@ constraints:
 
   set_storage_initial:
     equations:
-      - expression: storage_inter_cluster[datesteps=$final_step] * ((1 - storage_loss) ** 24) == storage_initial * storage_cap
+      - expression: storage_inter_cluster[datesteps=$final_step] * ((1 - storage_loss) ** 24) = storage_initial * storage_cap
     slices:
       final_step:
         - expression: get_val_at_index(datesteps=-1)
@@ -96,7 +96,7 @@ constraints:
     foreach: [nodes, techs, datesteps]
     where: "include_storage==True OR base_tech==storage"
     equations:
-      - expression: storage_inter_cluster == $storage_previous_step + $storage_intra
+      - expression: storage_inter_cluster = $storage_previous_step + $storage_intra
     sub_expressions:
       storage_previous_step:
         - where: datesteps==get_val_at_index(datesteps=0) AND NOT cyclic_storage==True

--- a/src/calliope/schemas/math_schema.py
+++ b/src/calliope/schemas/math_schema.py
@@ -36,7 +36,7 @@ class ExpressionItem(CalliopeBaseModel):
     """Condition to determine whether the accompanying expression is built."""
     expression: str
     """Expression for this component.
-    - Equations: LHS OPERATOR RHS, where LHS and RHS are math expressions and OPERATOR is one of [==, <=, >=].
+    - Equations: LHS OPERATOR RHS, where LHS and RHS are math expressions and OPERATOR is one of [=, <=, >=].
     - Subexpressions: be one term or a combination of terms using the operators [+, -, *, /, **].
     - Slices: a list of set items or a call to a helper function.
     """

--- a/tests/test_backend_expression_parser.py
+++ b/tests/test_backend_expression_parser.py
@@ -762,7 +762,7 @@ class TestComponentParser:
             func_or_not.format(instring), parse_all=True
         )
 
-    @pytest.mark.parametrize("instring", ["[FOO, BAR]", "foo == 1", "$foo", "[foo]"])
+    @pytest.mark.parametrize("instring", ["[FOO, BAR]", "foo = 1", "$foo", "[foo]"])
     def test_sub_expression_parser_fail(self, generate_sub_expression, instring):
         with pytest.raises(pp.ParseException):
             generate_sub_expression.parse_string(instring, parse_all=True)
@@ -798,7 +798,7 @@ class TestEquationParserComparison:
     def expected_right(self, var_right):
         return self.EXPR_PARAMS_AND_EXPECTED_EVAL[var_right]
 
-    @pytest.fixture(params=["<=", ">=", "=="])
+    @pytest.fixture(params=["<=", ">=", "="])
     def operator(self, request):
         return request.param
 
@@ -828,11 +828,11 @@ class TestEquationParserComparison:
         [
             ("1<=2", True),
             ("1 >= 2", False),
-            ("1  ==  2", False),
+            ("1  =  2", False),
             ("(1) <= (2)", True),
             ("1 * 3 <= 1e2", True),
             ("-1 >= -0.1 / 2", False),
-            ("2**2 == 4 * 1 / 1 * 1**1", True),
+            ("2**2 = 4 * 1 / 1 * 1**1", True),
             ("(1 + 3) * 2 >= 10 + -1", False),
         ],
     )
@@ -852,8 +852,8 @@ class TestEquationParserComparison:
         "equation_string",
         [
             "1 + 2 =<",  # missing RHS
-            "== 1 + 2 ",  # missing LHS
-            "1 = 2",  # unallowed operator
+            "= 1 + 2 ",  # missing LHS
+            "1 == 2",  # unallowed operator
             "1 < 2",  # unallowed operator
             "2 > 1",  # unallowed operator
             "1 (<= 2)",  # weird brackets
@@ -989,7 +989,7 @@ class TestAsMathString:
             ),
             (
                 "equation_comparison",
-                "no_dim_var == with_inf",
+                "no_dim_var = with_inf",
                 r"\textbf{no_dim_var} = \textit{with_inf}_\text{node,tech}",
             ),
         ],

--- a/tests/test_preprocess/test_model_math.py
+++ b/tests/test_preprocess/test_model_math.py
@@ -159,8 +159,8 @@ class TestValidateMathDict:
     @pytest.mark.parametrize(
         "component_dict",
         [
-            {"equations": [{"expression": "1 = 1"}]},
-            {"equations": [{"expression": "1 = 1"}], "where": "foo[bar]"},
+            {"equations": [{"expression": "1 == 1"}]},
+            {"equations": [{"expression": "1 == 1"}], "where": "foo[bar]"},
         ],
     )
     @pytest.mark.parametrize("both_fail", [True, False])
@@ -176,13 +176,13 @@ class TestValidateMathDict:
             math_dict["constraints"]["bar"] = component_dict
             errors_to_check.append("* constraints:bar:")
         else:
-            math_dict["constraints"]["bar"] = {"equations": [{"expression": "1 == 1"}]}
+            math_dict["constraints"]["bar"] = {"equations": [{"expression": "1 = 1"}]}
 
         with pytest.raises(calliope.exceptions.ModelError) as excinfo:
             model_math.build_math(math_priority, init_math, math_dict)
         assert check_error_or_warning(excinfo, errors_to_check)
 
-    @pytest.mark.parametrize("eq_string", ["1 = 1", "1 ==\n1[a]"])
+    @pytest.mark.parametrize("eq_string", ["1 == 1", "1 =\n1[a]"])
     def test_add_math_fails_marker_correct_position(
         self, init_math, math_priority, eq_string
     ):

--- a/tests/test_schemas/test_math_schema.py
+++ b/tests/test_schemas/test_math_schema.py
@@ -48,7 +48,7 @@ class TestMathEquationComponent:
         active: true
         equations:
           - where: "True"
-            expression: something == $sub_bar
+            expression: something = $sub_bar
         sub_expressions:
           bar:
             - where: "True"


### PR DESCRIPTION
Fixes #818

## Summary of changes in this pull request

This PR completes the standardisation of where / expression strings into their respective domains

* mathematical operations ("equations") now use `=`, `<=` and `>=` operators
* logical operations ("where" strings) use `==`

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [x] Changelog updated
- [x] Coverage maintained or improved