### PR TITLE
Update parsing to allow math and dims in where strings

### DIFF
--- a/docs/user_defined_math/components.md
+++ b/docs/user_defined_math/components.md
@@ -82,10 +82,10 @@ The default value should be set such that it has no impact on the optimisation p
         where: "cost_operation_monthly OR cost_investment_annualised OR cost_operation_variable OR cost_operation_fixed"
         equations:
           - expression: >-
-            default_if_empty(cost_investment_annualised, 0) +
+            cost_investment_annualised +
             $cost_operation_sum +
-            default_if_empty(cost_operation_fixed, 0) +
-            default_if_empty(cost_operation_monthly, 0)
+            cost_operation_fixed +
+            cost_operation_monthly
     ```
 
     For `cost` to know that `cost_operation_monthly` exists, the latter needs to be defined first.

--- a/docs/user_defined_math/helper_functions.md
+++ b/docs/user_defined_math/helper_functions.md
@@ -69,19 +69,6 @@ Using `roll(..., dimension_name=N)` allows you to do this.
 For example, `roll(storage, timesteps=1)` will shift all the storage decision variable objects by one timestep in the array.
 Then, `storage == roll(storage, timesteps=1) + 1` is equivalent to applying `storage[t] == storage[t - 1] + 1` in a for-loop.
 
-## default_if_empty
-
-We work with quite sparse arrays in our models.
-So, although your arrays are indexed over e.g., `nodes`, `techs` and `carriers`, a decision variable or parameter might only have one or two values in the array, with the rest being NaN.
-This can play havoc with defining math, with `nan` values making their way into your optimisation problem and then killing the solver or the solver interface.
-Using `default_if_empty(..., default=...)` in your `expression` string allows you to put a placeholder value in, which will be used if the math expression unavoidably _needs_ a value.
-Usually you shouldn't need to use this, as your `where` string will mask those NaN values.
-But if you're having trouble setting up your math, it is a useful function to getting it over the line.
-
-!!! note
-    Our internally defined parameters, listed in the `Parameters` section of our [pre-defined base math documentation][base-math] all have default values which propagate to the math.
-    You only need to use `default_if_empty` for decision variables and global expressions, and for user-defined parameters.
-
 ## where
 
 [Where strings](syntax.md#where-strings) only allow you to apply conditions across the whole expression equations.

--- a/src/calliope/backend/gurobi_backend_model.py
+++ b/src/calliope/backend/gurobi_backend_model.py
@@ -78,6 +78,11 @@ class GurobiBackendModel(backend_model.BackendModel):
 
         self._add_to_dataset(name, values, "parameters", definition.model_dump())
 
+        if name not in self.math["parameters"]:
+            self.math = self.math.update(
+                {f"parameters.{name}": definition.model_dump()}
+            )
+
     def add_constraint(  # noqa: D102, override
         self, name: str, definition: math_schema.Constraint
     ) -> None:

--- a/src/calliope/backend/pyomo_backend_model.py
+++ b/src/calliope/backend/pyomo_backend_model.py
@@ -91,6 +91,11 @@ class PyomoBackendModel(backend_model.BackendModel):
 
         self._add_to_dataset(name, values, "parameters", definition.model_dump())
 
+        if name not in self.math["parameters"]:
+            self.math = self.math.update(
+                {f"parameters.{name}": definition.model_dump()}
+            )
+
     def add_constraint(  # noqa: D102, override
         self, name: str, definition: math_schema.Constraint
     ) -> None:

--- a/src/calliope/preprocess/model_math.py
+++ b/src/calliope/preprocess/model_math.py
@@ -106,16 +106,20 @@ def _validate_math_string_parsing(math_model: CalliopeBuildMath) -> None:
     Evaluation issues will be raised only on adding a component to the backend.
     """
     validation_errors: dict = dict()
-    valid_component_names = set(
-        math_model.variables.root
-        | math_model.parameters.root
-        | math_model.global_expressions.root
-    )
+    valid_component_names: dict[str, set[str]] = {
+        "dimension_names": set(math_model.dimensions.root),
+        "input_names": set(math_model.parameters.root).union(math_model.lookups.root),
+        "var_expr_names": set(math_model.variables.root).union(
+            math_model.global_expressions.root
+        ),
+    }
     for component_group in typing.get_args(ORDERED_COMPONENTS_T):
         for name, dict_ in math_model[component_group].root.items():
-            parsed = parsing.ParsedBackendComponent(component_group, name, dict_)
+            parsed = parsing.ParsedBackendComponent(
+                component_group, name, dict_, valid_component_names
+            )
             parsed.parse_top_level_where(errors="ignore")
-            parsed.parse_equations(valid_component_names, errors="ignore")
+            parsed.parse_equations(errors="ignore")
             if not parsed._is_valid:
                 validation_errors[f"{component_group}:{name}"] = parsed._errors
 

--- a/tests/test_backend_pyomo.py
+++ b/tests/test_backend_pyomo.py
@@ -1942,14 +1942,13 @@ class TestNewBackend:
                         "foreach": ["nodes", "techs", "costs"],
                         "where": "cost_new",
                         "equations": [{"expression": "source_cap * cost_new"}],
+                        "default": 0,
                     },
                     # cost_investment_source_cap exists in the pre-defined math.
                     "cost_investment_source_cap": {
                         "where": "source_cap",
                         "equations": [
-                            {
-                                "expression": "default_if_empty(cost_source_cap, 0) * source_cap + default_if_empty(new_expr, 0)"
-                            }
+                            {"expression": "cost_source_cap * source_cap + new_expr"}
                         ],
                     },
                 },


### PR DESCRIPTION
Fixes #733

## Summary of changes in this pull request

* where strings can now accept arithmetic in helper functions and when making comparisons.
* valid component names are split by type (dims, inputs, vars&exprs) so that parsing can handle them separately. This allows us to limit what gets included in different parts of where strings (e.g. no vars/exprs in comparisons) and simplifies evaluation (no need to check what type it is as the parsing has already handled that). This is only applied in `where` strings. There is scope to extend it to `expression` strings but I haven't done so here.
* helper functions updated as now everything is passed around as an xarray dataarray, never a simple string. It's a slight overcomplication when all you're doing is referring to a string (e.g. `base_tech==transmission`) but it's the only way of handling situations when there is legitimate crossover between strings and components (`base_tech==storage` since storage is both a base tech and a decision variable). To handle this ambiguity, simple strings/numbers have both the value and array name assigned to the string/number (e.g. `da = xr.DataArray(2, name=2)`) so we can use it both in arithmetic (`flow_cap_max+2`) and in comparisons (`flow_cap_max==2`) without it acting weird (I hope...).
* Removed `default_if_empty` rather than fix it to match the changes made since we handle default values differently now.
* 
## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved