### PR TITLE
Allow making a tech inactive while it still has defined data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ For example, `model.inputs.flow_cap_max.attrs["default"]` is now only available 
 
 |fixed| Example notebook outputs no longer clutter search results in docs and search result example notebook pages are grouped under the top-level page header (#675).
 
+|fixed| Allow a tech to be set `active: False` even if data for it is defined (e.g. through a CSV file).
+
 ### Internal changes
 
 |fixed| example user-defined math tests that were missing global expressions in the resulting LP files.

--- a/src/calliope/preprocess/data_tables.py
+++ b/src/calliope/preprocess/data_tables.py
@@ -125,6 +125,8 @@ class DataTable:
             except KeyError:
                 continue
             for tech in techs_this_node:
+                if tech not in techs_incl_inheritance:
+                    continue
                 if (
                     techs_incl_inheritance[tech].get("base_tech", None)
                     == "transmission"

--- a/tests/preprocess/data_sources_test.py
+++ b/tests/preprocess/data_sources_test.py
@@ -646,6 +646,14 @@ class TestDataTableNodeDict:
 
         assert node_dict == {}
 
+    def test_node_dict_skips_inactive_tech(self, table_obj):
+        """Techs in the data table but missing from techs_incl_inheritance because of active=False should be skipped."""
+        df_dict = {"available_area": {("foo1", "bar1"): 1, ("foo1", "bar2"): 2}}
+        tech_dict = calliope.AttrDict({"bar1": {}})  # bar2 is inactive / filtered out
+        node_dict = table_obj(df_dict).node_dict(tech_dict)
+
+        assert node_dict == {"foo1": {"techs": {"bar1": None}}}
+
     def test_transmission_tech_with_nodes(self, table_obj):
         df_dict = {"param": {("foo1", "bar1"): 1, ("foo2", "bar2"): 2}}
         tech_dict = calliope.AttrDict(


### PR DESCRIPTION
## Summary of changes in this pull request

There was an issue when disabling a tech with `active: False` while it still has parameter data, e.g. from tabular data. In this case the model fails with a KeyError. This makes `active: False` less useful as one cannot just mark something inactive without wiping all its data from the model too.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved
