### PR TITLE
Make gurobi warmstart test compatible with gurobi>=13

### DIFF
--- a/tests/test_backend_gurobi.py
+++ b/tests/test_backend_gurobi.py
@@ -288,6 +288,7 @@ class TestNewBackend:
         simple_supply_gurobi.solve(force=True, warmstart=True)
 
         # default warmstart = 1 (<v13), = -1 (>=v13)
+        # TODO: Remove `1` check when dropping support for gurobi<13
         assert simple_supply_gurobi.backend._instance.Params.LPWarmStart in [-1, 1]
         assert (
             "LPWarmStart"


### PR DESCRIPTION
Fixes issues coming up in the CI.

Gurobi's LPWarmstart has a different default now (compare [now](https://docs.gurobi.com/projects/optimizer/en/current/reference/parameters.html#lpwarmstart) to [previous](https://docs.gurobi.com/projects/optimizer/en/12.0/reference/parameters.html#lpwarmstart)).

Since `1` means a type of warmstart is activated in either version, and `-1` doesn't even exist in the older version, I think this simple fix is sufficient (rather than checking gurobi version and changing test accordingly).

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved