### PR TITLE
Remove math config contents from array attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
-## 0.7.0.dev7 (2025-09-05)
+## 0.7.0.dev8
 
 ### User-facing changes
+
+|removed| Duplication of math attributes in array attributes.
+For example, `model.inputs.flow_cap_max.attrs["default"]` is now only available from `model.math.build.parameters.flow_cap_max.default`.
+
+## 0.7.0.dev7 (2025-09-05)
+
+
 
 |fixed| `ModelDataFactory` is no longer run twice during startup, resulting in faster initialisation
 

--- a/src/calliope/backend/backend_model.py
+++ b/src/calliope/backend/backend_model.py
@@ -1275,7 +1275,7 @@ class BackendModel(BackendModelGenerator, Generic[T]):
                 f"Applying bound according to the {bound} parameter values.",
             )
             bound_array = self.get_parameter(bound)
-            fill_na = bound_array.attrs["default"]
+            fill_na = self.math.parameters[bound].default
             references.add(bound)
         else:
             bound_array = xr.DataArray(bound)

--- a/src/calliope/backend/expression_parser.py
+++ b/src/calliope/backend/expression_parser.py
@@ -849,8 +849,10 @@ class EvalUnslicedComponent(EvalToArrayStr):
                 f"Trying to access a math component that is not yet defined: {self.name}. "
                 "If the referenced component is a global expression, set its `order` to have it defined first."
             )
-        if evaluated.isnull().any() and pd.notna(evaluated.attrs["default"]):
-            evaluated = evaluated.fillna(evaluated.attrs["default"])
+        if evaluated.isnull().any() and pd.notna(
+            default := self.eval_attrs["math"].find(self.name)[1].default
+        ):
+            evaluated = evaluated.fillna(default)
 
         self.eval_attrs["references"].add(self.name)
         return evaluated

--- a/src/calliope/backend/gurobi_backend_model.py
+++ b/src/calliope/backend/gurobi_backend_model.py
@@ -149,7 +149,7 @@ class GurobiBackendModel(backend_model.BackendModel):
 
     def set_objective(self, name: str) -> None:  # noqa: D102, override
         to_set = self.objectives[name]
-        sense = self.OBJECTIVE_SENSE_DICT[to_set.attrs["sense"]]
+        sense = self.OBJECTIVE_SENSE_DICT[self.math.objectives[name].sense]
         self._instance.setObjective(to_set.item(), sense=sense)
         self._instance.update()
         self.objective = name

--- a/src/calliope/preprocess/model_data.py
+++ b/src/calliope/preprocess/model_data.py
@@ -126,7 +126,6 @@ class ModelDataFactory:
         self.add_colors()
         self.add_link_distances()
         self.update_and_resample_dimensions()
-        self.assign_input_attr()
         self.dataset = self.dataset.assign_coords(
             self._update_dtypes(self.dataset.coords)
         )
@@ -383,17 +382,6 @@ class ModelDataFactory:
                 "Filling missing technology color array values from default palette."
             )
             self.dataset["color"] = self.dataset["color"].fillna(new_color_array)
-
-    def assign_input_attr(self):
-        """Assign metadata as attributes to each input array."""
-        all_attrs = {
-            **self.math.parameters.model_dump(),
-            **self.math.lookups.model_dump(),
-        }
-        for var_name, var_data in self.dataset.data_vars.items():
-            self.dataset[var_name] = var_data.assign_attrs(all_attrs.get(var_name, {}))
-            # Remove this redundant attribute
-            self.dataset[var_name].attrs.pop("active", None)
 
     def _get_relevant_node_refs(self, techs_dict: AttrDict, node: str) -> list[str]:
         """Get all references to input data made in technologies at nodes.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,9 +279,6 @@ def dummy_model_data():
     for k in ["lookup_multi_dim_nodes", "lookup_multi_dim_techs", "lookup_techs"]:
         model_data[k] = model_data[k].where(model_data[k] != "nan")
 
-    # This value is set directly to ensure it finds its way through to the LaTex math.
-    model_data.no_dims.attrs["default"] = 0
-
     return model_data
 
 

--- a/tests/test_backend_expression_parser.py
+++ b/tests/test_backend_expression_parser.py
@@ -355,7 +355,7 @@ class TestEquationParserElements:
         self, unsliced_param_with_obj_names, eval_kwargs, string_val
     ):
         parsed_ = unsliced_param_with_obj_names.parse_string(string_val, parse_all=True)
-        default = eval_kwargs["input_data"][string_val].attrs["default"]
+        default = eval_kwargs["math"].parameters[string_val].default
         assert (
             parsed_[0]
             .eval(**eval_kwargs)
@@ -907,7 +907,7 @@ class TestAsMathString:
             "where_array": None,
             "references": set(),
             "backend_interface": dummy_latex_backend_model,
-            "math": dummy_model_math,
+            "math": dummy_latex_backend_model.math,
             "input_data": dummy_latex_backend_model.inputs,
         }
 

--- a/tests/test_backend_general.py
+++ b/tests/test_backend_general.py
@@ -205,10 +205,6 @@ class TestGetters:
             "symmetric_transmission",
         }
 
-    def test_get_variable_default(self, variable):
-        """Check a decision variable has expected default val."""
-        assert variable.attrs["default"] == 0
-
     def test_get_variable_coords_in_name(self, variable):
         """Check a decision variable does not have verbose strings activated."""
         assert variable.attrs["coords_in_name"] is False
@@ -268,10 +264,6 @@ class TestGetters:
             "cost_investment_annualised",
             "cost_operation_fixed",
         }
-
-    def test_get_global_expression_default(self, global_expression):
-        """Check a global expression has expected default."""
-        assert global_expression.attrs["default"] == 0
 
     def test_get_global_expression_coords_in_name(self, global_expression):
         """Check a global expression does not have verbose strings activated."""

--- a/tests/test_backend_where_parser.py
+++ b/tests/test_backend_where_parser.py
@@ -194,7 +194,7 @@ class TestInputParser:
         self, param_lookup, dummy_model_data, data_var_string, expected, eval_kwargs
     ):
         parsed_ = param_lookup.parse_string(data_var_string, parse_all=True)
-        default = eval_kwargs["input_data"][expected].attrs["default"]
+        default = eval_kwargs["math"].parameters[data_var_string].default
         assert (
             parsed_[0]
             .eval(apply_where=False, **eval_kwargs)

--- a/tests/test_preprocess_model_data.py
+++ b/tests/test_preprocess_model_data.py
@@ -287,18 +287,6 @@ class TestModelData:
             ["#123", "#17344c", "#321", "#456"],
         )
 
-    def test_assign_input_attr(
-        self, model_data_factory: ModelDataFactory, simple_da, timeseries_da
-    ):
-        model_data_factory.dataset["storage_cap_max"] = simple_da
-        model_data_factory.dataset["bar"] = timeseries_da
-        assert model_data_factory.dataset.data_vars
-
-        model_data_factory.assign_input_attr()
-
-        assert model_data_factory.dataset["storage_cap_max"].attrs["default"] == np.inf
-        assert "default" not in model_data_factory.dataset["bar"].attrs
-
     def test_get_relevant_node_refs_ts_data(self, model_data_factory: ModelDataFactory):
         techs_dict = AttrDict(
             {


### PR DESCRIPTION
As discussed in #834 

- Removes all use of `attrs` to access information that is already stored in the math.
- Removes math attrs from being attached to input data in the first place

>[!NOTE]
>To be merged in after #834 

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved