### PR TITLE
Add cost source use & reorganise annual investment cost expression

### DIFF
--- a/src/calliope/example_models/national_scale/data_tables/costs.csv
+++ b/src/calliope/example_models/national_scale/data_tables/costs.csv
@@ -1,4 +1,4 @@
-parameters,cost_flow_cap,cost_storage_cap,cost_area_use,cost_source_cap,cost_flow_in,cost_flow_out
+parameters,cost_flow_cap,cost_storage_cap,cost_area_use,cost_source_cap,cost_source_use,cost_flow_out
 comment,USD per kW,USD per kWh storage capacity,USD per m2,USD per kW,USD per kWh,USD per kWh
 ccgt,750,,,,0.02,
 csp,1000,50,200,200,,0.002

--- a/src/calliope/example_models/urban_scale/model_config/techs.yaml
+++ b/src/calliope/example_models/urban_scale/model_config/techs.yaml
@@ -49,7 +49,7 @@ techs:
       data: 15
       index: monetary
       dims: costs
-    cost_flow_in:
+    cost_source_use:
       data: 0.1 # 10p/kWh electricity price #ppt
       index: monetary
       dims: costs
@@ -66,7 +66,7 @@ techs:
       data: 1
       index: monetary
       dims: costs
-    cost_flow_in:
+    cost_source_use:
       data: 0.025 # 2.5p/kWh gas price #ppt
       index: monetary
       dims: costs

--- a/src/calliope/math/base.yaml
+++ b/src/calliope/math/base.yaml
@@ -84,7 +84,7 @@ parameters:
     description: >-
       Cost per unit of the decision variable `flow_cap` and per unit distance of a transmission link.
       Applied to transmission links only.
-    unit: $\frac{\{cost}}{\text{power}\times\text{distance}}$
+    unit: $\frac{\text{cost}}{\text{power}\times\text{distance}}$
 
   cost_purchase_per_distance:
     default: 0
@@ -92,14 +92,14 @@ parameters:
     description: >-
       Cost applied if the binary variable `purchased` is 1 or per unit of the integer variable `units`.
       Requires the parameter `cap_method` to be `integer`.
-    unit: $\frac{\{cost}}{\text{unit}\times\text{distance}}$
+    unit: $\frac{\text{cost}}{\text{unit}\times\text{distance}}$
 
   cost_flow_cap:
     default: 0
     title: Cost of flow capacity.
     description: >-
       Cost per unit of the decision variable `flow_cap`.
-    unit: $\frac{\{cost}}{\text{power}}$
+    unit: $\frac{\text{cost}}{\text{power}}$
 
   cost_export:
     default: 0
@@ -108,7 +108,7 @@ parameters:
     description: >-
       Cost per unit of `flow_export` in each timestep.
       Usually used in the negative sense, as a subsidy.
-    unit: $\frac{\{cost}}{\text{energy}}$
+    unit: $\frac{\text{cost}}{\text{energy}}$
 
   cost_interest_rate:
     default: 0
@@ -123,7 +123,7 @@ parameters:
     description: >-
       Annual costs applied per unit `flow_cap`.
       These costs are not subject to being recalculated relative to technology lifetime, only scaled to reflect the fraction of one year that the model represents (e.g., 7 days ~= 0.02 of a year).
-    unit: $\frac{\{cost}}{\text{power}}$
+    unit: $\frac{\text{cost}}{\text{power}}$
 
   cost_om_annual_investment_fraction:
     default: 0
@@ -137,8 +137,16 @@ parameters:
     resample_method: mean
     title: Carrier inflow cost.
     description: >-
-      Cost per unit of `flow_in` in each timestep. Also used as the cost per unit of `source_use` in `supply` technologies.
-    unit: $\frac{\{cost}}{\text{energy}}$
+      Cost per unit of `flow_in` in each timestep.
+    unit: $\frac{\text{cost}}{\text{energy}}$
+
+  cost_source_use:
+    default: 0
+    resample_method: mean
+    title: Resource use cost.
+    description: >-
+      Cost per unit of `source_use` in `supply` technologies.
+    unit: $\frac{\text{cost}}{\text{energy}}$
 
   cost_flow_out:
     default: 0
@@ -146,7 +154,7 @@ parameters:
     title: Carrier outflow cost
     description: >-
       Cost per unit of `flow_out` in each timestep.
-    unit: $\frac{\{cost}}{\text{energy}}$
+    unit: $\frac{\text{cost}}{\text{energy}}$
 
   cost_purchase:
     default: 0
@@ -154,7 +162,7 @@ parameters:
     description: >-
       Cost applied to the variable `purchased_units`.
       Requires the parameter `cap_method` to be `integer`.
-    unit: $\frac{\{cost}}{\text{unit}}$
+    unit: $\frac{\text{cost}}{\text{unit}}$
 
   cost_area_use:
     default: 0
@@ -168,14 +176,14 @@ parameters:
     title: Cost of source flow capacity.
     description: >-
       Cost per unit `source_cap`.
-    unit: $\frac{\{cost}}{\text{power}}$
+    unit: $\frac{\text{cost}}{\text{power}}$
 
   cost_storage_cap:
     default: 0
     title: Cost of storage capacity.
     description: >-
       Cost per unit `storage_cap`, i.e., the maximum available capacity of the storage technology's "reservoir".
-    unit: $\frac{\{cost}}{\text{energy}}$
+    unit: $\frac{\text{cost}}{\text{energy}}$
 
   cost_depreciation_rate:
     default: 1
@@ -1199,13 +1207,10 @@ global_expressions:
       - expression: timestep_weights * ($cost_export + $cost_flow_out + $cost_flow_in)
     sub_expressions:
       cost_export:
-        - where: any(carrier_export, over=carriers) AND any(cost_export, over=carriers)
-          expression: sum(cost_export * flow_export, over=carriers)
-        - where: NOT (any(carrier_export, over=carriers) AND any(cost_export, over=carriers))
-          expression: "0"
+        - expression: sum(cost_export * flow_export, over=carriers)
       cost_flow_in:
         - where: "base_tech==supply"
-          expression: cost_flow_in * source_use
+          expression: cost_source_use * source_use
         - where: "NOT base_tech==supply"
           expression: sum(cost_flow_in * flow_in, over=carriers)
       cost_flow_out:
@@ -1311,7 +1316,7 @@ global_expressions:
     default: 0
     unit: cost
     foreach: [nodes, techs, costs]
-    where: cost_investment AND (cost_om_annual OR cost_om_annual_investment_fraction)
+    where: (cost_om_annual AND flow_cap) OR (cost_investment AND cost_om_annual_investment_fraction)
     equations:
       - expression: >-
           $annualisation_weight * (
@@ -1414,4 +1419,9 @@ checks:
   lat_lons_out_of_range:
     where: latitude < -90 OR latitude > 90 OR longitude < -180 OR longitude > 180
     message: Node latitude/longitude must be specified in WGS84 / EPSG4326 format.
+    errors: warn
+
+  flow_in_for_supply_tech:
+    where: base_tech==supply AND cost_flow_in
+    message: Use `cost_source_use` instead of `cost_flow_in` to set an inflow cost for `supply` technologies.
     errors: warn

--- a/src/calliope/math/base.yaml
+++ b/src/calliope/math/base.yaml
@@ -1202,12 +1202,15 @@ global_expressions:
     default: 0
     unit: $\frac{\text{cost}}{\text{hour}}$
     foreach: [nodes, techs, costs, timesteps]
-    where: "cost_export OR cost_flow_in OR cost_flow_out"
+    where: "cost_export OR cost_flow_in OR cost_flow_out OR cost_source_use"
     equations:
       - expression: timestep_weights * ($cost_export + $cost_flow_out + $cost_flow_in)
     sub_expressions:
       cost_export:
-        - expression: sum(cost_export * flow_export, over=carriers)
+        - where: any(carrier_export, over=carriers) AND any(cost_export, over=carriers)
+          expression: sum(cost_export * flow_export, over=carriers)
+        - where: NOT (any(carrier_export, over=carriers) AND any(cost_export, over=carriers))
+          expression: "0"
       cost_flow_in:
         - where: "base_tech==supply"
           expression: cost_source_use * source_use

--- a/tests/common/national_scale_from_data_tables/data_tables/techs_costs_monetary.csv
+++ b/tests/common/national_scale_from_data_tables/data_tables/techs_costs_monetary.csv
@@ -1,4 +1,4 @@
-techs,cost_area_use,cost_flow_cap,cost_flow_in,cost_flow_out,cost_interest_rate,cost_source_cap,cost_storage_cap
+techs,cost_area_use,cost_flow_cap,cost_source_use,cost_flow_out,cost_interest_rate,cost_source_cap,cost_storage_cap
 battery,,,,,0.1,,200
 ccgt,,750,0.02,,0.1,,
 csp,200,1000,,0.002,0.1,200,50

--- a/tests/common/test_model/scenarios.yaml
+++ b/tests/common/test_model/scenarios.yaml
@@ -456,6 +456,10 @@ overrides:
           data: 0.1
           index: monetary
           dims: costs
+        cost_source_use:
+          data: 0.1
+          index: monetary
+          dims: costs
 
   demand_elec_max:
     data_tables:

--- a/tests/test_backend_general.py
+++ b/tests/test_backend_general.py
@@ -201,6 +201,7 @@ class TestGetters:
         assert variable.attrs["references"] == {
             "flow_in_max",
             "flow_out_max",
+            "cost_operation_fixed",
             "cost_investment_flow_cap",
             "symmetric_transmission",
         }


### PR DESCRIPTION
Fixes #831 
Fixes #804 

## Summary of changes in this pull request

* use a carrier-agnostic cost for source use of supply technologies, to avoid clashes when indexing `cost_flow_in` over carriers _and_ assigning a value for it to supply technologies
* update where string of `cost_operation_fixed` to build the expression for either instance of it being needed
* fix units referring to cost from `\{cost}` to `\text{cost}`

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved