### PR TITLE
Add hook to clean notebook pages in docs search index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.0.dev8 (TBD)
+
+### User-facing changes
+
+|fixed| Example notebook outputs no longer clutter search results in docs and search result example notebook pages are grouped under the top-level page header (#675).
+
 ## 0.7.0.dev7 (2025-09-05)
 
 ### User-facing changes

--- a/docs/hooks/clean_search.py
+++ b/docs/hooks/clean_search.py
@@ -1,0 +1,33 @@
+# Copyright (C) since 2013 Calliope contributors listed in AUTHORS.
+# Licensed under the Apache 2.0 License (see LICENSE file).
+"""Clean up rendered notebook entries in mkdocs search index."""
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger("mkdocs")
+
+
+def on_post_build(config: dict):
+    """Hook to run after the build process."""
+    search_file = Path(config["site_dir"]) / "search" / "search_index.json"
+
+    search_data = json.loads(search_file.read_text(encoding="utf-8"))
+    # 1. remove code blocks from search results
+    cleaned_search_data = [
+        i for i in search_data["docs"] if not i["text"].startswith("In\u00a0")
+    ]
+    updated_examples = []
+    for i in cleaned_search_data:
+        # 2. remove header icon (¶) from end of title text in search
+        i["title"] = i["title"].removesuffix("\u00b6")
+        # 3. remove cross-ref (#i-am-a-cross-ref) from the first search result of each rendered notebook page so that it acts the same as top-level headers in .md files in search results.
+        if (
+            i["location"].startswith("examples/")
+            and (example := i["location"].split("/")[1]) not in updated_examples
+        ):
+            i["location"] = f"examples/{example}/"
+            updated_examples.append(example)
+    search_data["docs"] = cleaned_search_data
+    search_file.write_text(json.dumps(search_data), encoding="utf-8")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ hooks:
   - docs/hooks/generate_math_docs.py
   - docs/hooks/generate_plots.py
   - docs/hooks/add_notebooks.py
+  - docs/hooks/clean_search.py
 extra:
   min_python_version: "3.10"
   max_python_version: "3.12"


### PR DESCRIPTION
Fixes #675 

Mkdocs creates a search index JSON file which is what is used to fill the search results. I've gone to this source and removed/edited the notebook entries since they follow a similar pattern.

## Code block removal

It's far from perfect since search results for entire code blocks (inputs and outputs) are lost as they are the same entry in the search index. However, it does keep the markdown parts of the notebooks, which is probably sufficient for useful search functionality.

## Search grouping

I've also cleaned up how the search results are presented for rendered notebooks. For standard `.md` files, results are grouped under the top-level header. This wasn't the case for rendered notebooks as mkdocs doesn't seem to be able to understand that there is a top-level header. I've just said that the first header is the top-level one and updated the search index entries accordingly.

### before

<img width="1407" height="819" alt="image" src="https://github.com/user-attachments/assets/242e53d7-3896-4f04-b7da-53293a7b0aa2" />

### after

<img width="1407" height="708" alt="image" src="https://github.com/user-attachments/assets/3987fde3-c6de-4c28-a367-5227e6fc4afb" />

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved