### PR TITLE
Remove _reentry; add runtime entries for timeseries agg/math updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.7.0.dev8
+
+### User-facing changes
+
+|fixed| Reloading a clustered model from file was attempting to re-cluster (#824).
+
+|changed| Init config can be updated on re-init _and_ on loading a model from NetCDF, e.g. to apply new subsetting, resampling, clustering, math.
+
 ## 0.7.0.dev7 (2025-09-05)
 
 ### User-facing changes

--- a/src/calliope/preprocess/__init__.py
+++ b/src/calliope/preprocess/__init__.py
@@ -1,6 +1,5 @@
 """Preprocessing module."""
 
 from calliope.preprocess.data_tables import DataTable
-from calliope.preprocess.model_data import ModelDataFactory
 from calliope.preprocess.model_definition import prepare_model_definition
 from calliope.preprocess.model_math import build_math, initialise_math

--- a/src/calliope/preprocess/model_data.py
+++ b/src/calliope/preprocess/model_data.py
@@ -2,8 +2,10 @@
 # Licensed under the Apache 2.0 License (see LICENSE file).
 """Model data processing functionality."""
 
+import functools
 import itertools
 import logging
+from abc import ABC
 from collections.abc import Hashable, Mapping
 from copy import deepcopy
 from pathlib import Path
@@ -16,14 +18,83 @@ from typing_extensions import NotRequired, TypedDict
 
 from calliope import exceptions
 from calliope.attrdict import AttrDict
-from calliope.preprocess import data_tables, model_math, time
-from calliope.schemas import config_schema, dimension_data_schema, math_schema
+from calliope.preprocess import data_tables, time
+from calliope.schemas import (
+    config_schema,
+    dimension_data_schema,
+    math_schema,
+    runtime_attrs_schema,
+)
 from calliope.util import DATETIME_DTYPE, DTYPE_OPTIONS
 from calliope.util.tools import listify
 
 LOGGER = logging.getLogger(__name__)
 
 DATA_T = float | int | bool | str | None | list[float | int | bool | str | None]
+
+
+class ModelDTypeUpdater(ABC):
+    """Model data production class."""
+
+    config: config_schema.Init
+    math: math_schema.CalliopeBuildMath
+
+    def _update_dtypes(
+        self, ds: Mapping[Hashable, "xr.DataArray"], id_: str = ""
+    ) -> Mapping[Hashable, "xr.DataArray"]:
+        """Update data types of coordinates or data variables in the dataset.
+
+        Args:
+            ds (xr.Dataset): Dataset to update.
+            math (math_schema.CalliopeBuildMath): Model math definition.
+            id_ (str, optional): ID of the dataset being updated, for logging purposes. Defaults to an empty string.
+
+        Raises:
+            exceptions.ModelError: If there is a mismatch between the provided variable and its definition in the model math.
+
+        Returns:
+            xr.Dataset: `ds` with data types updated.
+        """
+        prefix = f"{id_} | " if id_ else ""
+        for var_name, var_data in ds.items():
+            try:
+                src, math_def = self.math.find(
+                    var_name, subset=["lookups", "parameters", "dimensions"]
+                )
+            except KeyError:
+                LOGGER.info(
+                    f"{prefix}input data `{var_name}` not defined in model math; "
+                    "it will not be available in the optimisation problem."
+                )
+                continue
+
+            dtype_str = math_def.dtype  # type: ignore
+            dtype = DTYPE_OPTIONS[dtype_str]
+            LOGGER.debug(
+                f"{prefix}{src} | Updating values of `{var_name}` to {dtype_str} type"
+            )
+            match dtype_str:
+                case "string":
+                    updated_var = var_data.astype(dtype).where(var_data.notnull())
+                case "datetime":
+                    updated_var = time._datetime_index(
+                        var_data.to_series(), self.config.datetime_format
+                    ).to_xarray()
+                case "date":
+                    updated_var = (
+                        time._datetime_index(
+                            var_data.to_series(), self.config.date_format
+                        )
+                        .to_xarray()
+                        .assign_attrs(var_data.attrs)
+                    )
+                case "bool":
+                    updated_var = var_data.fillna(False).astype(dtype)
+                case _:
+                    updated_var = var_data.astype(dtype)
+
+            ds[var_name] = updated_var
+        return ds
 
 
 class ValidatedInput(TypedDict):
@@ -50,28 +121,14 @@ class ModelDefinition(TypedDict):
 LOGGER = logging.getLogger(__name__)
 
 
-class ModelDataFactory:
-    """Model data production class."""
-
-    # Output of: sns.color_palette('cubehelix', 10).as_hex()
-    _DEFAULT_PALETTE = [
-        "#19122b",
-        "#17344c",
-        "#185b48",
-        "#3c7632",
-        "#7e7a36",
-        "#bc7967",
-        "#d486af",
-        "#caa9e7",
-        "#c2d2f3",
-        "#d6f0ef",
-    ]
+class ModelDataBuilder(ModelDTypeUpdater):
+    """Model data builder class."""
 
     def __init__(
         self,
         init_config: config_schema.Init,
-        model_definition: AttrDict | xr.Dataset,
-        math: math_schema.CalliopeInputMath,
+        model_definition: AttrDict,
+        math: math_schema.CalliopeBuildMath,
         definition_path: str | Path | None = None,
         data_table_dfs: dict[str, pd.DataFrame] | None = None,
     ):
@@ -82,55 +139,28 @@ class ModelDataFactory:
         Args:
             init_config (config_schema.Init): Model initialisation configuration (i.e., `config`).
             model_definition (ModelDefinition): Definition of model input data.
-            math (math_schema.CalliopeInputMath): Math schema to apply to the model.
+            math (math_schema.CalliopeBuildMath): Math to apply to the model.
             definition_path (Path, None): Path to the main model definition file. Defaults to None.
             data_table_dfs: (dict[str, pd.DataFrame], None): Dataframes with model data. Defaults to None.
-            attributes (dict): Attributes to attach to the model Dataset.
         """
-        self.config: config_schema.Init = init_config
-        math_priority = model_math.get_math_priority(self.config)
-        self.math = model_math.build_math(
-            math_priority,
-            math.model_dump(),
-            validate=init_config.pre_validate_math_strings,
-        )
+        self.config = init_config
         self.tech_data_from_tables = AttrDict()
-
-        if isinstance(model_definition, dict):
-            self.model_definition: ModelDefinition = model_definition.copy()
-            self.dataset = xr.Dataset()
-            tables = []
-            for table, table_dict in model_definition.get("data_tables", {}).items():
-                tables.append(
-                    data_tables.DataTable(
-                        table, table_dict, data_table_dfs, definition_path
-                    )
+        self.math = math
+        self.model_definition: ModelDefinition = model_definition.copy()
+        self.dataset = xr.Dataset()
+        tables = []
+        for table, table_dict in model_definition.get("data_tables", {}).items():
+            tables.append(
+                data_tables.DataTable(
+                    table, table_dict, data_table_dfs, definition_path
                 )
-            self.init_from_data_tables(tables)
-
-        elif isinstance(model_definition, xr.Dataset):
-            self.model_definition: ModelDefinition = AttrDict()
-            self.dataset = model_definition.copy()
+            )
+        self.init_from_data_tables(tables)
 
     def build(self):
         """Build dataset from model definition."""
         self.add_node_tech_data()
         self.add_top_level_data_definitions()
-
-    def clean(self):
-        """Clean built dataset."""
-        # If input dataset is empty, stop here.
-        if not self.dataset:
-            return None
-        self.clean_data_from_undefined_members()
-        self.add_colors()
-        self.add_link_distances()
-        self.update_and_resample_dimensions()
-        self.assign_input_attr()
-        self.dataset = self.dataset.assign_coords(
-            self._update_dtypes(self.dataset.coords)
-        )
-        self.dataset = self._update_dtypes(self.dataset)
 
     def init_from_data_tables(self, data_tables: list[data_tables.DataTable]):
         """Initialise the model definition and dataset using data loaded from file / in-memory objects.
@@ -258,142 +288,6 @@ class ModelDataFactory:
                 )
 
             self._add_to_dataset(input_ds, f"(Model inputs, {name})")
-
-    def update_and_resample_dimensions(self):
-        """If resampling/clustering is requested in the initialisation config, apply it here."""
-        if not any(
-            dim.dtype.kind == DATETIME_DTYPE for dim in self.dataset.coords.values()
-        ):
-            raise exceptions.ModelError(
-                "Must define at least one timeseries data input in a Calliope model."
-            )
-        self._subset_dims()
-        self._resample_dims()
-
-        self.dataset = time.add_inferred_time_params(self.dataset)
-
-        if self.config.time_cluster is not None:
-            self.dataset = time.cluster(
-                self.dataset, self.config.time_cluster, self.config.datetime_format
-            )
-
-    def clean_data_from_undefined_members(self):
-        """Generate the `definition_matrix` array and remove undefined members.
-
-        Members stripped:
-        - Any dimension items that are NaN in all arrays.
-        - Any arrays that are NaN in all index positions.
-        """
-        ds = self._update_dtypes(self.dataset)
-        def_matrix = ds.carrier_in | ds.carrier_out
-        # NaNing values where they are irrelevant requires definition_matrix to be boolean
-        for var_name, var_data in ds.data_vars.items():
-            non_dims = set(def_matrix.dims).difference(var_data.dims)
-            var_updated = var_data.where(def_matrix.any(non_dims))
-            ds[var_name] = (
-                var_updated
-                if var_data.dtype.kind != "b"
-                else var_updated.fillna(False).astype(bool)
-            )
-        # dropping index values where they are irrelevant requires definition_matrix to be NaN where False
-        ds["definition_matrix"] = def_matrix.where(def_matrix)
-
-        for dim in def_matrix.dims:
-            orig_dim_vals = set(ds.coords[dim].data)
-            ds = ds.dropna(dim, how="all", subset=["definition_matrix"])
-            deleted_dim_vals = orig_dim_vals.difference(set(ds.coords[dim].data))
-            if deleted_dim_vals:
-                LOGGER.debug(
-                    f"Deleting {dim} values as they are not defined anywhere in the model: {deleted_dim_vals}"
-                )
-
-        # The boolean version of definition_matrix is what we keep
-        ds["definition_matrix"] = def_matrix
-
-        vars_to_delete = [
-            var_name for var_name, var in ds.data_vars.items() if var.isnull().all()
-        ]
-        if vars_to_delete:
-            LOGGER.debug(f"Deleting empty input data: {vars_to_delete}")
-        self.dataset = ds.drop_vars(vars_to_delete)
-
-    def add_link_distances(self):
-        """If latitude/longitude are provided but distances between nodes have not been computed, compute them now.
-
-        The schema will have already handled the fact that if one of lat/lon is provided, the other must also be provided.
-        """
-        # If no distance was given, we calculate it from coordinates
-        if (
-            "latitude" in self.dataset.data_vars
-            and "longitude" in self.dataset.data_vars
-        ):
-            geod = geodesic.Geodesic.WGS84
-            distances = {}
-            for tech in self.dataset.techs:
-                if self.dataset.base_tech.sel(techs=tech).item() != "transmission":
-                    continue
-                tech_def = self.dataset.definition_matrix.sel(techs=tech).any(
-                    "carriers"
-                )
-                node1, node2 = tech_def.where(tech_def).dropna("nodes").nodes.values
-                distances[tech.item()] = geod.Inverse(
-                    self.dataset.latitude.sel(nodes=node1).item(),
-                    self.dataset.longitude.sel(nodes=node1).item(),
-                    self.dataset.latitude.sel(nodes=node2).item(),
-                    self.dataset.longitude.sel(nodes=node2).item(),
-                )["s12"]
-            distance_array = pd.Series(distances).rename_axis(index="techs").to_xarray()
-            if self.config.distance_unit == "km":
-                distance_array /= 1000
-        else:
-            LOGGER.debug(
-                "Link distances will not be computed automatically since lat/lon coordinates are not defined."
-            )
-            return None
-
-        if "distance" not in self.dataset.data_vars:
-            self.dataset["distance"] = distance_array
-            LOGGER.debug(
-                "Link distance matrix automatically computed from lat/lon coordinates."
-            )
-        else:
-            self.dataset["distance"] = self.dataset["distance"].fillna(distance_array)
-            LOGGER.debug(
-                "Any missing link distances automatically computed from lat/lon coordinates."
-            )
-
-    def add_colors(self):
-        """If technology colours have not been provided / only partially provided, generate a sequence of colors to fill the gap.
-
-        This is a convenience function for downstream plotting.
-        Since we have removed core plotting components from Calliope, it is not a strictly necessary preprocessing step.
-        """
-        techs = self.dataset.techs
-        color_array = self.dataset.get("color")
-        default_palette_cycler = itertools.cycle(range(len(self._DEFAULT_PALETTE)))
-        new_color_array = xr.DataArray(
-            [self._DEFAULT_PALETTE[next(default_palette_cycler)] for tech in techs],
-            coords={"techs": techs},
-        )
-        if color_array is None:
-            LOGGER.debug("Building technology color array from default palette.")
-            self.dataset["color"] = new_color_array
-        elif color_array.isnull().any():
-            LOGGER.debug(
-                "Filling missing technology color array values from default palette."
-            )
-            self.dataset["color"] = self.dataset["color"].fillna(new_color_array)
-
-    def assign_input_attr(self):
-        """Assign metadata as attributes to each input array."""
-        all_attrs = {
-            **self.math.parameters.model_dump(),
-            **self.math.lookups.model_dump(),
-        }
-        for var_name, var_data in self.dataset.data_vars.items():
-            self.dataset[var_name] = var_data.assign_attrs(all_attrs.get(var_name, {}))
-            # Remove this redundant attribute
-            self.dataset[var_name].attrs.pop("active", None)
 
     def _get_relevant_node_refs(self, techs_dict: AttrDict, node: str) -> list[str]:
         """Get all references to input data made in technologies at nodes.
@@ -733,62 +627,247 @@ class ModelDataFactory:
         )  # cannot import carriers at the `link_from` node
         node_to_data.pop("carrier_in")  # cannot export carrier at the `link_to` node
 
-    def _update_dtypes(
-        self, ds: Mapping[Hashable, "xr.DataArray"], id_: str = ""
-    ) -> Mapping[Hashable, "xr.DataArray"]:
-        """Update data types of coordinates or data variables in the dataset.
+    def _raise_error_on_transmission_tech_def(
+        self, tech_def_dict: AttrDict, node_name: str
+    ):
+        """Do not allow any transmission techs to be defined in the node-level tech dict.
 
         Args:
-            ds (xr.Dataset): Dataset to update.
-            to_update (Literal["coords", "data_vars"]): Which part of the dataset to update.
-            id_ (str, optional): ID of the dataset being updated, for logging purposes. Defaults to an empty string.
+            tech_def_dict (dict): Tech definition dict (after full inheritance) at a node.
+            node_name (str): Node name.
 
         Raises:
-            exceptions.ModelError: If there is a mismatch between the provided variable and its definition in the model math.
+            exceptions.ModelError: Raise if any defined techs have the `transmission` base_tech.
+        """
+        transmission_techs = [
+            k
+            for k, v in tech_def_dict.items()
+            if v.get("base_tech", "") == "transmission"
+        ]
+
+        if transmission_techs:
+            raise exceptions.ModelError(
+                f"(nodes, {node_name}) | Transmission techs cannot be directly defined at nodes; "
+                f"they will be automatically assigned to nodes based on `link_to` and `link_from` for: {transmission_techs}."
+            )
+
+
+class ModelDataCleaner(ModelDTypeUpdater):
+    """Model data cleaning class."""
+
+    # Output of: sns.color_palette('cubehelix', 10).as_hex()
+    _DEFAULT_PALETTE = [
+        "#19122b",
+        "#17344c",
+        "#185b48",
+        "#3c7632",
+        "#7e7a36",
+        "#bc7967",
+        "#d486af",
+        "#caa9e7",
+        "#c2d2f3",
+        "#d6f0ef",
+    ]
+
+    def __init__(
+        self,
+        init_config: config_schema.Init,
+        dataset: xr.Dataset,
+        math: math_schema.CalliopeBuildMath,
+        runtime: runtime_attrs_schema.CalliopeRuntime,
+    ):
+        """Take a Calliope model definition dictionary and convert it into an xarray Dataset, ready for constraint generation.
+
+        This includes resampling/clustering timeseries data as necessary.
+
+        Args:
+            init_config (config_schema.Init): Model initialisation configuration (i.e., `config`).
+            dataset (xr.Dataset): Dataset containing model input data.
+            math (math_schema.CalliopeInputMath): Math schema to apply to the model.
+            runtime (runtime_attrs_schema.CalliopeRuntime): Runtime attributes of the model.
+        """
+        self.config = init_config
+        self.math = math
+        self.dataset = dataset.copy()
+        self.runtime = runtime
+
+    def clean_data_from_undefined_members(self):
+        """Generate the `definition_matrix` array and remove undefined members.
+
+        Members stripped:
+        - Any dimension items that are NaN in all arrays.
+        - Any arrays that are NaN in all index positions.
+        """
+        ds = self._update_dtypes(self.dataset)
+        def_matrix = ds.carrier_in | ds.carrier_out
+        # NaNing values where they are irrelevant requires definition_matrix to be boolean
+        for var_name, var_data in ds.data_vars.items():
+            non_dims = set(def_matrix.dims).difference(var_data.dims)
+            var_updated = var_data.where(def_matrix.any(non_dims))
+            ds[var_name] = (
+                var_updated
+                if var_data.dtype.kind != "b"
+                else var_updated.fillna(False).astype(bool)
+            )
+        # dropping index values where they are irrelevant requires definition_matrix to be NaN where False
+        self.dataset = self._drop_undefined(ds, def_matrix)
+
+    def add_colors(self):
+        """If technology colours have not been provided / only partially provided, generate a sequence of colors to fill the gap.
+
+        This is a convenience function for downstream plotting.
+        Since we have removed core plotting components from Calliope, it is not a strictly necessary preprocessing step.
+        """
+        techs = self.dataset.techs
+        color_array = self.dataset.get("color")
+        default_palette_cycler = itertools.cycle(range(len(self._DEFAULT_PALETTE)))
+        new_color_array = xr.DataArray(
+            [self._DEFAULT_PALETTE[next(default_palette_cycler)] for tech in techs],
+            coords={"techs": techs},
+        )
+        if color_array is None:
+            LOGGER.debug("Building technology color array from default palette.")
+            self.dataset["color"] = new_color_array
+        elif color_array.isnull().any():
+            LOGGER.debug(
+                "Filling missing technology color array values from default palette."
+            )
+            self.dataset["color"] = self.dataset["color"].fillna(new_color_array)
+
+    def add_link_distances(self):
+        """If latitude/longitude are provided but distances between nodes have not been computed, compute them now.
+
+        The schema will have already handled the fact that if one of lat/lon is provided, the other must also be provided.
+        """
+        # If no distance was given, we calculate it from coordinates
+        if (
+            "latitude" in self.dataset.data_vars
+            and "longitude" in self.dataset.data_vars
+            and (self.dataset.base_tech == "transmission").any()
+        ):
+            distances = {}
+            for tech in self.dataset.techs:
+                if self.dataset.base_tech.sel(techs=tech).item() != "transmission":
+                    continue
+                tech_def = self.dataset.definition_matrix.sel(techs=tech).any(
+                    "carriers"
+                )
+                node1, node2 = tech_def.where(tech_def).dropna("nodes").nodes.values
+                distances[tech.item()] = self._get_distance(node1, node2)
+            distance_array = pd.Series(distances).rename_axis(index="techs").to_xarray()
+            if self.config.distance_unit == "km":
+                distance_array /= 1000
+        else:
+            LOGGER.debug(
+                "Link distances will not be computed automatically since lat/lon coordinates are not defined."
+            )
+            return None
+
+        if "distance" not in self.dataset.data_vars:
+            self.dataset["distance"] = distance_array
+            LOGGER.debug(
+                "Link distance matrix automatically computed from lat/lon coordinates."
+            )
+        else:
+            self.dataset["distance"] = self.dataset["distance"].fillna(distance_array)
+            LOGGER.debug(
+                "Any missing link distances automatically computed from lat/lon coordinates."
+            )
+
+    def update_and_resample_dimensions(self):
+        """If resampling/clustering is requested in the initialisation config, apply it here."""
+        if not any(
+            dim.dtype.kind == DATETIME_DTYPE for dim in self.dataset.coords.values()
+        ):
+            raise exceptions.ModelError(
+                "Must define at least one timeseries data input in a Calliope model."
+            )
+        runtime_updater = {}
+        if self.config.subset != self.runtime.subset:
+            self._subset_dims()
+            runtime_updater["subset"] = self.config.subset.model_dump()
+        if self.config.resample != self.runtime.resample:
+            self._resample_dims()
+            runtime_updater["resample"] = self.config.resample.model_dump()
+
+        if not self.runtime.instantiated:
+            self.dataset = time.add_inferred_time_params(self.dataset)
+
+        if self.runtime.time_cluster is None and self.config.time_cluster is not None:
+            self.dataset = time.cluster(
+                self.dataset, self.config.time_cluster, self.config.datetime_format
+            )
+            runtime_updater["time_cluster"] = self.config.time_cluster
+        elif self.config.time_cluster != self.runtime.time_cluster:
+            raise exceptions.ModelError(
+                "Cannot change time clustering configuration at this stage."
+            )
+        self.runtime = self.runtime.update(runtime_updater)
+
+    def assign_input_attr(self):
+        """Assign metadata as attributes to each input array."""
+        all_attrs = {
+            **self.math.parameters.model_dump(),
+            **self.math.lookups.model_dump(),
+        }
+        for var_name, var_data in self.dataset.data_vars.items():
+            self.dataset[var_name] = var_data.assign_attrs(all_attrs.get(var_name, {}))
+            # Remove this redundant attribute
+            self.dataset[var_name].attrs.pop("active", None)
+
+    @staticmethod
+    def _drop_undefined(ds: xr.Dataset, def_matrix: xr.DataArray) -> xr.Dataset:
+        """Drop undefined members from a dataset.
+
+        Members dropped:
+        - Any dimension items that are NaN in all arrays.
+        - Any arrays that are NaN in all index positions.
+
+        Args:
+            ds (xr.Dataset): Dataset to drop undefined members from.
+            def_matrix (xr.DataArray): Definition matrix to use to identify undefined members.
 
         Returns:
-            xr.Dataset: `ds` with data types updated.
+            xr.Dataset: Input `ds` with undefined members dropped.
         """
-        prefix = f"{id_} | " if id_ else ""
-        for var_name, var_data in ds.items():
-            try:
-                src, math_def = self.math.find(
-                    var_name, subset=["lookups", "parameters", "dimensions"]
+        ds["definition_matrix"] = def_matrix.where(def_matrix)
+        for dim in def_matrix.dims:
+            orig_dim_vals = set(ds.coords[dim].data)
+            ds = ds.dropna(dim, how="all", subset=["definition_matrix"])
+            deleted_dim_vals = orig_dim_vals.difference(set(ds.coords[dim].data))
+            if deleted_dim_vals:
+                LOGGER.debug(
+                    f"Deleting {dim} values as they are not defined anywhere in the model: {deleted_dim_vals}"
                 )
-            except KeyError:
-                LOGGER.info(
-                    f"{prefix}input data `{var_name}` not defined in model math; "
-                    "it will not be available in the optimisation problem."
-                )
-                continue
 
-            dtype_str = math_def.dtype  # type: ignore
-            dtype = DTYPE_OPTIONS[dtype_str]
-            LOGGER.debug(
-                f"{prefix}{src} | Updating values of `{var_name}` to {dtype_str} type"
-            )
-            match dtype_str:
-                case "string":
-                    updated_var = var_data.astype(dtype).where(var_data.notnull())
-                case "datetime":
-                    updated_var = time._datetime_index(
-                        var_data.to_series(), self.config.datetime_format
-                    ).to_xarray()
-                case "date":
-                    updated_var = (
-                        time._datetime_index(
-                            var_data.to_series(), self.config.date_format
-                        )
-                        .to_xarray()
-                        .assign_attrs(var_data.attrs)
-                    )
-                case "bool":
-                    updated_var = var_data.fillna(False).astype(dtype)
-                case _:
-                    updated_var = var_data.astype(dtype)
+        # The boolean version of definition_matrix is what we keep
+        ds["definition_matrix"] = def_matrix
 
-            ds[var_name] = updated_var
-        return ds
+        vars_to_delete = [
+            var_name for var_name, var in ds.data_vars.items() if var.isnull().all()
+        ]
+        if vars_to_delete:
+            LOGGER.debug(f"Deleting empty input data: {vars_to_delete}")
+        return ds.drop_vars(vars_to_delete)
+
+    @functools.cache
+    def _get_distance(self, node1: str, node2: str) -> float:
+        """Get and cache the distance between two nodes.
+
+        Args:
+            node1 (str): The first node.
+            node2 (str): The second node.
+
+        Returns:
+            float: The geodesic distance between the two nodes.
+        """
+        geod = geodesic.Geodesic.WGS84
+        return geod.Inverse(
+            self.dataset.latitude.sel(nodes=node1).item(),
+            self.dataset.longitude.sel(nodes=node1).item(),
+            self.dataset.latitude.sel(nodes=node2).item(),
+            self.dataset.longitude.sel(nodes=node2).item(),
+        )["s12"]
 
     def _subset_dims(self):
         """Subset all timeseries dimensions according to an input slice of start and end times.
@@ -818,7 +897,22 @@ class ModelDataFactory:
             else:
                 selectors[dim_name] = subset
 
-        self.dataset = self.dataset.sel(**selectors)
+        subset_dataset = self.dataset.sel(**selectors)
+
+        # Drop any transmission links that are now hanging (i.e., only connected to one node)
+        hanging_links = (
+            subset_dataset.definition_matrix.sel(
+                techs=subset_dataset.base_tech == "transmission"
+            )
+            .sum("nodes")
+            .where(lambda x: x == 1, drop=True)
+            .techs
+        )
+        subset_dataset = subset_dataset.drop_sel(techs=hanging_links)
+
+        self.dataset = self._drop_undefined(
+            subset_dataset, subset_dataset.definition_matrix
+        )
 
     def _resample_dims(self):
         ds = self.dataset
@@ -835,26 +929,15 @@ class ModelDataFactory:
             ds = time.resample(ds, self.math, dim_name, resampler)
         self.dataset = ds
 
-    def _raise_error_on_transmission_tech_def(
-        self, tech_def_dict: AttrDict, node_name: str
-    ):
-        """Do not allow any transmission techs to be defined in the node-level tech dict.
-
-        Args:
-            tech_def_dict (dict): Tech definition dict (after full inheritance) at a node.
-            node_name (str): Node name.
-
-        Raises:
-            exceptions.ModelError: Raise if any defined techs have the `transmission` base_tech.
-        """
-        transmission_techs = [
-            k
-            for k, v in tech_def_dict.items()
-            if v.get("base_tech", "") == "transmission"
-        ]
-
-        if transmission_techs:
-            raise exceptions.ModelError(
-                f"(nodes, {node_name}) | Transmission techs cannot be directly defined at nodes; "
-                f"they will be automatically assigned to nodes based on `link_to` and `link_from` for: {transmission_techs}."
-            )
+    def clean(self):
+        """Clean built dataset."""
+        # If input dataset is empty, stop here.
+        self.clean_data_from_undefined_members()
+        self.add_colors()
+        self.add_link_distances()
+        self.update_and_resample_dimensions()
+        self.assign_input_attr()
+        self.dataset = self.dataset.assign_coords(
+            self._update_dtypes(self.dataset.coords)
+        )
+        self.dataset = self._update_dtypes(self.dataset)

--- a/src/calliope/preprocess/time.py
+++ b/src/calliope/preprocess/time.py
@@ -103,7 +103,12 @@ def resample(
 
     for var_name, var_data in data_ts.data_vars.items():
         resampler = var_data.resample(**resample_kwargs)
-        var_math = math.find(var_name, subset=["parameters", "lookups"])[1]
+        try:
+            var_math = math.find(var_name, subset=["parameters", "lookups"])[1]
+        except KeyError as e:
+            raise exceptions.ModelError(
+                f"No resampling method defined in math configuration for timeseries input data `{var_name}`."
+            ) from e
         resample_method = var_math["resample_method"]
 
         if resample_method == "sum":

--- a/src/calliope/schemas/runtime_attrs_schema.py
+++ b/src/calliope/schemas/runtime_attrs_schema.py
@@ -5,7 +5,8 @@
 from pydantic import Field
 
 from calliope import _version
-from calliope.schemas.general import CalliopeBaseModel
+from calliope.schemas.config_schema import Resamples, Subsets
+from calliope.schemas.general import AttrStr, CalliopeBaseModel
 
 
 class CalliopeRuntime(CalliopeBaseModel):
@@ -27,3 +28,18 @@ class CalliopeRuntime(CalliopeBaseModel):
 
     termination_condition: str | None = None
     """Indicates whether the optimisation problem solved to optimality (`optimal`) or not (e.g. `unbounded`, `infeasible`)."""
+
+    instantiated: bool = False
+    """Indicates whether the model has been instantiated."""
+
+    subset: Subsets = Subsets()
+    """List all applied subsets."""
+
+    resample: Resamples = Resamples()
+    """List all applied resamples."""
+
+    time_cluster: AttrStr | None = None
+    """Indicates the time clustering applied to the model."""
+
+    math_priority: list[AttrStr] = Field(default_factory=list)
+    """The order of math entries applied to the model, with each subsequent one overwriting the last."""

--- a/tests/test_backend_pyomo.py
+++ b/tests/test_backend_pyomo.py
@@ -2016,7 +2016,7 @@ class TestVerboseStrings:
             )
             .item()
             .name
-            == "variables[flow_out][4]"
+            == "variables[flow_out][8]"
         )
         assert not simple_supply.backend.variables.flow_out.coords_in_name
 

--- a/tests/test_preprocess_model_data.py
+++ b/tests/test_preprocess_model_data.py
@@ -6,8 +6,8 @@ import pytest
 import xarray as xr
 
 from calliope import AttrDict, exceptions, io
-from calliope.preprocess import prepare_model_definition
-from calliope.preprocess.model_data import ModelDataFactory
+from calliope.preprocess import model_math, prepare_model_definition
+from calliope.preprocess.model_data import ModelDataBuilder, ModelDataCleaner
 from calliope.util import DATETIME_DTYPE
 
 from .common.util import build_test_model as build_model
@@ -20,34 +20,101 @@ def model_def(minimal_test_model_path):
         io.read_rich_yaml(minimal_test_model_path),
         scenario="simple_supply,empty_tech_node",
         definition_path=minimal_test_model_path,
-        pre_validate_math_strings=False,
     )
-    # Erase data tables for simplicity
-    # FIXME: previous tests omitted this. Either update tests or remove the data_table from the test model.
-    model_def_override.definition.data_tables.root = {}
     return model_def_override
 
 
 @pytest.fixture(scope="class")
-def init_config(default_config, model_def):
+def model_def_no_ts(model_def):
+    # Erase data tables for simplicity
+    # FIXME: previous tests omitted this. Either update tests or remove the data_table from the test model.
+    model_def.definition.data_tables.root = {}
+    return model_def
+
+
+@pytest.fixture(scope="class")
+def math_priority(model_def):
+    return model_math.get_math_priority(model_def.config.init)
+
+
+@pytest.fixture(scope="class")
+def math(model_def, math_priority):
+    math = model_math.build_math(
+        math_priority,
+        model_def.math.init.model_dump(),
+        validate=model_def.config.init.pre_validate_math_strings,
+    )
+    return math
+
+
+@pytest.fixture(scope="class")
+def config(default_config, model_def):
     updated_config = default_config.update(model_def.config.model_dump())
-    return updated_config.init
+    return updated_config
+
+
+@pytest.fixture(scope="class")
+def simple_da():
+    data = {("foo", 1): [True, 10], ("foo", 2): [False, 20], ("bar", 1): [True, 30]}
+    da = pd.Series(data).rename_axis(index=["foobar", "foobaz"]).to_xarray()
+    return da
+
+
+@pytest.fixture(scope="class")
+def timeseries_da():
+    data = {
+        ("2005-01-01 00:00", "bar"): [True, 10],
+        ("2005-01-01 01:00", "bar"): [False, 20],
+    }
+    da = pd.Series(data).rename_axis(index=["timesteps", "foobaz"]).to_xarray()
+    da.coords["timesteps"] = da.coords["timesteps"].astype("M")
+    return da
 
 
 @pytest.fixture
-def model_data_factory(minimal_test_model_path, model_def, init_config):
-    return ModelDataFactory(
-        init_config,
-        AttrDict(model_def.definition.model_dump(exclude_defaults=True)),
-        model_def.math.init,
+def model_data_builder(minimal_test_model_path, model_def_no_ts, config, math):
+    return ModelDataBuilder(
+        config.init,
+        AttrDict(model_def_no_ts.definition.model_dump(exclude_defaults=True)),
+        math,
         minimal_test_model_path,
     )
 
 
 @pytest.fixture
-def model_data_factory_w_params(model_data_factory: ModelDataFactory):
-    model_data_factory.add_node_tech_data()
-    return model_data_factory
+def model_data_builder_w_params(model_data_builder: ModelDataBuilder):
+    model_data_builder.add_node_tech_data()
+    return model_data_builder
+
+
+@pytest.fixture(scope="class")
+def model_data_builder_built_data(config, model_def, math, minimal_test_model_path):
+    builder = ModelDataBuilder(
+        config.init,
+        AttrDict(model_def.definition.model_dump(exclude_defaults=True)),
+        math,
+        minimal_test_model_path,
+    )
+    builder.build()
+    return builder.dataset
+
+
+@pytest.fixture
+def model_data_cleaner(
+    model_data_builder_built_data, config, model_def, math, math_priority
+):
+    return ModelDataCleaner(
+        config.init,
+        model_data_builder_built_data,
+        math,
+        model_def.runtime.update({"math_priority": math_priority}),
+    )
+
+
+@pytest.fixture
+def model_data_cleaner_with_def_matrix(model_data_cleaner):
+    model_data_cleaner.clean_data_from_undefined_members()
+    return model_data_cleaner
 
 
 @pytest.fixture
@@ -56,57 +123,21 @@ def my_caplog(caplog):
     return caplog
 
 
-@pytest.fixture
-def model_data_factory_with_time(model_data_factory_w_params):
-    time_da = pd.Series(
-        1,
-        index=pd.date_range(
-            "2005-01-01", "2005-01-04 23:59", freq="h", name="timesteps"
-        ),
-    )
-    model_data_factory_w_params._add_to_dataset(
-        time_da.to_xarray().to_dataset(name="time_data"), ""
-    )
-    model_data_factory_w_params.config = model_data_factory_w_params.config.update(
-        {"subset": {"timesteps": None}}
-    )
-    model_data_factory_w_params.math = model_data_factory_w_params.math.update(
-        {"parameters.time_data": {"resample_method": "sum"}}
-    )
-    return model_data_factory_w_params
-
-
 @pytest.mark.filterwarnings("ignore:(?s).*Converting non-nanosecond precision datetime")
-class TestModelData:
-    @pytest.fixture(scope="class")
-    def simple_da(self):
-        data = {("foo", 1): [True, 10], ("foo", 2): [False, 20], ("bar", 1): [True, 30]}
-        da = pd.Series(data).rename_axis(index=["foobar", "foobaz"]).to_xarray()
-        return da
-
-    @pytest.fixture(scope="class")
-    def timeseries_da(self):
-        data = {
-            ("2005-01-01 00:00", "bar"): [True, 10],
-            ("2005-01-01 01:00", "bar"): [False, 20],
-        }
-        da = pd.Series(data).rename_axis(index=["timesteps", "foobaz"]).to_xarray()
-        da.coords["timesteps"] = da.coords["timesteps"].astype("M")
-        return da
-
-    def test_add_node_tech_data(self, model_data_factory_w_params: ModelDataFactory):
-        assert set(model_data_factory_w_params.dataset.nodes.values) == {"a", "b", "c"}
-        assert set(model_data_factory_w_params.dataset.techs.values) == {
+class TestModelDataBuilder:
+    def test_add_node_tech_data(self, model_data_builder_w_params: ModelDataBuilder):
+        assert set(model_data_builder_w_params.dataset.nodes.values) == {"a", "b", "c"}
+        assert set(model_data_builder_w_params.dataset.techs.values) == {
             "test_supply_elec",
             "test_demand_elec",
             "test_link_a_b_elec",
             "test_link_a_b_heat",
         }
-        assert set(model_data_factory_w_params.dataset.carriers.values) == {
+        assert set(model_data_builder_w_params.dataset.carriers.values) == {
             "electricity",
             "heat",
         }
-        assert set(model_data_factory_w_params.dataset.data_vars.keys()) == {
+        assert set(model_data_builder_w_params.dataset.data_vars.keys()) == {
             "distance",
             "name",
             "carrier_out",
@@ -117,189 +148,7 @@ class TestModelData:
             "flow_out_eff",
         }
 
-    def test_update_time_dimension_and_params(
-        self, model_data_factory_w_params: ModelDataFactory, timeseries_da
-    ):
-        model_data_factory_w_params.dataset["timeseries_da"] = timeseries_da
-        model_data_factory_w_params.update_and_resample_dimensions()
-        assert "timestep_resolution" in model_data_factory_w_params.dataset.data_vars
-        assert "timestep_weights" in model_data_factory_w_params.dataset.data_vars
-
-    def test_clean_data_from_undefined_members(
-        self, my_caplog, model_data_factory: ModelDataFactory
-    ):
-        model_data_factory.dataset["carrier_in"] = (
-            pd.Series(
-                {
-                    ("A", "foo", "c1"): True,
-                    ("B", "bar", "c2"): np.nan,
-                    ("C", "foo", "c1"): True,
-                }
-            )
-            .rename_axis(index=["nodes", "techs", "carriers"])
-            .to_xarray()
-        )
-        model_data_factory.dataset["carrier_out"] = (
-            pd.Series(
-                {
-                    ("A", "foo", "c2"): True,
-                    ("B", "bar", "c1"): np.nan,
-                    ("C", "foo", "c2"): True,
-                }
-            )
-            .rename_axis(index=["nodes", "techs", "carriers"])
-            .to_xarray()
-        )
-
-        model_data_factory.dataset["will_remain"] = (
-            pd.Series({"foo": 1, "bar": 2}).rename_axis(index="techs").to_xarray()
-        )
-        model_data_factory.dataset["will_delete"] = (
-            pd.Series({"foo": np.nan, "bar": 2}).rename_axis(index="techs").to_xarray()
-        )
-        model_data_factory.dataset["will_delete_2"] = (
-            pd.Series({("foo", "B"): 2})
-            .rename_axis(index=["techs", "nodes"])
-            .to_xarray()
-        )
-
-        model_data_factory.clean_data_from_undefined_members()
-
-        assert (
-            "Deleting techs values as they are not defined anywhere in the model: {'bar'}"
-            in my_caplog.text
-        )
-        assert (
-            "Deleting nodes values as they are not defined anywhere in the model: {'B'}"
-            in my_caplog.text
-        )
-        assert (
-            "Deleting empty input data: ['will_delete', 'will_delete_2']"
-            in my_caplog.text
-        )
-
-        assert "will_delete" not in model_data_factory.dataset
-        assert "will_delete_2" not in model_data_factory.dataset
-        assert model_data_factory.dataset["will_remain"].item() == 1
-        assert set(model_data_factory.dataset.techs.values) == {"foo"}
-        assert set(model_data_factory.dataset.nodes.values) == {"A", "C"}
-        assert model_data_factory.dataset["definition_matrix"].dtype.kind == "b"
-
-    @pytest.mark.parametrize(
-        ("existing_distance", "expected_distance"), [(np.nan, 343.834), (1, 1)]
-    )
-    def test_add_link_distances_missing_distance(
-        self,
-        my_caplog,
-        model_data_factory_w_params: ModelDataFactory,
-        existing_distance,
-        expected_distance,
-    ):
-        model_data_factory_w_params.clean_data_from_undefined_members()
-        model_data_factory_w_params.dataset["latitude"] = (
-            pd.Series({"a": 51.507222, "b": 48.8567})
-            .rename_axis(index="nodes")
-            .to_xarray()
-        )
-        model_data_factory_w_params.dataset["longitude"] = (
-            pd.Series({"a": -0.1275, "b": 2.3508})
-            .rename_axis(index="nodes")
-            .to_xarray()
-        )
-        model_data_factory_w_params.dataset["distance"] = (
-            pd.Series({"test_link_a_b_elec": existing_distance})
-            .rename_axis(index="techs")
-            .to_xarray()
-        )
-
-        model_data_factory_w_params.add_link_distances()
-        assert "Any missing link distances automatically computed" in my_caplog.text
-        assert model_data_factory_w_params.dataset["distance"].sel(
-            techs="test_link_a_b_elec"
-        ).item() == pytest.approx(expected_distance)
-
-    @pytest.mark.parametrize(("unit", "expected"), [("m", 343834), ("km", 343.834)])
-    def test_add_link_distances_no_da(
-        self, my_caplog, model_data_factory_w_params: ModelDataFactory, unit, expected
-    ):
-        new_config = model_data_factory_w_params.config.update({"distance_unit": unit})
-        model_data_factory_w_params.config = new_config
-        model_data_factory_w_params.clean_data_from_undefined_members()
-        model_data_factory_w_params.dataset["latitude"] = (
-            pd.Series({"A": 51.507222, "B": 48.8567})
-            .rename_axis(index="nodes")
-            .to_xarray()
-        )
-        model_data_factory_w_params.dataset["longitude"] = (
-            pd.Series({"A": -0.1275, "B": 2.3508})
-            .rename_axis(index="nodes")
-            .to_xarray()
-        )
-        del model_data_factory_w_params.dataset["distance"]
-
-        model_data_factory_w_params.add_link_distances()
-        assert "Link distance matrix automatically computed" in my_caplog.text
-        assert (
-            model_data_factory_w_params.dataset["distance"].dropna("techs")
-            == pytest.approx(expected)
-        ).all()
-
-    def test_add_link_distances_no_latlon(
-        self, my_caplog, model_data_factory_w_params: ModelDataFactory
-    ):
-        model_data_factory_w_params.clean_data_from_undefined_members()
-        model_data_factory_w_params.add_link_distances()
-        assert "Link distances will not be computed automatically" in my_caplog.text
-
-    def test_add_colors_no_init_da(
-        self, my_caplog, model_data_factory_w_params: ModelDataFactory
-    ):
-        model_data_factory_w_params.add_colors()
-        assert "Building technology color" in my_caplog.text
-        np.testing.assert_array_equal(
-            model_data_factory_w_params.dataset["color"].values,
-            ["#19122b", "#17344c", "#185b48", "#3c7632"],
-        )
-
-    def test_add_colors_full_init_da(
-        self, my_caplog, model_data_factory_w_params: ModelDataFactory
-    ):
-        model_data_factory_w_params.dataset["color"] = xr.DataArray(
-            ["#123", "#654", "#321", "#456"], dims=("techs",)
-        )
-        color_da_copy = model_data_factory_w_params.dataset["color"].copy()
-        model_data_factory_w_params.add_colors()
-        assert "technology color" not in my_caplog.text
-        assert model_data_factory_w_params.dataset["color"].equals(color_da_copy)
-
-    def test_add_colors_partial_init_da(
-        self, my_caplog, model_data_factory_w_params: ModelDataFactory
-    ):
-        model_data_factory_w_params.dataset["color"] = pd.Series(
-            ["#123", np.nan, "#321", "#456"],
-            index=model_data_factory_w_params.dataset.techs.to_index(),
-        ).to_xarray()
-
-        model_data_factory_w_params.add_colors()
-        assert "Filling missing technology color" in my_caplog.text
-        np.testing.assert_array_equal(
-            model_data_factory_w_params.dataset["color"].values,
-            ["#123", "#17344c", "#321", "#456"],
-        )
-
-    def test_assign_input_attr(
-        self, model_data_factory: ModelDataFactory, simple_da, timeseries_da
-    ):
-        model_data_factory.dataset["storage_cap_max"] = simple_da
-        model_data_factory.dataset["bar"] = timeseries_da
-        assert model_data_factory.dataset.data_vars
-
-        model_data_factory.assign_input_attr()
-
-        assert model_data_factory.dataset["storage_cap_max"].attrs["default"] == np.inf
-        assert "default" not in model_data_factory.dataset["bar"].attrs
-
-    def test_get_relevant_node_refs_ts_data(self, model_data_factory: ModelDataFactory):
+    def test_get_relevant_node_refs_ts_data(self, model_data_builder: ModelDataBuilder):
         techs_dict = AttrDict(
             {
                 "foo": {
@@ -320,11 +169,11 @@ class TestModelData:
                 "bar": None,
             }
         )
-        model_data_factory._get_relevant_node_refs(techs_dict, "A")
+        model_data_builder._get_relevant_node_refs(techs_dict, "A")
         assert techs_dict == expected_tech_dict
 
     def test_get_relevant_node_refs_no_ts_data(
-        self, model_data_factory: ModelDataFactory
+        self, model_data_builder: ModelDataBuilder
     ):
         techs_dict = AttrDict(
             {
@@ -336,17 +185,17 @@ class TestModelData:
                 "bar": None,
             }
         )
-        refs = model_data_factory._get_relevant_node_refs(techs_dict, "A")
+        refs = model_data_builder._get_relevant_node_refs(techs_dict, "A")
         assert set(refs) == set(["key1", "key2", "key3"])
 
     def test_get_relevant_node_refs_parent_at_node_not_supported(
-        self, model_data_factory: ModelDataFactory
+        self, model_data_builder: ModelDataBuilder
     ):
         techs_dict = AttrDict(
             {"bar": {"key1": 1}, "foo": {"base_tech": "foobar"}, "baz": None}
         )
         with pytest.raises(exceptions.ModelError) as excinfo:
-            model_data_factory._get_relevant_node_refs(techs_dict, "A")
+            model_data_builder._get_relevant_node_refs(techs_dict, "A")
 
         assert check_error_or_warning(
             excinfo,
@@ -364,12 +213,12 @@ class TestModelData:
         ],
     )
     def test_param_dict_to_array(
-        self, model_data_factory: ModelDataFactory, param_data, expected_da
+        self, model_data_builder: ModelDataBuilder, param_data, expected_da
     ):
-        da = model_data_factory._input_data_dict_to_array("foo", param_data)
+        da = model_data_builder._input_data_dict_to_array("foo", param_data)
         assert da.equals(expected_da)
 
-    def test_definition_dict_to_ds(self, model_data_factory: ModelDataFactory):
+    def test_definition_dict_to_ds(self, model_data_builder: ModelDataBuilder):
         def_dict = {
             "test_idx": {
                 "foo": 1,
@@ -377,7 +226,7 @@ class TestModelData:
             }
         }
         dim_name = "test_dim"
-        param_ds = model_data_factory._definition_dict_to_ds(def_dict, dim_name)
+        param_ds = model_data_builder._definition_dict_to_ds(def_dict, dim_name)
         expected_ds = xr.Dataset(
             {
                 "foo": pd.Series({"test_idx": 1}).rename_axis(index="test_dim"),
@@ -399,10 +248,10 @@ class TestModelData:
         ],
     )
     def test_prepare_param_dict_indexed_idx(
-        self, model_data_factory: ModelDataFactory, input_idx, expected_idx
+        self, model_data_builder: ModelDataBuilder, input_idx, expected_idx
     ):
         dict_skeleton = {"data": 1, "dims": ["foo"]}
-        output = model_data_factory._prepare_input_data_dict(
+        output = model_data_builder._prepare_input_data_dict(
             "foo", {"index": input_idx, **dict_skeleton}
         )
         assert output == {"index": expected_idx, **dict_skeleton}
@@ -412,99 +261,99 @@ class TestModelData:
         [("foo", ["foo"]), (["foo"], ["foo"]), (["foo", "bar"], ["foo", "bar"])],
     )
     def test_prepare_param_dict_indexed_dim(
-        self, model_data_factory: ModelDataFactory, input_dim, expected_dim
+        self, model_data_builder: ModelDataBuilder, input_dim, expected_dim
     ):
         dict_skeleton = {"data": 1, "index": [["foo"]]}
-        output = model_data_factory._prepare_input_data_dict(
+        output = model_data_builder._prepare_input_data_dict(
             "foo", {"dims": input_dim, **dict_skeleton}
         )
         assert output == {"dims": expected_dim, **dict_skeleton}
 
-    def test_prepare_param_dict_unindexed(self, model_data_factory: ModelDataFactory):
-        output = model_data_factory._prepare_input_data_dict("foo", 1)
+    def test_prepare_param_dict_unindexed(self, model_data_builder: ModelDataBuilder):
+        output = model_data_builder._prepare_input_data_dict("foo", 1)
         assert output == {"data": 1, "index": [[]], "dims": []}
 
     def test_prepare_param_dict_lookup(
-        self, model_data_factory: ModelDataFactory, simple_da: xr.DataArray
+        self, model_data_builder: ModelDataBuilder, simple_da: xr.DataArray
     ):
-        model_data_factory.math = model_data_factory.math.update(
+        model_data_builder.math = model_data_builder.math.update(
             {
                 "lookups": {
                     "lookup_arr": {"pivot_values_to_dim": "foobar", "dtype": "bool"}
                 }
             }
         )
-        model_data_factory.dataset["orig"] = simple_da
-        output = model_data_factory._prepare_input_data_dict(
+        model_data_builder.dataset["orig"] = simple_da
+        output = model_data_builder._prepare_input_data_dict(
             "lookup_arr", ["foo", "bar"]
         )
         assert output == {"data": True, "index": [["foo"], ["bar"]], "dims": ["foobar"]}
 
-    def test_prepare_param_dict_not_lookup(self, model_data_factory: ModelDataFactory):
+    def test_prepare_param_dict_not_lookup(self, model_data_builder: ModelDataBuilder):
         with pytest.raises(ValueError) as excinfo:  # noqa: PT011, false positive
-            model_data_factory._prepare_input_data_dict("foo", ["foo", "bar"])
+            model_data_builder._prepare_input_data_dict("foo", ["foo", "bar"])
         assert check_error_or_warning(
             excinfo, "foo | Cannot pass un-indexed input data"
         )
 
     @pytest.mark.parametrize("param_data", [1, [1], [1, 2, 3]])
     def test_prepare_param_dict_no_broadcast_allowed(
-        self, model_data_factory, param_data
+        self, model_data_builder, param_data
     ):
-        new_config = model_data_factory.config.update({"broadcast_input_data": False})
-        model_data_factory.config = new_config
+        new_config = model_data_builder.config.update({"broadcast_input_data": False})
+        model_data_builder.config = new_config
         param_dict = {"data": param_data, "index": [["foo"], ["bar"]], "dims": "foobar"}
         with pytest.raises(exceptions.ModelError) as excinfo:  # noqa: PT011, false positive
-            model_data_factory._prepare_input_data_dict("foo", param_dict)
+            model_data_builder._prepare_input_data_dict("foo", param_dict)
         assert check_error_or_warning(
             excinfo,
             f"foo | Length mismatch between data ({param_data}) and index ([['foo'], ['bar']]) in input definition",
         )
 
     def test_inherit_defs_inactive(
-        self, my_caplog, model_data_factory: ModelDataFactory
+        self, my_caplog, model_data_builder: ModelDataBuilder
     ):
         def_dict = {"A": {"active": False}}
-        new_def_dict = model_data_factory._inherit_defs(
+        new_def_dict = model_data_builder._inherit_defs(
             dim_name="nodes", dim_dict=AttrDict(def_dict)
         )
         assert "(nodes, A) | Deactivated." in my_caplog.text
         assert not new_def_dict
 
-    def test_inherit_defs_nodes_from_base(self, model_data_factory: ModelDataFactory):
+    def test_inherit_defs_nodes_from_base(self, model_data_builder: ModelDataBuilder):
         """Without a `dim_dict` to start off inheritance chaining, the `dim_name` will be used to find keys."""
-        new_def_dict = model_data_factory._inherit_defs(dim_name="nodes")
+        new_def_dict = model_data_builder._inherit_defs(dim_name="nodes")
         assert set(new_def_dict.keys()) == {"a", "b", "c"}
 
-    def test_inherit_defs_techs(self, model_data_factory: ModelDataFactory):
+    def test_inherit_defs_techs(self, model_data_builder: ModelDataBuilder):
         """`dim_dict` overrides content of base model definition."""
-        model_data_factory.model_definition.set_key("techs.foo.base_tech", "supply")
-        model_data_factory.model_definition.set_key("techs.foo.my_param", 2)
+        model_data_builder.model_definition.set_key("techs.foo.base_tech", "supply")
+        model_data_builder.model_definition.set_key("techs.foo.my_param", 2)
 
         def_dict = {"foo": {"my_param": 1}}
-        new_def_dict = model_data_factory._inherit_defs(
+        new_def_dict = model_data_builder._inherit_defs(
             dim_name="techs", dim_dict=AttrDict(def_dict)
         )
         assert new_def_dict == {"foo": {"my_param": 1, "base_tech": "supply"}}
 
-    def test_inherit_defs_techs_empty_def(self, model_data_factory: ModelDataFactory):
+    def test_inherit_defs_techs_empty_def(self, model_data_builder: ModelDataBuilder):
         """An empty `dim_dict` entry can be handled, by returning the model definition for that entry."""
-        model_data_factory.model_definition.set_key("techs.foo.base_tech", "supply")
-        model_data_factory.model_definition.set_key("techs.foo.my_param", 2)
+        model_data_builder.model_definition.set_key("techs.foo.base_tech", "supply")
+        model_data_builder.model_definition.set_key("techs.foo.my_param", 2)
 
         def_dict = {"foo": None}
-        new_def_dict = model_data_factory._inherit_defs(
+        new_def_dict = model_data_builder._inherit_defs(
             dim_name="techs", dim_dict=AttrDict(def_dict)
         )
         assert new_def_dict == {"foo": {"my_param": 2, "base_tech": "supply"}}
 
     def test_inherit_defs_techs_missing_base_def(
-        self, model_data_factory: ModelDataFactory
+        self, model_data_builder: ModelDataBuilder
     ):
         """If inheriting from a template, checks against the schema will still be undertaken."""
         def_dict = {"foo": {"base_tech": "supply"}}
         with pytest.raises(KeyError) as excinfo:
-            model_data_factory._inherit_defs(
+            model_data_builder._inherit_defs(
                 dim_name="techs", dim_dict=AttrDict(def_dict), foobar="bar"
             )
         assert check_error_or_warning(
@@ -512,21 +361,21 @@ class TestModelData:
             "(foobar, bar), (techs, foo) | Reference to item not defined in base techs",
         )
 
-    def test_deactivate_single_dim(self, model_data_factory_w_params: ModelDataFactory):
-        assert "a" in model_data_factory_w_params.dataset.nodes
-        model_data_factory_w_params._deactivate_item(nodes="a")
-        assert "a" not in model_data_factory_w_params.dataset.nodes
+    def test_deactivate_single_dim(self, model_data_builder_w_params: ModelDataBuilder):
+        assert "a" in model_data_builder_w_params.dataset.nodes
+        model_data_builder_w_params._deactivate_item(nodes="a")
+        assert "a" not in model_data_builder_w_params.dataset.nodes
 
-    def test_deactivate_two_dims(self, model_data_factory_w_params: ModelDataFactory):
+    def test_deactivate_two_dims(self, model_data_builder_w_params: ModelDataBuilder):
         to_drop = {"nodes": "a", "techs": "test_supply_elec"}
-        model_data_factory_w_params._deactivate_item(**to_drop)
-        assert "a" in model_data_factory_w_params.dataset.nodes
-        assert "test_supply_elec" in model_data_factory_w_params.dataset.techs
+        model_data_builder_w_params._deactivate_item(**to_drop)
+        assert "a" in model_data_builder_w_params.dataset.nodes
+        assert "test_supply_elec" in model_data_builder_w_params.dataset.techs
         assert (
-            model_data_factory_w_params.dataset.carrier_in.sel(**to_drop) == 0
+            model_data_builder_w_params.dataset.carrier_in.sel(**to_drop) == 0
         ).all()
         assert (
-            model_data_factory_w_params.dataset.carrier_out.sel(**to_drop) == 0
+            model_data_builder_w_params.dataset.carrier_out.sel(**to_drop) == 0
         ).all()
 
     @pytest.mark.parametrize(
@@ -539,20 +388,20 @@ class TestModelData:
         ],
     )
     def test_deactivate_no_action(
-        self, model_data_factory_w_params: ModelDataFactory, to_drop: dict
+        self, model_data_builder_w_params: ModelDataBuilder, to_drop: dict
     ):
-        orig_dataset = model_data_factory_w_params.dataset.copy(deep=True)
-        model_data_factory_w_params._deactivate_item(**to_drop)
-        assert model_data_factory_w_params.dataset.equals(orig_dataset)
+        orig_dataset = model_data_builder_w_params.dataset.copy(deep=True)
+        model_data_builder_w_params._deactivate_item(**to_drop)
+        assert model_data_builder_w_params.dataset.equals(orig_dataset)
 
     def test_links_to_node_format_all_active(
-        self, my_caplog, model_data_factory: ModelDataFactory
+        self, my_caplog, model_data_builder: ModelDataBuilder
     ):
         node_dict = {
             "a": {"foo": {"base_tech": "supply"}},
             "b": {"bar": {"base_tech": "demand"}},
         }
-        link_dict = model_data_factory._links_to_node_format(node_dict)
+        link_dict = model_data_builder._links_to_node_format(node_dict)
         assert "Deactivated" not in my_caplog.text
         assert set(link_dict.keys()) == {"a", "b"}
         assert all(
@@ -568,37 +417,37 @@ class TestModelData:
         )
 
     def test_links_to_node_format_none_active(
-        self, my_caplog, model_data_factory: ModelDataFactory
+        self, my_caplog, model_data_builder: ModelDataBuilder
     ):
         node_dict = {"c": {"foo": {"base_tech": "supply"}}}
-        link_dict = model_data_factory._links_to_node_format(node_dict)
+        link_dict = model_data_builder._links_to_node_format(node_dict)
         assert (
             "(links, test_link_a_b_elec) | Deactivated due to missing" in my_caplog.text
         )
         assert not link_dict
 
     def test_links_to_node_format_one_active(
-        self, my_caplog, model_data_factory: ModelDataFactory
+        self, my_caplog, model_data_builder: ModelDataBuilder
     ):
         node_dict = {
             "a": {"foo": {"base_tech": "supply"}},
             "c": {"bar": {"base_tech": "demand"}},
         }
-        link_dict = model_data_factory._links_to_node_format(node_dict)
+        link_dict = model_data_builder._links_to_node_format(node_dict)
         assert (
             "(links, test_link_a_b_elec) | Deactivated due to missing" in my_caplog.text
         )
         assert not link_dict
 
-    def test_links_to_node_format_one_way(self, model_data_factory: ModelDataFactory):
-        model_data_factory.model_definition["techs"]["test_link_a_b_elec"][
+    def test_links_to_node_format_one_way(self, model_data_builder: ModelDataBuilder):
+        model_data_builder.model_definition["techs"]["test_link_a_b_elec"][
             "one_way"
         ] = True
         node_dict = {
             "a": {"foo": {"base_tech": "supply"}},
             "b": {"bar": {"base_tech": "demand"}},
         }
-        link_dict = model_data_factory._links_to_node_format(node_dict)
+        link_dict = model_data_builder._links_to_node_format(node_dict)
         assert "carrier_out" not in link_dict["a"]["test_link_a_b_elec"]
         assert "carrier_in" not in link_dict["b"]["test_link_a_b_elec"]
 
@@ -613,47 +462,47 @@ class TestModelData:
 
     @pytest.mark.parametrize("coord_name", ["foosteps", "barsteps"])
     def test_add_to_dataset_timeseries(
-        self, my_caplog, model_data_factory: ModelDataFactory, coord_name
+        self, my_caplog, model_data_builder: ModelDataBuilder, coord_name
     ):
-        model_data_factory.math = model_data_factory.math.update(
+        model_data_builder.math = model_data_builder.math.update(
             {"dimensions": {coord_name: {"dtype": "datetime", "iterator": "i"}}}
         )
         new_idx = pd.Index(["2005-01-01 00:00", "2005-01-01 01:00"], name=coord_name)
         new_param = pd.DataFrame({"ts_data": [True, False]}, index=new_idx).to_xarray()
-        model_data_factory._add_to_dataset(new_param, "foo")
+        model_data_builder._add_to_dataset(new_param, "foo")
 
         assert (
             f"foo | dimensions | Updating values of `{coord_name}` to datetime type"
             in my_caplog.text
         )
         assert (
-            model_data_factory.dataset.coords[coord_name].dtype.kind == DATETIME_DTYPE
+            model_data_builder.dataset.coords[coord_name].dtype.kind == DATETIME_DTYPE
         )
-        assert "ts_data" in model_data_factory.dataset
+        assert "ts_data" in model_data_builder.dataset
 
     def test_add_to_dataset_no_timeseries(
-        self, my_caplog, model_data_factory: ModelDataFactory, simple_da: xr.DataArray
+        self, my_caplog, model_data_builder: ModelDataBuilder, simple_da: xr.DataArray
     ):
         new_param = simple_da.copy().to_dataset(name="non_ts_data")
-        model_data_factory._add_to_dataset(new_param, "foo")
+        model_data_builder._add_to_dataset(new_param, "foo")
 
         assert "datetime type" not in my_caplog.text
         # make sure nothing has changed in the array
-        assert "non_ts_data" in model_data_factory.dataset
-        assert model_data_factory.dataset["non_ts_data"].equals(simple_da)
+        assert "non_ts_data" in model_data_builder.dataset
+        assert model_data_builder.dataset["non_ts_data"].equals(simple_da)
 
     @pytest.mark.parametrize(
         "data", [[1.0, 2.0], ["1.0", "2.0"], [1, "2.0"], ["1", 2.0]]
     )
     def test_update_float_dims(
-        self, my_caplog, model_data_factory: ModelDataFactory, data
+        self, my_caplog, model_data_builder: ModelDataBuilder, data
     ):
         new_idx = pd.Index(data, name="bar")
         new_param = pd.DataFrame({"my_data": [True, False]}, index=new_idx).to_xarray()
-        model_data_factory.math = model_data_factory.math.update(
+        model_data_builder.math = model_data_builder.math.update(
             {"dimensions": {"bar": {"dtype": "float", "iterator": "i"}}}
         )
-        updated_ds = model_data_factory._update_dtypes(new_param.coords, "foo")
+        updated_ds = model_data_builder._update_dtypes(new_param.coords, "foo")
 
         assert (
             "foo | dimensions | Updating values of `bar` to float type"
@@ -663,14 +512,14 @@ class TestModelData:
 
     @pytest.mark.parametrize("data", [[1, 2], ["1", "2"], ["1", 2], [1, "2"]])
     def test_update_integer_dims(
-        self, my_caplog, model_data_factory: ModelDataFactory, data
+        self, my_caplog, model_data_builder: ModelDataBuilder, data
     ):
         new_idx = pd.Index(data, name="bar")
         new_param = pd.DataFrame({"my_data": [True, False]}, index=new_idx).to_xarray()
-        model_data_factory.math = model_data_factory.math.update(
+        model_data_builder.math = model_data_builder.math.update(
             {"dimensions": {"bar": {"dtype": "integer", "iterator": "i"}}}
         )
-        updated_ds = model_data_factory._update_dtypes(new_param.coords, "foo")
+        updated_ds = model_data_builder._update_dtypes(new_param.coords, "foo")
 
         assert (
             "foo | dimensions | Updating values of `bar` to integer type"
@@ -682,33 +531,33 @@ class TestModelData:
         ("data", "dtype"), [(["1", 2], "integer"), ([1.0, "2.0"], "float")]
     )
     def test_update_numeric_dims_in_model_data(
-        self, my_caplog, model_data_factory: ModelDataFactory, data, dtype
+        self, my_caplog, model_data_builder: ModelDataBuilder, data, dtype
     ):
         new_idx = pd.Index(data, name="bar")
         new_param = pd.DataFrame({"num_data": [True, False]}, index=new_idx).to_xarray()
-        model_data_factory.math = model_data_factory.math.update(
+        model_data_builder.math = model_data_builder.math.update(
             {"dimensions": {"bar": {"dtype": dtype, "iterator": "i"}}}
         )
-        model_data_factory._add_to_dataset(new_param, "foo")
+        model_data_builder._add_to_dataset(new_param, "foo")
 
         assert (
             f"foo | dimensions | Updating values of `bar` to {dtype} type"
             in my_caplog.text
         )
-        assert model_data_factory.dataset.coords["bar"].dtype.kind == dtype[0]
+        assert model_data_builder.dataset.coords["bar"].dtype.kind == dtype[0]
 
     @pytest.mark.parametrize(
         "data", [["foo", 2], [1.0, "foo"], ["foo", "bar"], ["Y1", "Y2"]]
     )
     def test_update_numeric_dims_no_update(
-        self, my_caplog, model_data_factory: ModelDataFactory, data
+        self, my_caplog, model_data_builder: ModelDataBuilder, data
     ):
         new_idx = pd.Index(data, name="bar")
         new_param = pd.DataFrame({"ts_data": [True, False]}, index=new_idx).to_xarray()
-        model_data_factory.math = model_data_factory.math.update(
+        model_data_builder.math = model_data_builder.math.update(
             {"dimensions": {"bar": {"dtype": "string", "iterator": "i"}}}
         )
-        updated_ds = model_data_factory._update_dtypes(new_param, "foo")
+        updated_ds = model_data_builder._update_dtypes(new_param, "foo")
 
         assert (
             "foo | dimensions | Updating values of `bar` to string type"
@@ -723,17 +572,17 @@ class TestModelData:
     def test_log_param_updates_new_coord(
         self,
         my_caplog,
-        model_data_factory: ModelDataFactory,
+        model_data_builder: ModelDataBuilder,
         simple_da: xr.DataArray,
         coords,
         new_coords,
     ):
-        model_data_factory.dataset["orig"] = simple_da
+        model_data_builder.dataset["orig"] = simple_da
         new_param = simple_da.to_series().rename_axis(index=coords).to_xarray()
-        model_data_factory.math = model_data_factory.math.update(
+        model_data_builder.math = model_data_builder.math.update(
             {"dimensions": {dim: {"dtype": "float", "iterator": "i"}} for dim in coords}
         )
-        model_data_factory._log_input_data_updates("foo", new_param)
+        model_data_builder._log_input_data_updates("foo", new_param)
         for coord in new_coords:
             assert (
                 f"(Model inputs, foo) | Adding a new dimension to the model: {coord}"
@@ -750,18 +599,18 @@ class TestModelData:
     def test_log_param_extends_coord(
         self,
         my_caplog,
-        model_data_factory: ModelDataFactory,
+        model_data_builder: ModelDataBuilder,
         simple_da: xr.DataArray,
         index,
         new_items,
     ):
-        model_data_factory.dataset["orig"] = simple_da
+        model_data_builder.dataset["orig"] = simple_da
         new_param = (
             pd.concat([simple_da.to_series(), pd.Series({index: [False, 1]})])
             .rename_axis(index=simple_da.dims)
             .to_xarray()
         )
-        model_data_factory._log_input_data_updates("foo", new_param)
+        model_data_builder._log_input_data_updates("foo", new_param)
         for item in new_items:
             coord_name, val = item
             val = f"'{val}'" if isinstance(val, str) else val
@@ -771,16 +620,16 @@ class TestModelData:
             )
 
     def test_log_param_no_logging_message(
-        self, my_caplog, model_data_factory: ModelDataFactory, simple_da: xr.DataArray
+        self, my_caplog, model_data_builder: ModelDataBuilder, simple_da: xr.DataArray
     ):
-        model_data_factory.dataset["orig"] = simple_da
+        model_data_builder.dataset["orig"] = simple_da
         new_param = simple_da.copy()
-        model_data_factory._log_input_data_updates("foo", new_param)
+        model_data_builder._log_input_data_updates("foo", new_param)
 
         assert "(Model inputs, foo) | Adding" not in my_caplog.text
 
     def test_raise_error_on_transmission_tech_in_node(
-        self, model_data_factory: ModelDataFactory
+        self, model_data_builder: ModelDataBuilder
     ):
         tech_def = {
             "tech1": {"base_tech": "supply"},
@@ -790,7 +639,7 @@ class TestModelData:
             },
         }
         with pytest.raises(exceptions.ModelError) as excinfo:
-            model_data_factory._raise_error_on_transmission_tech_def(
+            model_data_builder._raise_error_on_transmission_tech_def(
                 AttrDict(tech_def), "foo"
             )
         assert check_error_or_warning(
@@ -801,16 +650,16 @@ class TestModelData:
 
 class TestTopLevelParams:
     @pytest.fixture
-    def run_and_test(self, model_data_factory_w_params):
+    def run_and_test(self, model_data_builder_w_params):
         def _run_and_test(in_dict, out_dict, dims):
-            model_data_factory_w_params.model_definition["data_definitions"] = {
+            model_data_builder_w_params.model_definition["data_definitions"] = {
                 "my_val": in_dict
             }
-            model_data_factory_w_params.add_top_level_data_definitions()
+            model_data_builder_w_params.add_top_level_data_definitions()
 
             _data = pd.Series(out_dict).rename_axis(index=dims)
             pd.testing.assert_series_equal(
-                model_data_factory_w_params.dataset.my_val.to_series()
+                model_data_builder_w_params.dataset.my_val.to_series()
                 .dropna()
                 .reindex(_data.index),
                 _data,
@@ -943,7 +792,7 @@ class TestTopLevelParams:
         "ignore:(?s).*Operational mode requires the same timestep resolution:calliope.exceptions.ModelWarning"
     )
     def test_top_level_param_extend_dim_vals(
-        self, my_caplog, run_and_test, model_data_factory_w_params
+        self, my_caplog, run_and_test, model_data_builder_w_params
     ):
         # We do this test with timesteps as all other dimension elements are filtered out if there is no matching True element in `definition_matrix`
         run_and_test(
@@ -1008,158 +857,412 @@ class TestActiveFalse:
         assert "(techs, test_link_a_b_elec) | Deactivated." in my_caplog.text
 
 
-class TestSubset:
-    @pytest.fixture
-    def model_data_factory_with_int_dim(self, model_data_factory_w_params):
-        time_da = pd.Series(1, index=pd.Index(range(6), dtype=int, name="int_dim"))
-        model_data_factory_w_params._add_to_dataset(
-            time_da.to_xarray().to_dataset(name="int_dim_data"), ""
+class TestModelDataCleaner:
+    def test_update_time_dimension_and_params(
+        self, model_data_cleaner_with_def_matrix: ModelDataCleaner
+    ):
+        model_data_cleaner_with_def_matrix.update_and_resample_dimensions()
+        assert (
+            "timestep_resolution"
+            in model_data_cleaner_with_def_matrix.dataset.data_vars
         )
-        model_data_factory_w_params.math = model_data_factory_w_params.math.update(
+        assert (
+            "timestep_weights" in model_data_cleaner_with_def_matrix.dataset.data_vars
+        )
+
+    def test_clean_data_from_undefined_members(
+        self, my_caplog, model_data_cleaner: ModelDataCleaner
+    ):
+        model_data_cleaner.dataset = xr.Dataset(
             {
-                "dimensions.int_dim": {
-                    "dtype": "integer",
-                    "ordered": True,
-                    "iterator": "id",
-                }
+                "carrier_in": (
+                    pd.Series(
+                        {
+                            ("A", "foo", "c1"): True,
+                            ("B", "bar", "c2"): np.nan,
+                            ("C", "foo", "c1"): True,
+                        }
+                    )
+                    .rename_axis(index=["nodes", "techs", "carriers"])
+                    .to_xarray()
+                ),
+                "carrier_out": (
+                    pd.Series(
+                        {
+                            ("A", "foo", "c2"): True,
+                            ("B", "bar", "c1"): np.nan,
+                            ("C", "foo", "c2"): True,
+                        }
+                    )
+                    .rename_axis(index=["nodes", "techs", "carriers"])
+                    .to_xarray()
+                ),
+                "will_remain": (
+                    pd.Series({"foo": 1, "bar": 2})
+                    .rename_axis(index="techs")
+                    .to_xarray()
+                ),
+                "will_delete": (
+                    pd.Series({"foo": np.nan, "bar": 2})
+                    .rename_axis(index="techs")
+                    .to_xarray()
+                ),
+                "will_delete_2": (
+                    pd.Series({("foo", "B"): 2})
+                    .rename_axis(index=["techs", "nodes"])
+                    .to_xarray()
+                ),
             }
         )
-        return model_data_factory_w_params
 
-    def test_subset_time(self, model_data_factory_with_time: ModelDataFactory):
+        model_data_cleaner.clean_data_from_undefined_members()
+
+        assert (
+            "Deleting techs values as they are not defined anywhere in the model: {'bar'}"
+            in my_caplog.text
+        )
+        assert (
+            "Deleting nodes values as they are not defined anywhere in the model: {'B'}"
+            in my_caplog.text
+        )
+        assert (
+            "Deleting empty input data: ['will_delete', 'will_delete_2']"
+            in my_caplog.text
+        )
+
+        assert "will_delete" not in model_data_cleaner.dataset
+        assert "will_delete_2" not in model_data_cleaner.dataset
+        assert model_data_cleaner.dataset["will_remain"].item() == 1
+        assert set(model_data_cleaner.dataset.techs.values) == {"foo"}
+        assert set(model_data_cleaner.dataset.nodes.values) == {"A", "C"}
+        assert model_data_cleaner.dataset["definition_matrix"].dtype.kind == "b"
+
+    @pytest.mark.parametrize(
+        ("existing_distance", "expected_distance"), [(np.nan, 343.834), (1, 1)]
+    )
+    def test_add_link_distances_missing_distance(
+        self,
+        my_caplog,
+        model_data_cleaner: ModelDataCleaner,
+        existing_distance,
+        expected_distance,
+    ):
+        model_data_cleaner.clean_data_from_undefined_members()
+        model_data_cleaner.dataset["latitude"] = (
+            pd.Series({"a": 51.507222, "b": 48.8567})
+            .rename_axis(index="nodes")
+            .to_xarray()
+        )
+        model_data_cleaner.dataset["longitude"] = (
+            pd.Series({"a": -0.1275, "b": 2.3508})
+            .rename_axis(index="nodes")
+            .to_xarray()
+        )
+        model_data_cleaner.dataset["distance"] = (
+            pd.Series({"test_link_a_b_elec": existing_distance})
+            .rename_axis(index="techs")
+            .to_xarray()
+        )
+
+        model_data_cleaner.add_link_distances()
+        assert "Any missing link distances automatically computed" in my_caplog.text
+        assert model_data_cleaner.dataset["distance"].sel(
+            techs="test_link_a_b_elec"
+        ).item() == pytest.approx(expected_distance)
+
+    @pytest.mark.parametrize(("unit", "expected"), [("m", 343834), ("km", 343.834)])
+    def test_add_link_distances_no_da(
+        self, my_caplog, model_data_cleaner: ModelDataCleaner, unit, expected
+    ):
+        new_config = model_data_cleaner.config.update({"distance_unit": unit})
+        model_data_cleaner.config = new_config
+        model_data_cleaner.clean_data_from_undefined_members()
+        model_data_cleaner.dataset["latitude"] = (
+            pd.Series({"A": 51.507222, "B": 48.8567})
+            .rename_axis(index="nodes")
+            .to_xarray()
+        )
+        model_data_cleaner.dataset["longitude"] = (
+            pd.Series({"A": -0.1275, "B": 2.3508})
+            .rename_axis(index="nodes")
+            .to_xarray()
+        )
+        del model_data_cleaner.dataset["distance"]
+
+        model_data_cleaner.add_link_distances()
+        assert "Link distance matrix automatically computed" in my_caplog.text
+        assert (
+            model_data_cleaner.dataset["distance"].dropna("techs")
+            == pytest.approx(expected)
+        ).all()
+
+    def test_add_link_distances_no_latlon(
+        self, my_caplog, model_data_cleaner: ModelDataCleaner
+    ):
+        model_data_cleaner.clean_data_from_undefined_members()
+        model_data_cleaner.add_link_distances()
+        assert "Link distances will not be computed automatically" in my_caplog.text
+
+    def test_add_colors_no_init_da(
+        self, my_caplog, model_data_cleaner: ModelDataCleaner
+    ):
+        model_data_cleaner.add_colors()
+        assert "Building technology color" in my_caplog.text
+        np.testing.assert_array_equal(
+            model_data_cleaner.dataset["color"].values,
+            ["#19122b", "#17344c", "#185b48", "#3c7632"],
+        )
+
+    def test_add_colors_full_init_da(
+        self, my_caplog, model_data_cleaner: ModelDataCleaner
+    ):
+        model_data_cleaner.dataset["color"] = xr.DataArray(
+            ["#123", "#654", "#321", "#456"], dims=("techs",)
+        )
+        color_da_copy = model_data_cleaner.dataset["color"].copy()
+        model_data_cleaner.add_colors()
+        assert "technology color" not in my_caplog.text
+        assert model_data_cleaner.dataset["color"].equals(color_da_copy)
+
+    def test_add_colors_partial_init_da(
+        self, my_caplog, model_data_cleaner: ModelDataCleaner
+    ):
+        model_data_cleaner.dataset["color"] = pd.Series(
+            ["#123", np.nan, "#321", "#456"],
+            index=model_data_cleaner.dataset.techs.to_index(),
+        ).to_xarray()
+
+        model_data_cleaner.add_colors()
+        assert "Filling missing technology color" in my_caplog.text
+        np.testing.assert_array_equal(
+            model_data_cleaner.dataset["color"].values,
+            ["#123", "#17344c", "#321", "#456"],
+        )
+
+    def test_assign_input_attr(self, model_data_cleaner: ModelDataCleaner, simple_da):
+        model_data_cleaner.dataset["storage_cap_max"] = simple_da
+        model_data_cleaner.dataset["bar"] = xr.DataArray(1)
+        assert model_data_cleaner.dataset.data_vars
+
+        model_data_cleaner.assign_input_attr()
+
+        assert model_data_cleaner.dataset["storage_cap_max"].attrs["default"] == np.inf
+        assert "default" not in model_data_cleaner.dataset["bar"].attrs
+
+
+class TestSubset:
+    """Test subsetting of model data."""
+
+    @pytest.fixture
+    def model_data_cleaner_with_int_dim(self, model_data_cleaner_with_def_matrix):
+        time_da = pd.Series(1, index=pd.Index(range(6), dtype=int, name="int_dim"))
+        model_data_cleaner_with_def_matrix.dataset["int_dim_data"] = time_da.to_xarray()
+
+        model_data_cleaner_with_def_matrix.math = (
+            model_data_cleaner_with_def_matrix.math.update(
+                {
+                    "dimensions.int_dim": {
+                        "dtype": "integer",
+                        "ordered": True,
+                        "iterator": "id",
+                    }
+                }
+            )
+        )
+        return model_data_cleaner_with_def_matrix
+
+    def test_subset_time(self, model_data_cleaner_with_def_matrix: ModelDataCleaner):
         """Subsetting time dimension works as expected as a time slice"""
-        model_data_factory_with_time.config = (
-            model_data_factory_with_time.config.update(
+        model_data_cleaner_with_def_matrix.config = (
+            model_data_cleaner_with_def_matrix.config.update(
                 {"subset": {"timesteps": ["2005-01-01", "2005-01-02"]}}
             )
         )
-        model_data_factory_with_time._subset_dims()
+        model_data_cleaner_with_def_matrix._subset_dims()
         expected = pd.date_range(
             "2005-01-01", "2005-01-02 23:59", freq="h", name="timesteps"
         )
         pd.testing.assert_index_equal(
-            model_data_factory_with_time.dataset.timesteps.to_index(), expected
+            model_data_cleaner_with_def_matrix.dataset.timesteps.to_index(), expected
         )
 
-    def test_subset_nodes(self, model_data_factory_with_time: ModelDataFactory):
+    def test_subset_nodes(
+        self,
+        model_data_cleaner_with_def_matrix: ModelDataCleaner,
+        model_data_builder_built_data,
+    ):
         """Subsetting node dimension works as expected as an intersection with the subset list."""
-        model_data_factory_with_time.config = (
-            model_data_factory_with_time.config.update({"subset": {"nodes": ["a"]}})
+        model_data_cleaner_with_def_matrix.config = (
+            model_data_cleaner_with_def_matrix.config.update(
+                {"subset": {"nodes": ["a"], "timesteps": None}}
+            )
         )
-        model_data_factory_with_time._subset_dims()
+        model_data_cleaner_with_def_matrix._subset_dims()
         # no change in time subset
-        expected = pd.date_range(
-            "2005-01-01", "2005-01-04 23:59", freq="h", name="timesteps"
-        )
+        expected = model_data_builder_built_data.timesteps.to_index()
         pd.testing.assert_index_equal(
-            model_data_factory_with_time.dataset.timesteps.to_index(), expected
+            model_data_cleaner_with_def_matrix.dataset.timesteps.to_index(), expected
         )
         # only a change in node subset
         pd.testing.assert_index_equal(
-            model_data_factory_with_time.dataset.nodes.to_index(),
+            model_data_cleaner_with_def_matrix.dataset.nodes.to_index(),
             pd.Index(["a"], name="nodes"),
         )
 
     def test_subset_time_and_nodes(
-        self, model_data_factory_with_time: ModelDataFactory
+        self, model_data_cleaner_with_def_matrix: ModelDataCleaner
     ):
         """Subsetting two dimensions works as expected."""
-        model_data_factory_with_time.config = (
-            model_data_factory_with_time.config.update(
+        model_data_cleaner_with_def_matrix.config = (
+            model_data_cleaner_with_def_matrix.config.update(
                 {"subset": {"timesteps": ["2005-01-01", "2005-01-02"], "nodes": ["a"]}}
             )
         )
-        model_data_factory_with_time._subset_dims()
+        model_data_cleaner_with_def_matrix._subset_dims()
         expected = pd.date_range(
             "2005-01-01", "2005-01-02 23:59", freq="h", name="timesteps"
         )
         pd.testing.assert_index_equal(
-            model_data_factory_with_time.dataset.timesteps.to_index(), expected
+            model_data_cleaner_with_def_matrix.dataset.timesteps.to_index(), expected
         )
         pd.testing.assert_index_equal(
-            model_data_factory_with_time.dataset.nodes.to_index(),
+            model_data_cleaner_with_def_matrix.dataset.nodes.to_index(),
             pd.Index(["a"], name="nodes"),
         )
 
-    def test_numeric_ordered(self, model_data_factory_with_int_dim):
+    def test_numeric_ordered(self, model_data_cleaner_with_int_dim):
         """Subsetting an integer, ordered dimension uses a slicer."""
-        model_data_factory_with_int_dim.config = (
-            model_data_factory_with_int_dim.config.update(
+        model_data_cleaner_with_int_dim.config = (
+            model_data_cleaner_with_int_dim.config.update(
                 {"subset": {"int_dim": [1, 3]}}
             )
         )
-        model_data_factory_with_int_dim._subset_dims()
-        assert (model_data_factory_with_int_dim.dataset.int_dim == [1, 2, 3]).all()
+        model_data_cleaner_with_int_dim._subset_dims()
+        assert (model_data_cleaner_with_int_dim.dataset.int_dim == [1, 2, 3]).all()
 
-    def test_numeric_unordered(self, model_data_factory_with_int_dim):
+    def test_numeric_unordered(self, model_data_cleaner_with_int_dim):
         """Subsetting an integer, unordered dimension uses an intersection with the subset list."""
-        model_data_factory_with_int_dim.math = (
-            model_data_factory_with_int_dim.math.update(
+        model_data_cleaner_with_int_dim.math = (
+            model_data_cleaner_with_int_dim.math.update(
                 {"dimensions.int_dim": {"ordered": False}}
             )
         )
-        model_data_factory_with_int_dim.config = (
-            model_data_factory_with_int_dim.config.update(
+        model_data_cleaner_with_int_dim.config = (
+            model_data_cleaner_with_int_dim.config.update(
                 {"subset": {"int_dim": [1, 3]}}
             )
         )
-        model_data_factory_with_int_dim._subset_dims()
-        assert (model_data_factory_with_int_dim.dataset.int_dim == [1, 3]).all()
+        model_data_cleaner_with_int_dim._subset_dims()
+        assert (model_data_cleaner_with_int_dim.dataset.int_dim == [1, 3]).all()
 
     def test_subset_undefined_dim(
-        self, model_data_factory_with_time: ModelDataFactory, my_caplog
+        self, model_data_cleaner_with_def_matrix: ModelDataCleaner, my_caplog
     ):
         """Subsetting an undefined dimensions does nothing but logs a debug message."""
-        model_data_factory_with_time.config = (
-            model_data_factory_with_time.config.update(
+        model_data_cleaner_with_def_matrix.config = (
+            model_data_cleaner_with_def_matrix.config.update(
                 {"subset": {"undefined": ["foo"]}}
             )
         )
-        model_data_factory_with_time._subset_dims()
-        assert "undefined" not in model_data_factory_with_time.dataset.dims
+        model_data_cleaner_with_def_matrix._subset_dims()
+        assert "undefined" not in model_data_cleaner_with_def_matrix.dataset.dims
         assert (
             "Skipping subsetting for undefined dimension: undefined" in my_caplog.text
         )
 
 
 class TestResample:
-    def test_resample(self, model_data_factory_with_time: ModelDataFactory):
-        """Resampling a datetime dimension works as expected."""
-        model_data_factory_with_time.config = (
-            model_data_factory_with_time.config.update(
+    @pytest.fixture(params=["lookups", "parameters"])
+    def model_data_cleaner_with_1_ts_da(
+        self, request, model_data_cleaner_with_def_matrix
+    ):
+        model_data_cleaner_with_def_matrix.dataset["ts_data"] = xr.DataArray(
+            [10, 1] * (len(model_data_cleaner_with_def_matrix.dataset.timesteps) // 2),
+            dims=("timesteps",),
+        )
+        model_data_cleaner_with_def_matrix.config = (
+            model_data_cleaner_with_def_matrix.config.update(
                 {"resample": {"timesteps": "1D"}}
             )
         )
-        model_data_factory_with_time._resample_dims()
-        expected = pd.date_range(
-            "2005-01-01", "2005-01-04 23:59", freq="D", name="timesteps"
+
+        def _model_data_cleaner(agg_method):
+            model_data_cleaner_with_def_matrix.math = (
+                model_data_cleaner_with_def_matrix.math.update(
+                    {request.param: {"ts_data": {"resample_method": agg_method}}}
+                )
+            )
+            return model_data_cleaner_with_def_matrix
+
+        return _model_data_cleaner
+
+    def test_resample(self, model_data_cleaner_with_def_matrix: ModelDataCleaner):
+        """Resampling a datetime dimension works as expected."""
+        model_data_cleaner_with_def_matrix.config = (
+            model_data_cleaner_with_def_matrix.config.update(
+                {"resample": {"timesteps": "1D"}}
+            )
         )
+        model_data_cleaner_with_def_matrix._resample_dims()
+        expected = pd.date_range("2005-01-01", "2005-01-05", freq="D", name="timesteps")
         pd.testing.assert_index_equal(
-            model_data_factory_with_time.dataset.timesteps.to_index(), expected
+            model_data_cleaner_with_def_matrix.dataset.timesteps.to_index(), expected
         )
-        assert (model_data_factory_with_time.dataset.time_data == 24).all()
+
+    def test_resample_sum(self, model_data_cleaner_with_1_ts_da):
+        """Resampling with sum should aggregate values."""
+        cleaner = model_data_cleaner_with_1_ts_da("sum")
+        cleaner._resample_dims()
+        assert (cleaner.dataset["ts_data"] == 132).all()
+
+    def test_resample_mean(self, model_data_cleaner_with_1_ts_da):
+        """Resampling with mean should average values."""
+        cleaner = model_data_cleaner_with_1_ts_da("mean")
+        cleaner._resample_dims()
+        assert (cleaner.dataset["ts_data"] == 5.5).all()
+
+    def test_resample_first(self, model_data_cleaner_with_1_ts_da):
+        """Resampling with first should take the first value."""
+        cleaner = model_data_cleaner_with_1_ts_da("first")
+        cleaner._resample_dims()
+        assert (cleaner.dataset["ts_data"] == 10).all()
 
     def test_resample_fails_non_datetime(
-        self, model_data_factory_with_time: ModelDataFactory
+        self, model_data_cleaner_with_def_matrix: ModelDataCleaner
     ):
         """Cannot resample non-datetime dimensions"""
-        model_data_factory_with_time.config = (
-            model_data_factory_with_time.config.update({"resample": {"nodes": "1D"}})
+        model_data_cleaner_with_def_matrix.config = (
+            model_data_cleaner_with_def_matrix.config.update(
+                {"resample": {"nodes": "1D"}}
+            )
         )
         with pytest.raises(exceptions.ModelError, match="Cannot resample"):
-            model_data_factory_with_time._resample_dims()
+            model_data_cleaner_with_def_matrix._resample_dims()
 
     def test_resample_undefined_dim(
-        self, model_data_factory_with_time: ModelDataFactory, my_caplog
+        self, model_data_cleaner_with_def_matrix: ModelDataCleaner, my_caplog
     ):
         """Resampling an undefined dimensions does nothing but logs a debug message."""
-        model_data_factory_with_time.config = (
-            model_data_factory_with_time.config.update(
+        model_data_cleaner_with_def_matrix.config = (
+            model_data_cleaner_with_def_matrix.config.update(
                 {"resample": {"undefined": "1D"}}
             )
         )
-        model_data_factory_with_time._resample_dims()
-        assert "undefined" not in model_data_factory_with_time.dataset.dims
+        model_data_cleaner_with_def_matrix._resample_dims()
+        assert "undefined" not in model_data_cleaner_with_def_matrix.dataset.dims
         assert (
             "Skipping resampling for undefined dimension: undefined" in my_caplog.text
         )
+
+    def test_resample_undefined_var(
+        self, model_data_cleaner_with_def_matrix: ModelDataCleaner, timeseries_da
+    ):
+        """Resampling an undefined data array raises an error for lack of resampling method."""
+        model_data_cleaner_with_def_matrix.dataset["foo"] = timeseries_da
+        model_data_cleaner_with_def_matrix.config = (
+            model_data_cleaner_with_def_matrix.config.update(
+                {"resample": {"timesteps": "1D"}}
+            )
+        )
+        with pytest.raises(exceptions.ModelError, match="No resampling method defined"):
+            model_data_cleaner_with_def_matrix._resample_dims()


### PR DESCRIPTION
Fixes #824 

This should make re-init more robust by storing more things in `runtime` so we can compare against them when cleaning up the input dataset. This allows us to subset/resample/cluster only when there's a need to (runtime settings have changed).

## Summary of changes in this pull request

* Removed `_reentry` and replaced with more config stored in `runtime`. This is more robust for cases of re-init where clustering/subsetting/resampling are defined and/or are being changed.
* Allowed updates to init config on loading from file. This would allow someone to store and share a model at full resolution and with lots of techs/nodes but for others to then easily subset/resample/cluster that model for their needs.
* Split `ModelDataFactory` into a builder and cleaner class. They share one method (dtype updater) which I have placed in a shared abstract base class.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved