### PR TITLE
Update array default filling timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### User-facing changes
 
+|fixed| Default values on masked array entries entering into math expression summation.
+In particular, fixes `sum(flow_cap, over=carriers)` on the constraint `source_availability_supply` erroneously returning `inf` (#862).
+
 |fixed| Time clustering method, to handle cases where floating point errors can lead to index mismatches and dropped clusters (#826).
 
 |new| user-defined math example introducing monthly peak charges (#727).

--- a/docs/user_defined_math/helper_functions.md
+++ b/docs/user_defined_math/helper_functions.md
@@ -46,6 +46,11 @@ nodes:
 
 Using `sum(..., over=)` in an expression allows you to sum over one or more dimensions of your component array (be it a parameter, decision variable, or global expression).
 
+!!! note
+    Array default values may enter into the summation if there are NaN values in the array that are not masked by the `where` string.
+    For instance, if you sum `flow_cap`, which has `inf` as the default value, you risk having a summation returning `inf`.
+    If this occurs, consider masking these values by applying the [`where`](#where) helper function to first strip out unwanted entries before the `sum` function is applied.
+
 ## select_from_lookup_arrays
 
 Some of our arrays in [`model.inputs`][calliope.Model.inputs] are not data arrays, but "lookup" arrays.

--- a/docs/user_defined_math/helper_functions.md
+++ b/docs/user_defined_math/helper_functions.md
@@ -47,8 +47,7 @@ nodes:
 Using `sum(..., over=)` in an expression allows you to sum over one or more dimensions of your component array (be it a parameter, decision variable, or global expression).
 
 !!! note
-    Array default values may enter into the summation if there are NaN values in the array that are not masked by the `where` string.
-    For instance, if you sum `flow_cap`, which has `inf` as the default value, you risk having a summation returning `inf`.
+    Invalid variable default values such as `.inf` or `.nan` can enter into the summation if they are not properly masked in the `where` string.
     If this occurs, consider masking these values by applying the [`where`](#where) helper function to first strip out unwanted entries before the `sum` function is applied.
 
 ## select_from_lookup_arrays

--- a/src/calliope/backend/expression_parser.py
+++ b/src/calliope/backend/expression_parser.py
@@ -120,9 +120,12 @@ class EvalArrayOrMath(EvalString):
                 `array` with NaNs filled with defaults, where array applied,
                 and dimensions broadcast against the where array (to ensure consistent array shapes).
         """
-        where_array = self.eval_attrs.where_array
-        masked_array = array.broadcast_like(where_array).where(where_array)
-        return masked_array
+        if not self.eval_attrs.apply_where:
+            return array
+        elif (where_array := self.eval_attrs.where_array).equals(xr.DataArray(True)):
+            return array
+        else:
+            return array.broadcast_like(where_array).where(where_array)
 
     # Math strings evaluate to strings.
     @overload

--- a/src/calliope/backend/expression_parser.py
+++ b/src/calliope/backend/expression_parser.py
@@ -120,12 +120,11 @@ class EvalArrayOrMath(EvalString):
                 `array` with NaNs filled with defaults, where array applied,
                 and dimensions broadcast against the where array (to ensure consistent array shapes).
         """
-        if not self.eval_attrs.apply_where:
-            return array
-        elif (where_array := self.eval_attrs.where_array).equals(xr.DataArray(True)):
-            return array
-        else:
-            return array.broadcast_like(where_array).where(where_array)
+        if self.eval_attrs.apply_where:
+            where_array = self.eval_attrs.where_array
+            if not where_array.equals(xr.DataArray(True)):
+                array = array.broadcast_like(where_array).where(where_array)
+        return array
 
     # Math strings evaluate to strings.
     @overload

--- a/src/calliope/backend/expression_parser.py
+++ b/src/calliope/backend/expression_parser.py
@@ -121,8 +121,8 @@ class EvalArrayOrMath(EvalString):
                 and dimensions broadcast against the where array (to ensure consistent array shapes).
         """
         where_array = self.eval_attrs.where_array
-        arr = self._apply_default(array).broadcast_like(where_array).where(where_array)
-        return arr
+        masked_array = array.broadcast_like(where_array).where(where_array)
+        return masked_array
 
     # Math strings evaluate to strings.
     @overload
@@ -328,7 +328,7 @@ class EvalSignOp(EvalArrayOrMath):
         return self.sign + self._eval("math_string")
 
     def as_array(self) -> xr.DataArray:  # noqa: D102, override
-        evaluated = self._apply_where_array(self._eval("array"))
+        evaluated = self._eval("array")
         if self.sign == "-":
             evaluated = -1 * evaluated
         return evaluated
@@ -830,9 +830,9 @@ class EvalUnslicedComponent(EvalArrayOrMath):
                     f"Trying to access a math component that is not yet defined: {self.name}. "
                     "If the referenced component is a global expression, set its `order` to have it defined first."
                 )
-
+        evaluated_filled = self._apply_default(evaluated)
         self.eval_attrs.references.add(self.name)
-        return evaluated
+        return evaluated_filled
 
 
 class EvalGenericString(EvalArrayOrMath):

--- a/src/calliope/backend/expression_parser.py
+++ b/src/calliope/backend/expression_parser.py
@@ -92,6 +92,40 @@ class EvalArrayOrMath(EvalString):
         The purpose of this is to be able to access the string/number value whether we query the array name or its data.
         """
 
+    def _apply_default(self, array: xr.DataArray) -> xr.DataArray:
+        """Apply default values to an array where relevant.
+
+        Derived arrays (e.g., the result of applying arithmetic) no longer have the original array name, so they do not trigger default value application.
+
+        Args:
+            array (xr.DataArray): Array to apply default values to.
+
+        Returns:
+            xr.DataArray: Array with default values applied, if the array name is defined in the math schema.
+        """
+        try:
+            default = self.eval_attrs.math.find(array.name)["default"]
+            if array.isnull().any() and pd.notna(default):
+                array = array.fillna(default)
+        except KeyError:
+            pass
+        return array
+
+    def _apply_where_array(self, array: xr.DataArray) -> xr.DataArray:
+        """Util function to apply where arrays to non-latex strings.
+
+        Args:
+            array (xr.DataArray): The array to apply the where array to.
+
+        Returns:
+            xr.DataArray:
+                `array` with NaNs filled with defaults, where array applied,
+                and dimensions broadcast against the where array (to ensure consistent array shapes).
+        """
+        where_array = self.eval_attrs.where_array
+        arr = self._apply_default(array).broadcast_like(where_array).where(where_array)
+        return arr
+
     # Math strings evaluate to strings.
     @overload
     def eval(
@@ -202,16 +236,6 @@ class EvalOperatorOperand(EvalArrayOrMath):
             except StopIteration:
                 break
 
-    def _apply_where_array(self, evaluated: xr.DataArray) -> xr.DataArray:
-        """Util function to apply where arrays to non-latex strings."""
-        where_array = self.eval_attrs.where_array
-        try:
-            evaluated = evaluated.where(where_array)
-        except AttributeError:
-            evaluated = evaluated.broadcast_like(where_array).where(where_array)
-
-        return evaluated
-
     def _skip_component_on_conditional(self, component: str, operator_: str) -> bool:
         """Conditional to skip adding to math string if element evaluates to zero.
 
@@ -306,7 +330,7 @@ class EvalSignOp(EvalArrayOrMath):
         return self.sign + self._eval("math_string")
 
     def as_array(self) -> xr.DataArray:  # noqa: D102, override
-        evaluated = self._eval("array")
+        evaluated = self._apply_where_array(self._eval("array"))
         if self.sign == "-":
             evaluated = -1 * evaluated
         return evaluated
@@ -368,8 +392,8 @@ class EvalComparisonOp(EvalArrayOrMath):
                 raise self.error_msg(
                     f"The {side}-hand side of the equation is indexed over dimensions not present in `foreach`: {extra_dims}"
                 )
-        lhs_where = lhs.broadcast_like(where)
-        rhs_where = rhs.broadcast_like(where)
+        lhs_where = self._apply_where_array(lhs)
+        rhs_where = self._apply_where_array(rhs)
 
         match self.op:
             case "==":
@@ -808,10 +832,6 @@ class EvalUnslicedComponent(EvalArrayOrMath):
                     f"Trying to access a math component that is not yet defined: {self.name}. "
                     "If the referenced component is a global expression, set its `order` to have it defined first."
                 )
-        if evaluated.isnull().any() and pd.notna(
-            default := self.eval_attrs.math.find(self.name)["default"]
-        ):
-            evaluated = evaluated.fillna(default)
 
         self.eval_attrs.references.add(self.name)
         return evaluated

--- a/src/calliope/backend/expression_parser.py
+++ b/src/calliope/backend/expression_parser.py
@@ -103,12 +103,10 @@ class EvalArrayOrMath(EvalString):
         Returns:
             xr.DataArray: Array with default values applied, if the array name is defined in the math schema.
         """
-        try:
+        if isinstance(array.name, str):
             default = self.eval_attrs.math.find(array.name)["default"]
             if array.isnull().any() and pd.notna(default):
                 array = array.fillna(default)
-        except KeyError:
-            pass
         return array
 
     def _apply_where_array(self, array: xr.DataArray) -> xr.DataArray:

--- a/src/calliope/backend/helper_functions.py
+++ b/src/calliope/backend/helper_functions.py
@@ -436,6 +436,8 @@ class SelectFromLookupArrays(ParsingHelperFunction):
     NAME = "select_from_lookup_arrays"
     #:
     ALLOWED_IN = ["expression"]
+    #:
+    ignore_where = True
 
     def as_math_string(self, array: str, **lookup_arrays: str) -> str:  # noqa: D102, override
         new_strings = {
@@ -597,11 +599,8 @@ class Roll(ParsingHelperFunction):
     NAME = "roll"
     #:
     ALLOWED_IN = ["expression"]
-
-    @property
-    def ignore_where(self) -> bool:
-        """Whether or not to ignore `where` functionality."""
-        return True
+    #:
+    ignore_where = True
 
     def as_math_string(self, array: str, **roll_kwargs: str) -> str:  # noqa: D102, override
         new_strings = {
@@ -700,8 +699,6 @@ class GroupSum(ParsingHelperFunction):
     #:
     ALLOWED_IN = ["expression"]
 
-    ignore_where = True
-
     def as_math_string(self, array: str, groupby: str, group_dim: str) -> str:  # noqa: D102, override
         group_dim_singular = self._dim_iterator(group_dim)
         sum_lim_string = rf"\text{{ if }} {groupby} = \text{{{group_dim_singular}}}"
@@ -786,8 +783,6 @@ class GroupDatetime(ParsingHelperFunction):
     NAME = "group_datetime"
     #:
     ALLOWED_IN = ["expression"]
-
-    ignore_where = True
 
     def as_math_string(self, array: str, over: str, group: str) -> str:  # noqa: D102, override
         overstring = self._instr(over)

--- a/src/calliope/backend/helper_functions.py
+++ b/src/calliope/backend/helper_functions.py
@@ -395,7 +395,7 @@ class Sum(ParsingHelperFunction):
                 the summation will lead to a NaN (xarray.DataArray.sum arg: `min_count=1`).
         """
         filtered_over = set(self._to_str_list(over)).intersection(array.dims)
-        return array.sum(filtered_over, min_count=1, skipna=True)
+        return array.sum(filtered_over, min_count=1, skipna=True, keep_attrs=True)
 
 
 class ReduceCarrierDim(ParsingHelperFunction):
@@ -635,7 +635,7 @@ class Roll(ParsingHelperFunction):
             * foo      (foo) <U1 'A' 'B' 'C'
         """
         roll_kwargs_int: Mapping = {k: int(v) for k, v in roll_kwargs.items()}
-        return array.roll(roll_kwargs_int)
+        return array.roll(**roll_kwargs_int)
 
 
 class Where(ParsingHelperFunction):
@@ -774,8 +774,12 @@ class GroupSum(ParsingHelperFunction):
         for group_name, array_subset in groups:
             grouped[group_name] = array_subset.sum("_stacked", min_count=1, skipna=True)
 
-        array = xr.concat(
-            grouped.values(), dim=pd.Index(grouped.keys(), name=group_dim.name)
+        array = (
+            xr.concat(
+                grouped.values(), dim=pd.Index(grouped.keys(), name=group_dim.name)
+            )
+            .assign_attrs(array.attrs)
+            .rename(array.name)
         )
         return array
 
@@ -940,5 +944,10 @@ class SumNextN(ParsingHelperFunction):
                     str(over.name), min_count=1
                 )
             )
-        final_array = xr.concat(results, dim=over).broadcast_like(array)
+        final_array = (
+            xr.concat(results, dim=over)
+            .broadcast_like(array)
+            .assign_attrs(array.attrs)
+            .rename(array.name)
+        )
         return final_array

--- a/src/calliope/backend/helper_functions.py
+++ b/src/calliope/backend/helper_functions.py
@@ -233,7 +233,7 @@ class WhereAny(ParsingHelperFunction):
             )
         available_dims = set(input_component.dims).intersection(self._to_str_list(over))
 
-        return input_component.any(dim=available_dims, keep_attrs=True)
+        return input_component.any(dim=available_dims)
 
 
 class Defined(ParsingHelperFunction):
@@ -395,7 +395,7 @@ class Sum(ParsingHelperFunction):
                 the summation will lead to a NaN (xarray.DataArray.sum arg: `min_count=1`).
         """
         filtered_over = set(self._to_str_list(over)).intersection(array.dims)
-        return array.sum(filtered_over, min_count=1, skipna=True, keep_attrs=True)
+        return array.sum(filtered_over, min_count=1, skipna=True)
 
 
 class ReduceCarrierDim(ParsingHelperFunction):
@@ -635,7 +635,7 @@ class Roll(ParsingHelperFunction):
             * foo      (foo) <U1 'A' 'B' 'C'
         """
         roll_kwargs_int: Mapping = {k: int(v) for k, v in roll_kwargs.items()}
-        return array.roll(**roll_kwargs_int)
+        return array.roll(roll_kwargs_int)
 
 
 class Where(ParsingHelperFunction):
@@ -774,13 +774,9 @@ class GroupSum(ParsingHelperFunction):
         for group_name, array_subset in groups:
             grouped[group_name] = array_subset.sum("_stacked", min_count=1, skipna=True)
 
-        array = (
-            xr.concat(
-                grouped.values(), dim=pd.Index(grouped.keys(), name=group_dim.name)
-            )
-            .assign_attrs(array.attrs)
-            .rename(array.name)
-        )
+        array = xr.concat(
+            grouped.values(), dim=pd.Index(grouped.keys(), name=group_dim.name)
+        ).rename(array.name)
         return array
 
 
@@ -945,9 +941,6 @@ class SumNextN(ParsingHelperFunction):
                 )
             )
         final_array = (
-            xr.concat(results, dim=over)
-            .broadcast_like(array)
-            .assign_attrs(array.attrs)
-            .rename(array.name)
+            xr.concat(results, dim=over).broadcast_like(array).rename(array.name)
         )
         return final_array

--- a/src/calliope/backend/helper_functions.py
+++ b/src/calliope/backend/helper_functions.py
@@ -645,6 +645,8 @@ class Where(ParsingHelperFunction):
     #:
     ALLOWED_IN = ["expression"]
 
+    ignore_where = True
+
     def as_math_string(self, array: str, condition: str) -> str:  # noqa: D102, override
         return rf"({array} \text{{if }} {condition} == True)"
 

--- a/src/calliope/backend/parsing.py
+++ b/src/calliope/backend/parsing.py
@@ -346,6 +346,7 @@ class ParsedBackendEquation:
             eval_attrs_["references"] = references
         evaluated = self.expression[0].eval(return_type, EvalAttrs(**eval_attrs_))
         if return_type == "array":
+            evaluated = self.expression[0]._apply_where_array(evaluated)
             self.raise_error_on_where_expr_mismatch(evaluated, where)
         return evaluated
 

--- a/src/calliope/backend/where_parser.py
+++ b/src/calliope/backend/where_parser.py
@@ -61,10 +61,6 @@ class EvalAndOr(
                 val = operator.or_(val, evaluated_operand)
         return val
 
-    def _apply_where_array(self, evaluated: xr.DataArray) -> xr.DataArray:
-        """Override func from parent class to effectively do nothing."""
-        return evaluated
-
     def as_math_string(self) -> str:  # noqa: D102, override
         return super().as_math_string()
 

--- a/src/calliope/example_models/urban_scale/scenarios.yaml
+++ b/src/calliope/example_models/urban_scale/scenarios.yaml
@@ -85,7 +85,3 @@ overrides:
       X1_to_N1.flow_cap: 300
       N1_to_X2.flow_cap: 250
       N1_to_X3.flow_cap: 320
-
-  pv_per_cap:
-    techs.pv.source_unit: per_cap
-    data_tables.pv_resource.select.scaler: per_cap

--- a/src/calliope/example_models/urban_scale/scenarios.yaml
+++ b/src/calliope/example_models/urban_scale/scenarios.yaml
@@ -85,3 +85,7 @@ overrides:
       X1_to_N1.flow_cap: 300
       N1_to_X2.flow_cap: 250
       N1_to_X3.flow_cap: 320
+
+  pv_per_cap:
+    techs.pv.source_unit: per_cap
+    data_tables.pv_resource.select.scaler: per_cap

--- a/src/calliope/exceptions.py
+++ b/src/calliope/exceptions.py
@@ -32,11 +32,15 @@ class BackendWarning(Warning):
 
 def warn(message: str, _class: type[Warning] = ModelWarning):
     """Raises the specified type of warning."""
+    formatwarning = warnings.formatwarning
+
     warnings.formatwarning = (
         lambda message, category, *args, **kwargs: f"{category.__name__}: {message}\n"
     )
-    warnings.warn(message, _class)
-    warnings.formatwarning = warnings._formatwarning_orig
+    try:
+        warnings.warn(message, _class)
+    finally:
+        warnings.formatwarning = formatwarning
 
 
 def print_warnings_and_raise_errors(

--- a/src/calliope/exceptions.py
+++ b/src/calliope/exceptions.py
@@ -34,8 +34,8 @@ def warn(message: str, _class: type[Warning] = ModelWarning):
     """Raises the specified type of warning."""
     formatwarning = warnings.formatwarning
 
-    warnings.formatwarning = (
-        lambda message, category, *args, **kwargs: f"{category.__name__}: {message}\n"
+    warnings.formatwarning = lambda message, category, *args, **kwargs: (
+        f"{category.__name__}: {message}\n"
     )
     try:
         warnings.warn(message, _class)

--- a/src/calliope/math/base.yaml
+++ b/src/calliope/math/base.yaml
@@ -701,7 +701,7 @@ constraints:
         - where: "sink_unit==per_area"
           expression: "area_use"
         - where: "sink_unit==per_cap"
-          expression: "sum(flow_cap, over=carriers)"
+          expression: "sum(where(flow_cap, carrier_in), over=carriers)"
         - where: "sink_unit==absolute"
           expression: "1"
 
@@ -766,7 +766,7 @@ constraints:
         - where: "source_unit==per_area"
           expression: "area_use"
         - where: "source_unit==per_cap"
-          expression: "sum(flow_cap, over=carriers)"
+          expression: "sum(where(flow_cap, carrier_out), over=carriers)"
         - where: "source_unit==absolute"
           expression: "1"
 

--- a/tests/backend/expression_parser_test.py
+++ b/tests/backend/expression_parser_test.py
@@ -1233,7 +1233,7 @@ class TestApplyDefault:
         The sum helper function should receive an array with defaults applied and then the where array applied on top of that.
         """
         parsed_ = helper_function_allow_arithmetic.parse_string(
-            "sum(1 + where(with_inf, with_inf_as_bool)), over=[nodes, techs])",
+            "sum(1 + where(with_inf, with_inf_as_bool), over=[nodes, techs])",
             parse_all=True,
         )
         evaluated_ = self.assert_method_called(2, parsed_[0], **eval_kwargs)

--- a/tests/backend/expression_parser_test.py
+++ b/tests/backend/expression_parser_test.py
@@ -1283,7 +1283,12 @@ class TestApplyWhereArray:
             assert spy_method.call_count == n_calls
         return evaluated_
 
-    def test_apply_where_array_not_called_for_bare_component(
+    def test_apply_where_array_not_called_for_number(self, number, eval_kwargs):
+        """Baseline: _apply_where_array is NOT called when evaluating a component directly (no arithmetic/comparison context)."""
+        parsed_ = number.parse_string("1", parse_all=True)
+        self.assert_method_called(0, parsed_[0], **eval_kwargs)
+
+    def test_apply_where_array_called_for_unsliced_component(
         self, unsliced_param_with_obj_names, eval_kwargs
     ):
         """Baseline: _apply_where_array is NOT called when evaluating a component directly (no arithmetic/comparison context)."""
@@ -1341,6 +1346,18 @@ class TestApplyWhereArray:
             parsed_[0],
             eval_kwargs["return_type"],
             replace(eval_kwargs["eval_attrs"], where_array=where),
+        )
+        assert not evaluated_.isnull().any()
+
+    def test_apply_where_array_do_not_apply(self, arithmetic, eval_kwargs):
+        """With apply_where=False, no values are masked out — NaN-filled defaults are preserved."""
+        parsed_ = arithmetic.parse_string("with_inf + 1", parse_all=True)
+        where = xr.DataArray(False)
+        evaluated_ = self.assert_method_called(
+            2,
+            parsed_[0],
+            eval_kwargs["return_type"],
+            replace(eval_kwargs["eval_attrs"], where_array=where, apply_where=False),
         )
         assert not evaluated_.isnull().any()
 
@@ -1407,6 +1424,4 @@ class TestApplyWhereArray:
         # For techs where only_techs is defined and where_array is True, values should match
         # only_techs values: [5 (default-filled), 1, 2, 3] after default is applied
         # with_inf_as_bool techs row: [False, True, True, True] (for nodes=foo)
-        assert (
-            evaluated_.sel(nodes="foo", techs="foobar").item() == 5.0
-        )  # filled from default
+        assert evaluated_.sel(nodes="foo", techs="foobar").item() == 5.0

--- a/tests/backend/expression_parser_test.py
+++ b/tests/backend/expression_parser_test.py
@@ -353,8 +353,8 @@ class TestEquationParserElements:
         self, unsliced_param_with_obj_names, eval_kwargs, string_val
     ):
         parsed_ = unsliced_param_with_obj_names.parse_string(string_val, parse_all=True)
-        default = eval_kwargs["eval_attrs"].math.parameters[string_val].default
-        expected = eval_kwargs["eval_attrs"].backend_data[string_val].fillna(default)
+        # We do not expect defaults to have been applied to raw unsliced objects
+        expected = eval_kwargs["eval_attrs"].backend_data[string_val]
         assert parsed_[0].eval(**eval_kwargs).equals(expected)
 
     def test_unsliced_param_references(
@@ -1011,3 +1011,256 @@ class TestAsMathString:
         parsed_ = parser_func.parse_string(instring, parse_all=True)
         evaluated_ = parsed_[0].eval(**latex_eval_kwargs)
         assert evaluated_ == expected
+
+
+class TestApplyDefault:
+    """Test that _apply_default correctly fills NaN values with defaults from math definitions.
+
+    Note: _apply_default is only called in specific evaluation contexts:
+    - EvalSignOp (unary +/-)
+    - EvalOperatorOperand (binary arithmetic through _apply_where_array)
+    - EvalComparisonOp (comparison operations)
+
+    It is NOT called when directly evaluating unsliced/sliced components or in helper functions.
+    """
+
+    @pytest.mark.parametrize(
+        ("component", "default_value", "nan_count_before"),
+        [
+            ("with_inf", 100, 2),  # Has NaN values, has default
+            ("only_techs", 5, 1),  # Has NaN values, has default
+            ("no_dims", 0, 0),  # No NaN values
+        ],
+    )
+    def test_apply_default_context_unsliced_component_baseline(
+        self,
+        unsliced_param_with_obj_names,
+        eval_kwargs,
+        component,
+        default_value,
+        nan_count_before,
+    ):
+        """Test baseline: EvalUnslicedComponent does NOT call _apply_default directly.
+
+        This test verifies that when we evaluate a component directly (not in an arithmetic
+        or comparison context), NaN values are NOT filled with defaults.
+        """
+        parsed_ = unsliced_param_with_obj_names.parse_string(component, parse_all=True)
+
+        # Check NaN count before
+        original_data = eval_kwargs["eval_attrs"].backend_data[component]
+        actual_nan_before = (
+            pd.isnull(original_data).sum().item()
+            if original_data.size > 1
+            else (1 if pd.isnull(original_data) else 0)
+        )
+        assert actual_nan_before == nan_count_before
+
+        # Evaluate WITHOUT arithmetic/comparison context
+        evaluated_ = parsed_[0].eval(**eval_kwargs)
+
+        # NaN count should be UNCHANGED because _apply_default is not called
+        actual_nan_after = (
+            pd.isnull(evaluated_).sum().item()
+            if evaluated_.size > 1
+            else (1 if pd.isnull(evaluated_) else 0)
+        )
+        assert actual_nan_after == nan_count_before, (
+            f"Direct evaluation should not apply defaults - expected {nan_count_before} NaN, got {actual_nan_after}"
+        )
+
+    @pytest.mark.parametrize(
+        ("component", "expected_filled_value"),
+        [
+            ("with_inf", 100),  # default=100
+            ("only_techs", 5),  # default=5
+        ],
+    )
+    def test_apply_default_in_sign_operation(
+        self, arithmetic, eval_kwargs, component, expected_filled_value
+    ):
+        """Test that _apply_default is applied in unary sign operations (EvalSignOp).
+
+        EvalSignOp.as_array() calls _apply_default directly.
+        """
+        # Test negative sign
+        parsed_neg = arithmetic.parse_string(f"-{component}", parse_all=True)
+        evaluated_neg = parsed_neg[0].eval(**eval_kwargs)
+
+        # After applying default in sign operation, should have no NaN
+        assert not pd.isnull(evaluated_neg).any(), (
+            f"Sign operation should apply defaults for {component}"
+        )
+
+        # Test positive sign
+        parsed_pos = arithmetic.parse_string(f"+{component}", parse_all=True)
+        evaluated_pos = parsed_pos[0].eval(**eval_kwargs)
+        assert not pd.isnull(evaluated_pos).any(), (
+            f"Sign operation should apply defaults for {component}"
+        )
+
+    @pytest.mark.parametrize(
+        ("component", "expected_filled_value", "nan_index"),
+        [
+            ("with_inf", 100, (0, 1)),  # NaN at nodes=foo, techs=bar
+            ("only_techs", 5, 0),  # NaN at techs=foobar
+        ],
+    )
+    def test_apply_default_in_arithmetic_operations(
+        self, arithmetic, eval_kwargs, component, expected_filled_value, nan_index
+    ):
+        """Test that _apply_default is applied in arithmetic operations (EvalOperatorOperand).
+
+        EvalOperatorOperand.as_array() calls _apply_where_array, which calls _apply_default.
+        """
+        # with_inf + 1, where with_inf has default=100 for NaN values
+        parsed_ = arithmetic.parse_string(f"{component} + 1", parse_all=True)
+        evaluated_ = parsed_[0].eval(**eval_kwargs)
+
+        # After applying default and adding 1, should have no NaN
+        assert not pd.isnull(evaluated_).any(), (
+            "Arithmetic operation should apply defaults"
+        )
+
+        # Check that the previously NaN value is now filled with default + 1
+        if isinstance(nan_index, tuple):
+            filled_value = evaluated_.isel(
+                nodes=nan_index[0], techs=nan_index[1]
+            ).item()
+        else:
+            filled_value = evaluated_.isel(techs=nan_index).item()
+        assert filled_value == expected_filled_value + 1
+
+    @pytest.mark.parametrize("operator", ["*", "/", "-", "**"])
+    def test_apply_default_various_arithmetic_operators(
+        self, arithmetic, eval_kwargs, operator
+    ):
+        """Test _apply_default works with all arithmetic operators."""
+        parsed_ = arithmetic.parse_string(f"with_inf {operator} 2", parse_all=True)
+        evaluated_ = parsed_[0].eval(**eval_kwargs)
+
+        # Should apply default before any arithmetic operation
+        assert not pd.isnull(evaluated_).any()
+
+    def test_apply_default_preserves_non_nan_values_in_arithmetic(
+        self, arithmetic, eval_kwargs
+    ):
+        """Test that _apply_default only fills NaN values and preserves other values in arithmetic context."""
+        # with_inf has some non-NaN values that should be preserved when defaults are applied
+        # Evaluate with arithmetic (which triggers _apply_default)
+        parsed_ = arithmetic.parse_string("with_inf + 0", parse_all=True)
+        evaluated_ = parsed_[0].eval(**eval_kwargs)
+
+        # Verify the evaluation completed successfully and has the expected shape
+        assert isinstance(evaluated_, xr.DataArray)
+        assert evaluated_.shape == (2, 4)  # nodes x techs
+
+        # After applying defaults, there should be no NaN values in the result
+        # (with_inf has default=100, so all NaN should be filled)
+        assert not pd.isnull(evaluated_).any()
+
+    def test_apply_default_no_default_defined_in_arithmetic(
+        self, arithmetic, eval_kwargs
+    ):
+        """Test that components without a defined default still work in arithmetic.
+
+        Components without defaults in the math definition should still be usable,
+        they just won't have NaN values filled.
+        """
+        # multi_dim_var is a decision variable without a default value
+        parsed_ = arithmetic.parse_string("multi_dim_var + 0", parse_all=True)
+        # Should evaluate without error even though no default is defined
+        evaluated_ = parsed_[0].eval(**eval_kwargs)
+        assert isinstance(evaluated_, xr.DataArray)
+
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            "with_inf + only_techs",  # Both have defaults
+            "with_inf * only_techs",
+            "with_inf - only_techs",
+            "with_inf / only_techs",
+        ],
+    )
+    def test_apply_default_multiple_components_in_expression(
+        self, arithmetic, eval_kwargs, expression
+    ):
+        """Test that _apply_default is applied to all components in complex expressions."""
+        parsed_ = arithmetic.parse_string(expression, parse_all=True)
+        evaluated_ = parsed_[0].eval(**eval_kwargs)
+
+        # Both with_inf and only_techs have defaults, so result should have no NaN
+        assert not pd.isnull(evaluated_).any()
+
+    def test_apply_default_nested_arithmetic(self, arithmetic, eval_kwargs):
+        """Test _apply_default in nested arithmetic expressions."""
+        # Complex nested expression with components that have defaults
+        parsed_ = arithmetic.parse_string(
+            "(with_inf + 1) * (only_techs - 2)", parse_all=True
+        )
+        evaluated_ = parsed_[0].eval(**eval_kwargs)
+
+        # Defaults should be applied at each level
+        assert not pd.isnull(evaluated_).any()
+
+    def test_apply_default_power_operation(self, arithmetic, eval_kwargs):
+        """Test _apply_default with power operations."""
+        parsed_ = arithmetic.parse_string("only_techs ** 2", parse_all=True)
+        evaluated_ = parsed_[0].eval(**eval_kwargs)
+
+        # only_techs has default=5, so NaN should be filled before power operation
+        assert not pd.isnull(evaluated_).any()
+        # The NaN value at index 0 should now be 5**2=25
+        assert evaluated_.isel(techs=0).item() == 25
+
+    def test_apply_default_in_helper_function_with_negation(
+        self, helper_function_allow_arithmetic, eval_kwargs
+    ):
+        """Test that _apply_default is applied when negation is passed to helper function.
+
+        The sum helper function should receive an array with defaults applied and then the where array applied on top of that.
+        """
+        # Test sum over negation of with_inf
+        parsed_ = helper_function_allow_arithmetic.parse_string(
+            "sum(-with_inf, over=[nodes, techs])", parse_all=True
+        )
+        where = eval_kwargs["eval_attrs"].input_data.with_inf_and_only_techs_as_bool
+        evaluated_ = parsed_[0].eval(
+            eval_kwargs["return_type"],
+            replace(eval_kwargs["eval_attrs"], where_array=where),
+        )
+        assert evaluated_.item()() == -7
+
+    def test_apply_default_in_helper_function_with_arithmetic(
+        self, helper_function_allow_arithmetic, eval_kwargs
+    ):
+        """Test that _apply_default is applied when arithmetic is passed to helper function.
+
+        The sum helper function should receive an array with defaults already applied
+        when the input is an arithmetic expression (e.g., sum(with_inf + 1, over=[...])).
+        """
+        # Test sum over arithmetic with with_inf
+        parsed_ = helper_function_allow_arithmetic.parse_string(
+            "sum(with_inf + 1, over=[nodes, techs])", parse_all=True
+        )
+        where = eval_kwargs["eval_attrs"].input_data.with_inf_and_only_techs_as_bool
+        evaluated_ = parsed_[0].eval(
+            eval_kwargs["return_type"],
+            replace(eval_kwargs["eval_attrs"], where_array=where),
+        )
+        assert evaluated_.item()() == 11
+
+    def test_apply_default_generic_string_edge_case(
+        self, evaluatable_identifier, eval_kwargs
+    ):
+        """Test edge case where EvalGenericString returns an array with same name as math component.
+
+        EvalGenericString creates a DataArray with the string as both name and value.
+        This should NOT trigger _apply_default since it's not in an arithmetic/sign/comparison context.
+        """
+        parsed_ = evaluatable_identifier.parse_string("hello", parse_all=True)
+        evaluated_ = parsed_[0].eval(**eval_kwargs)
+
+        # This should evaluate to the string "hello" as a scalar DataArray
+        assert evaluated_.item() == "hello"
+        assert evaluated_.name == "hello"

--- a/tests/backend/expression_parser_test.py
+++ b/tests/backend/expression_parser_test.py
@@ -50,7 +50,9 @@ def valid_component_names():
         "multi_dim_var",
         "no_dim_var",
         "all_true",
+        "all_ones",
         "only_techs_as_bool",
+        "with_inf_as_bool",
     ]
 
 
@@ -205,7 +207,10 @@ def helper_function_allow_arithmetic(
 ):
     arithmetic = pp.Forward()
     helper_func = expression_parser.helper_function_parser(
-        arithmetic, helper_func_list, generic_identifier=identifier
+        arithmetic,
+        helper_func_list,
+        generic_identifier=identifier,
+        allow_function_in_function=True,
     )
     return expression_parser.arithmetic_parser(
         helper_func,
@@ -355,8 +360,8 @@ class TestEquationParserElements:
         self, unsliced_param_with_obj_names, eval_kwargs, string_val
     ):
         parsed_ = unsliced_param_with_obj_names.parse_string(string_val, parse_all=True)
-        # We do not expect defaults to have been applied to raw unsliced objects
-        expected = eval_kwargs["eval_attrs"].backend_data[string_val]
+        default = eval_kwargs["eval_attrs"].math.parameters[string_val].default
+        expected = eval_kwargs["eval_attrs"].backend_data[string_val].fillna(default)
         assert parsed_[0].eval(**eval_kwargs).equals(expected)
 
     def test_unsliced_param_references(
@@ -1038,7 +1043,7 @@ class TestApplyDefault:
 
     @pytest.mark.parametrize(("component"), ["with_inf", "only_techs", "all_true"])
     def test_apply_default_context_unsliced_component_baseline(
-        self, unsliced_param_with_obj_names, eval_kwargs, dummy_model_data, component
+        self, unsliced_param_with_obj_names, eval_kwargs, component
     ):
         """Test baseline: EvalUnslicedComponent does NOT call _apply_default directly.
 
@@ -1046,14 +1051,11 @@ class TestApplyDefault:
         or comparison context), NaN values are NOT filled with defaults.
         """
         parsed_ = unsliced_param_with_obj_names.parse_string(component, parse_all=True)
-        component_nulls = dummy_model_data[component].isnull()
 
         # Evaluate WITHOUT arithmetic/comparison context
         evaluated_ = parsed_[0].eval(**eval_kwargs)
 
-        assert evaluated_.isnull().equals(component_nulls), (
-            f"Direct evaluation should not apply defaults - expected {component_nulls.sum()} NaN, got {evaluated_.isnull().sum()}"
-        )
+        assert evaluated_.notnull().any()
 
     def test_apply_default_in_sign_operation(self, arithmetic, eval_kwargs):
         """Test that _apply_default is applied in unary sign operations (EvalSignOp).
@@ -1083,7 +1085,7 @@ class TestApplyDefault:
         """
         # with_inf + 1, where with_inf has default=100 for NaN values
         parsed_ = arithmetic.parse_string(f"{component} + 1", parse_all=True)
-        evaluated_ = self.assert_method_called(2, parsed_[0], **eval_kwargs)
+        evaluated_ = self.assert_method_called(1, parsed_[0], **eval_kwargs)
 
         # After applying default and adding 1, should have no NaN
         assert not pd.isnull(evaluated_).any(), (
@@ -1105,7 +1107,7 @@ class TestApplyDefault:
     ):
         """Test _apply_default works with all arithmetic operators."""
         parsed_ = arithmetic.parse_string(f"with_inf {operator} 2", parse_all=True)
-        evaluated_ = self.assert_method_called(2, parsed_[0], **eval_kwargs)
+        evaluated_ = self.assert_method_called(1, parsed_[0], **eval_kwargs)
 
         # Should apply default before any arithmetic operation
         assert not pd.isnull(evaluated_).any()
@@ -1117,7 +1119,7 @@ class TestApplyDefault:
         # with_inf has some non-NaN values that should be preserved when defaults are applied
         # Evaluate with arithmetic (which triggers _apply_default)
         parsed_ = arithmetic.parse_string("with_inf + 0", parse_all=True)
-        evaluated_ = self.assert_method_called(2, parsed_[0], **eval_kwargs)
+        evaluated_ = self.assert_method_called(1, parsed_[0], **eval_kwargs)
 
         # Verify the evaluation completed successfully and has the expected shape
         assert isinstance(evaluated_, xr.DataArray)
@@ -1138,7 +1140,7 @@ class TestApplyDefault:
         # multi_dim_var is a decision variable without a default value
         parsed_ = arithmetic.parse_string("multi_dim_var + 0", parse_all=True)
         # Should evaluate without error even though no default is defined
-        evaluated_ = self.assert_method_called(2, parsed_[0], **eval_kwargs)
+        evaluated_ = self.assert_method_called(1, parsed_[0], **eval_kwargs)
         assert isinstance(evaluated_, xr.DataArray)
 
     @pytest.mark.parametrize(
@@ -1166,7 +1168,7 @@ class TestApplyDefault:
         parsed_ = arithmetic.parse_string(
             "(with_inf + 1) * (only_techs - 2)", parse_all=True
         )
-        evaluated_ = self.assert_method_called(6, parsed_[0], **eval_kwargs)
+        evaluated_ = self.assert_method_called(2, parsed_[0], **eval_kwargs)
 
         # Defaults should be applied at each level
         assert not pd.isnull(evaluated_).any()
@@ -1174,7 +1176,7 @@ class TestApplyDefault:
     def test_apply_default_power_operation(self, arithmetic, eval_kwargs):
         """Test _apply_default with power operations."""
         parsed_ = arithmetic.parse_string("only_techs ** 2", parse_all=True)
-        evaluated_ = self.assert_method_called(2, parsed_[0], **eval_kwargs)
+        evaluated_ = self.assert_method_called(1, parsed_[0], **eval_kwargs)
 
         # only_techs has default=5, so NaN should be filled before power operation
         assert not pd.isnull(evaluated_).any()
@@ -1184,22 +1186,58 @@ class TestApplyDefault:
     def test_apply_default_in_helper_function_with_negation(
         self, helper_function_allow_arithmetic, eval_kwargs
     ):
-        """Test that _apply_default is applied when negation is passed to helper function.
-
-        The sum helper function should receive an array with defaults applied and then the where array applied on top of that.
-        """
+        """Test that _apply_default is applied when negation is passed to helper function."""
         # Test sum over negation of with_inf
         parsed_ = helper_function_allow_arithmetic.parse_string(
             "sum(-with_inf, over=[nodes, techs])", parse_all=True
         )
-        where = eval_kwargs["eval_attrs"].input_data.with_inf_and_only_techs_as_bool
-        evaluated_ = self.assert_method_called(
-            1,
-            parsed_[0],
-            eval_kwargs["return_type"],
-            replace(eval_kwargs["eval_attrs"], where_array=where),
+        evaluated_ = self.assert_method_called(1, parsed_[0], **eval_kwargs)
+        assert evaluated_.item()() == -float("inf")
+
+    def test_apply_default_in_helper_function_with_where_func(
+        self, helper_function, eval_kwargs
+    ):
+        """Test that _apply_default is applied before the where function in helper functions.
+        Without the `where` helper function, we would get inf.
+
+        The sum helper function should receive an array with defaults applied and then the where array applied on top of that.
+        """
+        parsed_ = helper_function.parse_string(
+            "sum(where(with_inf, with_inf_as_bool), over=[nodes, techs])",
+            parse_all=True,
         )
-        assert evaluated_.item()() == -7
+        evaluated_ = self.assert_method_called(2, parsed_[0], **eval_kwargs)
+        assert evaluated_.item()() == 8
+
+    def test_apply_default_in_helper_function_arithmetic_after_where(
+        self, helper_function_allow_arithmetic, eval_kwargs
+    ):
+        """Test that _apply_default is applied before arithmetic operations _and_ the where function in helper functions.
+        Without the `where` helper function, we would get inf.
+
+        The sum helper function should receive an array with defaults applied and then the where array applied on top of that.
+        """
+        parsed_ = helper_function_allow_arithmetic.parse_string(
+            "sum(where(with_inf + 1, with_inf_as_bool), over=[nodes, techs])",
+            parse_all=True,
+        )
+        evaluated_ = self.assert_method_called(2, parsed_[0], **eval_kwargs)
+        assert evaluated_.item()() == 13
+
+    def test_apply_default_in_helper_function_with_arithmetic_before_where(
+        self, helper_function_allow_arithmetic, eval_kwargs
+    ):
+        """Test that _apply_default is applied before arithmetic operations _and_ the where function in helper functions.
+        Without the `where` helper function, we would get inf.
+
+        The sum helper function should receive an array with defaults applied and then the where array applied on top of that.
+        """
+        parsed_ = helper_function_allow_arithmetic.parse_string(
+            "sum(1 + where(with_inf, with_inf_as_bool)), over=[nodes, techs])",
+            parse_all=True,
+        )
+        evaluated_ = self.assert_method_called(2, parsed_[0], **eval_kwargs)
+        assert evaluated_.item()() == 13
 
     def test_apply_default_in_helper_function_with_arithmetic(
         self, helper_function_allow_arithmetic, eval_kwargs
@@ -1216,10 +1254,159 @@ class TestApplyDefault:
         )
         where = eval_kwargs["eval_attrs"].input_data.with_inf_and_only_techs_as_bool
         evaluated_ = self.assert_method_called(
-            2,
+            1,
             parsed_[0],
             eval_kwargs["return_type"],
             replace(eval_kwargs["eval_attrs"], where_array=where),
         )
 
         assert evaluated_.item()() == 11
+
+
+class TestApplyWhereArray:
+    """Test that _apply_where_array correctly broadcasts and masks arrays using the where_array.
+
+    _apply_where_array is called in:
+    - EvalOperatorOperand.as_array() — once per operand in binary arithmetic
+    - EvalComparisonOp.as_array() — once for each of LHS and RHS
+
+    It is NOT called when directly evaluating unsliced/sliced components.
+    """
+
+    def assert_method_called(self, n_calls, parsed, *args, **kwargs) -> Any:
+        with patch.object(
+            expression_parser.EvalArrayOrMath,
+            "_apply_where_array",
+            wraps=parsed._apply_where_array,
+        ) as spy_method:
+            evaluated_ = parsed.eval(*args, **kwargs)
+            assert spy_method.call_count == n_calls
+        return evaluated_
+
+    def test_apply_where_array_not_called_for_bare_component(
+        self, unsliced_param_with_obj_names, eval_kwargs
+    ):
+        """Baseline: _apply_where_array is NOT called when evaluating a component directly (no arithmetic/comparison context)."""
+        parsed_ = unsliced_param_with_obj_names.parse_string("with_inf", parse_all=True)
+        self.assert_method_called(0, parsed_[0], **eval_kwargs)
+
+    @pytest.mark.parametrize("operator", ["+", "-", "*", "/", "**"])
+    def test_apply_where_array_called_per_operand_in_arithmetic(
+        self, arithmetic, eval_kwargs, operator
+    ):
+        """_apply_where_array is called once for each of the two operands in a binary arithmetic expression."""
+        parsed_ = arithmetic.parse_string(
+            f"all_ones {operator} all_ones", parse_all=True
+        )
+        self.assert_method_called(2, parsed_[0], **eval_kwargs)
+
+    def test_apply_where_array_called_for_all_operands_in_chained_arithmetic(
+        self, arithmetic, eval_kwargs
+    ):
+        """_apply_where_array is called once for each operand across all terms in a chained arithmetic expression."""
+        parsed_ = arithmetic.parse_string(
+            "all_ones + all_ones + no_dims", parse_all=True
+        )
+        self.assert_method_called(3, parsed_[0], **eval_kwargs)
+
+    def test_apply_where_array_called_in_comparison(
+        self, equation_comparison, eval_kwargs
+    ):
+        """_apply_where_array is called once each for the LHS and RHS of a comparison operation."""
+        parsed_ = equation_comparison.parse_string("1 == 1", parse_all=True)
+        self.assert_method_called(2, parsed_[0], **eval_kwargs)
+
+    def test_broadcast_in_apply_where_array_called_in_comparison(
+        self, equation_comparison, eval_kwargs
+    ):
+        """_apply_where_array broadcasts both LHS and RHS to the where_array shape in a comparison."""
+        where = eval_kwargs["eval_attrs"].input_data["all_true"]
+        parsed_ = equation_comparison.parse_string("all_ones == 1", parse_all=True)
+        evaluated_ = self.assert_method_called(
+            2,
+            parsed_[0],
+            eval_kwargs["return_type"],
+            replace(eval_kwargs["eval_attrs"], where_array=where),
+        )
+        assert evaluated_.dims == ("nodes", "techs")
+
+    def test_apply_where_array_default_true_does_not_mask(
+        self, arithmetic, eval_kwargs
+    ):
+        """With where_array=True (scalar), no values are masked out — NaN-filled defaults are preserved."""
+        parsed_ = arithmetic.parse_string("with_inf + 1", parse_all=True)
+        where = xr.DataArray(True)
+        evaluated_ = self.assert_method_called(
+            2,
+            parsed_[0],
+            eval_kwargs["return_type"],
+            replace(eval_kwargs["eval_attrs"], where_array=where),
+        )
+        assert not evaluated_.isnull().any()
+
+    def test_apply_where_array_masks_false_positions(
+        self, arithmetic, eval_kwargs, dummy_model_data
+    ):
+        """Positions where where_array is False are set to NaN in the result."""
+        where = dummy_model_data.with_inf_as_bool
+        parsed_ = arithmetic.parse_string("all_ones + 0", parse_all=True)
+        evaluated_ = self.assert_method_called(
+            2,
+            parsed_[0],
+            eval_kwargs["return_type"],
+            replace(eval_kwargs["eval_attrs"], where_array=where),
+        )
+        assert evaluated_.isnull().sum() == 3
+
+    def test_apply_where_array_preserves_unmasked_values(
+        self, arithmetic, eval_kwargs, dummy_model_data
+    ):
+        """Positions where where_array is True retain their computed arithmetic values."""
+        where = dummy_model_data.with_inf_as_bool
+        parsed_ = arithmetic.parse_string("all_ones * 3", parse_all=True)
+        evaluated_ = self.assert_method_called(
+            2,
+            parsed_[0],
+            eval_kwargs["return_type"],
+            replace(eval_kwargs["eval_attrs"], where_array=where),
+        )
+
+        non_nan_values = evaluated_.to_series()[where.to_series()].apply(lambda x: x())
+        assert (non_nan_values == 3.0).all()
+
+    def test_apply_where_array_broadcasts_lower_dim_array(
+        self, arithmetic, eval_kwargs, dummy_model_data
+    ):
+        """A 1D array is broadcast to the shape of a 2D where_array, giving a 2D result."""
+        where = dummy_model_data.with_inf_as_bool  # shape: (nodes, techs)
+        # only_techs is 1D (techs); after broadcast against (nodes, techs) where_array, result is 2D
+        parsed_ = arithmetic.parse_string("only_techs + 0", parse_all=True)
+        evaluated_ = self.assert_method_called(
+            2,
+            parsed_[0],
+            eval_kwargs["return_type"],
+            replace(eval_kwargs["eval_attrs"], where_array=where),
+        )
+
+        assert set(evaluated_.dims) == {"nodes", "techs"}
+
+    def test_apply_where_array_broadcast_values_match_original(
+        self, arithmetic, eval_kwargs, dummy_model_data
+    ):
+        """After broadcasting a 1D array, unmasked positions hold the original values (with defaults applied)."""
+        where = dummy_model_data.with_inf_as_bool  # shape: (nodes, techs)
+        # only_techs = [nan, 1, 2, 3]; default=5 fills the NaN before arithmetic
+        parsed_ = arithmetic.parse_string("only_techs + 0", parse_all=True)
+        evaluated_ = self.assert_method_called(
+            2,
+            parsed_[0],
+            eval_kwargs["return_type"],
+            replace(eval_kwargs["eval_attrs"], where_array=where),
+        )
+
+        # For techs where only_techs is defined and where_array is True, values should match
+        # only_techs values: [5 (default-filled), 1, 2, 3] after default is applied
+        # with_inf_as_bool techs row: [False, True, True, True] (for nodes=foo)
+        assert (
+            evaluated_.sel(nodes="foo", techs="foobar").item() == 5.0
+        )  # filled from default

--- a/tests/backend/expression_parser_test.py
+++ b/tests/backend/expression_parser_test.py
@@ -1083,9 +1083,7 @@ class TestApplyDefault:
         """
         # with_inf + 1, where with_inf has default=100 for NaN values
         parsed_ = arithmetic.parse_string(f"{component} + 1", parse_all=True)
-        evaluated_ = evaluated_ = self.assert_method_called(
-            2, parsed_[0], **eval_kwargs
-        )
+        evaluated_ = self.assert_method_called(2, parsed_[0], **eval_kwargs)
 
         # After applying default and adding 1, should have no NaN
         assert not pd.isnull(evaluated_).any(), (
@@ -1107,9 +1105,7 @@ class TestApplyDefault:
     ):
         """Test _apply_default works with all arithmetic operators."""
         parsed_ = arithmetic.parse_string(f"with_inf {operator} 2", parse_all=True)
-        evaluated_ = evaluated_ = self.assert_method_called(
-            2, parsed_[0], **eval_kwargs
-        )
+        evaluated_ = self.assert_method_called(2, parsed_[0], **eval_kwargs)
 
         # Should apply default before any arithmetic operation
         assert not pd.isnull(evaluated_).any()
@@ -1121,9 +1117,7 @@ class TestApplyDefault:
         # with_inf has some non-NaN values that should be preserved when defaults are applied
         # Evaluate with arithmetic (which triggers _apply_default)
         parsed_ = arithmetic.parse_string("with_inf + 0", parse_all=True)
-        evaluated_ = evaluated_ = self.assert_method_called(
-            2, parsed_[0], **eval_kwargs
-        )
+        evaluated_ = self.assert_method_called(2, parsed_[0], **eval_kwargs)
 
         # Verify the evaluation completed successfully and has the expected shape
         assert isinstance(evaluated_, xr.DataArray)
@@ -1144,9 +1138,7 @@ class TestApplyDefault:
         # multi_dim_var is a decision variable without a default value
         parsed_ = arithmetic.parse_string("multi_dim_var + 0", parse_all=True)
         # Should evaluate without error even though no default is defined
-        evaluated_ = evaluated_ = self.assert_method_called(
-            2, parsed_[0], **eval_kwargs
-        )
+        evaluated_ = self.assert_method_called(2, parsed_[0], **eval_kwargs)
         assert isinstance(evaluated_, xr.DataArray)
 
     @pytest.mark.parametrize(
@@ -1163,9 +1155,7 @@ class TestApplyDefault:
     ):
         """Test that _apply_default is applied to all components in complex expressions."""
         parsed_ = arithmetic.parse_string(expression, parse_all=True)
-        evaluated_ = evaluated_ = self.assert_method_called(
-            2, parsed_[0], **eval_kwargs
-        )
+        evaluated_ = self.assert_method_called(2, parsed_[0], **eval_kwargs)
 
         # Both with_inf and only_techs have defaults, so result should have no NaN
         assert not pd.isnull(evaluated_).any()
@@ -1176,9 +1166,7 @@ class TestApplyDefault:
         parsed_ = arithmetic.parse_string(
             "(with_inf + 1) * (only_techs - 2)", parse_all=True
         )
-        evaluated_ = evaluated_ = self.assert_method_called(
-            6, parsed_[0], **eval_kwargs
-        )
+        evaluated_ = self.assert_method_called(6, parsed_[0], **eval_kwargs)
 
         # Defaults should be applied at each level
         assert not pd.isnull(evaluated_).any()

--- a/tests/backend/expression_parser_test.py
+++ b/tests/backend/expression_parser_test.py
@@ -1,6 +1,8 @@
 import operator
 import random
 from dataclasses import replace
+from typing import Any
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -1024,21 +1026,19 @@ class TestApplyDefault:
     It is NOT called when directly evaluating unsliced/sliced components or in helper functions.
     """
 
-    @pytest.mark.parametrize(
-        ("component", "default_value", "nan_count_before"),
-        [
-            ("with_inf", 100, 2),  # Has NaN values, has default
-            ("only_techs", 5, 1),  # Has NaN values, has default
-            ("no_dims", 0, 0),  # No NaN values
-        ],
-    )
+    def assert_method_called(self, n_calls, parsed, *args, **kwargs) -> Any:
+        with patch.object(
+            expression_parser.EvalArrayOrMath,
+            "_apply_default",
+            wraps=parsed._apply_default,
+        ) as spy_method:
+            evaluated_ = parsed.eval(*args, **kwargs)
+            assert spy_method.call_count == n_calls
+        return evaluated_
+
+    @pytest.mark.parametrize(("component"), ["with_inf", "only_techs", "all_true"])
     def test_apply_default_context_unsliced_component_baseline(
-        self,
-        unsliced_param_with_obj_names,
-        eval_kwargs,
-        component,
-        default_value,
-        nan_count_before,
+        self, unsliced_param_with_obj_names, eval_kwargs, dummy_model_data, component
     ):
         """Test baseline: EvalUnslicedComponent does NOT call _apply_default directly.
 
@@ -1046,58 +1046,26 @@ class TestApplyDefault:
         or comparison context), NaN values are NOT filled with defaults.
         """
         parsed_ = unsliced_param_with_obj_names.parse_string(component, parse_all=True)
-
-        # Check NaN count before
-        original_data = eval_kwargs["eval_attrs"].backend_data[component]
-        actual_nan_before = (
-            pd.isnull(original_data).sum().item()
-            if original_data.size > 1
-            else (1 if pd.isnull(original_data) else 0)
-        )
-        assert actual_nan_before == nan_count_before
+        component_nulls = dummy_model_data[component].isnull()
 
         # Evaluate WITHOUT arithmetic/comparison context
         evaluated_ = parsed_[0].eval(**eval_kwargs)
 
-        # NaN count should be UNCHANGED because _apply_default is not called
-        actual_nan_after = (
-            pd.isnull(evaluated_).sum().item()
-            if evaluated_.size > 1
-            else (1 if pd.isnull(evaluated_) else 0)
-        )
-        assert actual_nan_after == nan_count_before, (
-            f"Direct evaluation should not apply defaults - expected {nan_count_before} NaN, got {actual_nan_after}"
+        assert evaluated_.isnull().equals(component_nulls), (
+            f"Direct evaluation should not apply defaults - expected {component_nulls.sum()} NaN, got {evaluated_.isnull().sum()}"
         )
 
-    @pytest.mark.parametrize(
-        ("component", "expected_filled_value"),
-        [
-            ("with_inf", 100),  # default=100
-            ("only_techs", 5),  # default=5
-        ],
-    )
-    def test_apply_default_in_sign_operation(
-        self, arithmetic, eval_kwargs, component, expected_filled_value
-    ):
+    def test_apply_default_in_sign_operation(self, arithmetic, eval_kwargs):
         """Test that _apply_default is applied in unary sign operations (EvalSignOp).
 
         EvalSignOp.as_array() calls _apply_default directly.
         """
         # Test negative sign
-        parsed_neg = arithmetic.parse_string(f"-{component}", parse_all=True)
-        evaluated_neg = parsed_neg[0].eval(**eval_kwargs)
-
+        parsed_ = arithmetic.parse_string("-with_inf", parse_all=True)
+        evaluated_ = self.assert_method_called(1, parsed_[0], **eval_kwargs)
         # After applying default in sign operation, should have no NaN
-        assert not pd.isnull(evaluated_neg).any(), (
-            f"Sign operation should apply defaults for {component}"
-        )
-
-        # Test positive sign
-        parsed_pos = arithmetic.parse_string(f"+{component}", parse_all=True)
-        evaluated_pos = parsed_pos[0].eval(**eval_kwargs)
-        assert not pd.isnull(evaluated_pos).any(), (
-            f"Sign operation should apply defaults for {component}"
-        )
+        assert not pd.isnull(evaluated_).any()
+        assert evaluated_.isel(nodes=0, techs=1) == -100
 
     @pytest.mark.parametrize(
         ("component", "expected_filled_value", "nan_index"),
@@ -1115,7 +1083,9 @@ class TestApplyDefault:
         """
         # with_inf + 1, where with_inf has default=100 for NaN values
         parsed_ = arithmetic.parse_string(f"{component} + 1", parse_all=True)
-        evaluated_ = parsed_[0].eval(**eval_kwargs)
+        evaluated_ = evaluated_ = self.assert_method_called(
+            2, parsed_[0], **eval_kwargs
+        )
 
         # After applying default and adding 1, should have no NaN
         assert not pd.isnull(evaluated_).any(), (
@@ -1137,7 +1107,9 @@ class TestApplyDefault:
     ):
         """Test _apply_default works with all arithmetic operators."""
         parsed_ = arithmetic.parse_string(f"with_inf {operator} 2", parse_all=True)
-        evaluated_ = parsed_[0].eval(**eval_kwargs)
+        evaluated_ = evaluated_ = self.assert_method_called(
+            2, parsed_[0], **eval_kwargs
+        )
 
         # Should apply default before any arithmetic operation
         assert not pd.isnull(evaluated_).any()
@@ -1149,7 +1121,9 @@ class TestApplyDefault:
         # with_inf has some non-NaN values that should be preserved when defaults are applied
         # Evaluate with arithmetic (which triggers _apply_default)
         parsed_ = arithmetic.parse_string("with_inf + 0", parse_all=True)
-        evaluated_ = parsed_[0].eval(**eval_kwargs)
+        evaluated_ = evaluated_ = self.assert_method_called(
+            2, parsed_[0], **eval_kwargs
+        )
 
         # Verify the evaluation completed successfully and has the expected shape
         assert isinstance(evaluated_, xr.DataArray)
@@ -1170,7 +1144,9 @@ class TestApplyDefault:
         # multi_dim_var is a decision variable without a default value
         parsed_ = arithmetic.parse_string("multi_dim_var + 0", parse_all=True)
         # Should evaluate without error even though no default is defined
-        evaluated_ = parsed_[0].eval(**eval_kwargs)
+        evaluated_ = evaluated_ = self.assert_method_called(
+            2, parsed_[0], **eval_kwargs
+        )
         assert isinstance(evaluated_, xr.DataArray)
 
     @pytest.mark.parametrize(
@@ -1187,7 +1163,9 @@ class TestApplyDefault:
     ):
         """Test that _apply_default is applied to all components in complex expressions."""
         parsed_ = arithmetic.parse_string(expression, parse_all=True)
-        evaluated_ = parsed_[0].eval(**eval_kwargs)
+        evaluated_ = evaluated_ = self.assert_method_called(
+            2, parsed_[0], **eval_kwargs
+        )
 
         # Both with_inf and only_techs have defaults, so result should have no NaN
         assert not pd.isnull(evaluated_).any()
@@ -1198,7 +1176,9 @@ class TestApplyDefault:
         parsed_ = arithmetic.parse_string(
             "(with_inf + 1) * (only_techs - 2)", parse_all=True
         )
-        evaluated_ = parsed_[0].eval(**eval_kwargs)
+        evaluated_ = evaluated_ = self.assert_method_called(
+            6, parsed_[0], **eval_kwargs
+        )
 
         # Defaults should be applied at each level
         assert not pd.isnull(evaluated_).any()
@@ -1206,7 +1186,7 @@ class TestApplyDefault:
     def test_apply_default_power_operation(self, arithmetic, eval_kwargs):
         """Test _apply_default with power operations."""
         parsed_ = arithmetic.parse_string("only_techs ** 2", parse_all=True)
-        evaluated_ = parsed_[0].eval(**eval_kwargs)
+        evaluated_ = self.assert_method_called(2, parsed_[0], **eval_kwargs)
 
         # only_techs has default=5, so NaN should be filled before power operation
         assert not pd.isnull(evaluated_).any()
@@ -1225,7 +1205,9 @@ class TestApplyDefault:
             "sum(-with_inf, over=[nodes, techs])", parse_all=True
         )
         where = eval_kwargs["eval_attrs"].input_data.with_inf_and_only_techs_as_bool
-        evaluated_ = parsed_[0].eval(
+        evaluated_ = self.assert_method_called(
+            1,
+            parsed_[0],
             eval_kwargs["return_type"],
             replace(eval_kwargs["eval_attrs"], where_array=where),
         )
@@ -1239,28 +1221,17 @@ class TestApplyDefault:
         The sum helper function should receive an array with defaults already applied
         when the input is an arithmetic expression (e.g., sum(with_inf + 1, over=[...])).
         """
+
         # Test sum over arithmetic with with_inf
         parsed_ = helper_function_allow_arithmetic.parse_string(
             "sum(with_inf + 1, over=[nodes, techs])", parse_all=True
         )
         where = eval_kwargs["eval_attrs"].input_data.with_inf_and_only_techs_as_bool
-        evaluated_ = parsed_[0].eval(
+        evaluated_ = self.assert_method_called(
+            2,
+            parsed_[0],
             eval_kwargs["return_type"],
             replace(eval_kwargs["eval_attrs"], where_array=where),
         )
+
         assert evaluated_.item()() == 11
-
-    def test_apply_default_generic_string_edge_case(
-        self, evaluatable_identifier, eval_kwargs
-    ):
-        """Test edge case where EvalGenericString returns an array with same name as math component.
-
-        EvalGenericString creates a DataArray with the string as both name and value.
-        This should NOT trigger _apply_default since it's not in an arithmetic/sign/comparison context.
-        """
-        parsed_ = evaluatable_identifier.parse_string("hello", parse_all=True)
-        evaluated_ = parsed_[0].eval(**eval_kwargs)
-
-        # This should evaluate to the string "hello" as a scalar DataArray
-        assert evaluated_.item() == "hello"
-        assert evaluated_.name == "hello"

--- a/tests/backend/parsing_test.py
+++ b/tests/backend/parsing_test.py
@@ -1141,8 +1141,7 @@ class TestParsedObjective:
     def test_parse_objective_dict_evaluate_eq2(
         self, objective_obj, eval_where_args, eval_expr_args
     ):
-        """Since we fill with default values in the sum, the NaN `only_techs` value gets included, leading to a sum of 11.
-        """
+        """Since we fill with default values in the sum, the NaN `only_techs` value gets included, leading to a sum of 11."""
         valid_where = objective_obj.equations[1].evaluate_where(*eval_where_args)
         objective_expression = objective_obj.equations[1].evaluate_expression(
             *eval_expr_args, where=valid_where

--- a/tests/backend/parsing_test.py
+++ b/tests/backend/parsing_test.py
@@ -1141,9 +1141,7 @@ class TestParsedObjective:
     def test_parse_objective_dict_evaluate_eq2(
         self, objective_obj, eval_where_args, eval_expr_args
     ):
-        """Expression is `sum(only_techs, over=[techs]) + 1`.
-
-        Since we fill with default values in the sum, the NaN `only_techs` value gets included, leading to a sum of 11.
+        """Since we fill with default values in the sum, the NaN `only_techs` value gets included, leading to a sum of 11.
         """
         valid_where = objective_obj.equations[1].evaluate_where(*eval_where_args)
         objective_expression = objective_obj.equations[1].evaluate_expression(

--- a/tests/backend/parsing_test.py
+++ b/tests/backend/parsing_test.py
@@ -1143,11 +1143,11 @@ class TestParsedObjective:
     ):
         """Expression is `sum(only_techs, over=[techs]) + 1`.
 
-        Since we do not fill with default values in the sum, the NaN `only_techs` value gets ignored, leading to a sum of 6.
+        Since we fill with default values in the sum, the NaN `only_techs` value gets included, leading to a sum of 11.
         """
         valid_where = objective_obj.equations[1].evaluate_where(*eval_where_args)
         objective_expression = objective_obj.equations[1].evaluate_expression(
             *eval_expr_args, where=valid_where
         )
 
-        assert objective_expression.sum() == 7
+        assert objective_expression.sum() == 12

--- a/tests/backend/parsing_test.py
+++ b/tests/backend/parsing_test.py
@@ -1141,8 +1141,13 @@ class TestParsedObjective:
     def test_parse_objective_dict_evaluate_eq2(
         self, objective_obj, eval_where_args, eval_expr_args
     ):
+        """Expression is `sum(only_techs, over=[techs]) + 1`.
+
+        Since we do not fill with default values in the sum, the NaN `only_techs` value gets ignored, leading to a sum of 6.
+        """
         valid_where = objective_obj.equations[1].evaluate_where(*eval_where_args)
         objective_expression = objective_obj.equations[1].evaluate_expression(
             *eval_expr_args, where=valid_where
         )
-        assert objective_expression.sum() == 12
+
+        assert objective_expression.sum() == 7

--- a/tests/example_models/example_models_test.py
+++ b/tests/example_models/example_models_test.py
@@ -357,7 +357,8 @@ class TestUrbanScaleExampleModelSenseChecks:
     @pytest.mark.time_intensive
     def test_operate_example_results(self):
         model = calliope.examples.operate(
-            subset={"timesteps": ["2005-07-01", "2005-07-04"]}
+            subset={"timesteps": ["2005-07-01", "2005-07-04"]},
+            scenario="operate,pv_per_cap",
         )
 
         model.build()
@@ -369,7 +370,6 @@ class TestUrbanScaleExampleModelSenseChecks:
             "Source capacity constraint defined and set to infinity for all supply_plus techs",
             "Storage cannot be cyclic in operate run mode, setting `run.cyclic_storage` to False for this run",
         ]
-
         assert all(
             model.results.timesteps
             == pd.date_range("2005-07", "2005-07-04 23:00:00", freq="h")

--- a/tests/example_models/example_models_test.py
+++ b/tests/example_models/example_models_test.py
@@ -356,9 +356,13 @@ class TestUrbanScaleExampleModelSenseChecks:
 
     @pytest.mark.time_intensive
     def test_operate_example_results(self):
+        override = {
+            "techs.pv.source_unit": "per_cap",
+            "data_tables.pv_resource.select.scaler": "per_cap",
+        }
+
         model = calliope.examples.operate(
-            subset={"timesteps": ["2005-07-01", "2005-07-04"]},
-            scenario="operate,pv_per_cap",
+            subset={"timesteps": ["2005-07-01", "2005-07-04"]}, override_dict=override
         )
 
         model.build()

--- a/tests/math/math_test.py
+++ b/tests/math/math_test.py
@@ -913,7 +913,7 @@ class TestUptimeDowntime(CustomMathExamples):
         )
 
     @pytest.mark.filterwarnings(
-        "ignore:(?s).*This parameter will only take effect if you have already defined:calliope.exceptions.ModelWarning"
+        "ignore:(?s).*This input data will only take effect if you have already defined:calliope.exceptions.ModelWarning"
     )
     def test_downtime(self, build_and_compare):
         overrides = {
@@ -1050,6 +1050,9 @@ class TestPeakMonthCost(CustomMathExamples):
         },
     }
 
+    @pytest.mark.filterwarnings(
+        "ignore:(?s).*This input data will only take effect if you have already defined:calliope.exceptions.ModelWarning"
+    )
     def test_net_import_share_max(self, build_and_compare):
         build_and_compare(
             "monthly_peak_flow_charge",

--- a/tests/preprocess/model_data_test.py
+++ b/tests/preprocess/model_data_test.py
@@ -73,7 +73,7 @@ def timeseries_da():
         ("2005-01-01 01:00", "bar"): [False, 20],
     }
     da = pd.Series(data).rename_axis(index=["timesteps", "foobaz"]).to_xarray()
-    da.coords["timesteps"] = da.coords["timesteps"].astype("M")
+    da.coords["timesteps"] = da.coords["timesteps"].astype("datetime64[ns]")
     return da
 
 
@@ -1421,6 +1421,9 @@ class TestUpdateAndResample:
         assert model_data_cleaner_with_def_matrix.runtime.resample.root == resample
         assert model_data_cleaner_with_def_matrix.dataset.timesteps.size == 2
 
+    @pytest.mark.filterwarnings(
+        "ignore:(?s).*Only one timestep defined. Inferring timestep resolution to be 1 hour:calliope.exceptions.ModelWarning"
+    )
     def test_resample_update_runtime_from_something(
         self, model_data_cleaner_with_def_matrix: ModelDataCleaner
     ):

--- a/tests/preprocess/time_test.py
+++ b/tests/preprocess/time_test.py
@@ -474,7 +474,7 @@ class TestAddInferredTimeParams:
         be inferred to be 1 hour
         """
         dataset = xr.Dataset().assign_coords(
-            timesteps=pd.date_range("2005-01-01", periods=1, freq="H")
+            timesteps=pd.date_range("2005-01-01", periods=1, freq="h")
         )
         # check in output error that it points to: 07/01/2005 10:00:00
         with pytest.warns(

--- a/tests/schemas/general_test.py
+++ b/tests/schemas/general_test.py
@@ -426,6 +426,7 @@ class TestCalliopeBaseModel:
         assert new_model.extra_nested.nested.foobar == 2
         assert model.model_dump() == model_dict
 
+    @pytest.mark.filterwarnings("ignore:Pydantic serializer warnings:UserWarning")
     @pytest.mark.parametrize(
         "to_update",
         [


### PR DESCRIPTION
Fixes #862 

I ended up trying to fill with default values as late as possible, just before applying arithmetic or comparisons. Since we probably want default values even when we don't go through these two processes (e.g. you just sum an array in a global expression, no other arithmetic), I apply the default value right at the end as well, once out of the expression parser.

I don't think there's one solution to this that will be super clean, but this works with current models and fixes #862 so is possibly the best right now.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved
