### PR TITLE
Cleanup warnings

### DIFF
--- a/src/calliope/backend/expression_parser.py
+++ b/src/calliope/backend/expression_parser.py
@@ -120,12 +120,11 @@ class EvalArrayOrMath(EvalString):
                 `array` with NaNs filled with defaults, where array applied,
                 and dimensions broadcast against the where array (to ensure consistent array shapes).
         """
-        if not self.eval_attrs.apply_where:
-            return array
-        elif (where_array := self.eval_attrs.where_array).equals(xr.DataArray(True)):
-            return array
-        else:
-            return array.broadcast_like(where_array).where(where_array)
+        if self.eval_attrs.apply_where:
+            where_array = self.eval_attrs.where_array
+            if not where_array.equals(xr.DataArray(True)):
+                array = array.broadcast_like(where_array).where(where_array)
+        return array
 
     # Math strings evaluate to strings.
     @overload

--- a/src/calliope/exceptions.py
+++ b/src/calliope/exceptions.py
@@ -32,11 +32,15 @@ class BackendWarning(Warning):
 
 def warn(message: str, _class: type[Warning] = ModelWarning):
     """Raises the specified type of warning."""
+    formatwarning = warnings.formatwarning
+
     warnings.formatwarning = (
         lambda message, category, *args, **kwargs: f"{category.__name__}: {message}\n"
     )
-    warnings.warn(message, _class)
-    warnings.formatwarning = warnings._formatwarning_orig
+    try:
+        warnings.warn(message, _class)
+    finally:
+        warnings.formatwarning = formatwarning
 
 
 def print_warnings_and_raise_errors(

--- a/tests/math/math_test.py
+++ b/tests/math/math_test.py
@@ -913,7 +913,7 @@ class TestUptimeDowntime(CustomMathExamples):
         )
 
     @pytest.mark.filterwarnings(
-        "ignore:(?s).*This parameter will only take effect if you have already defined:calliope.exceptions.ModelWarning"
+        "ignore:(?s).*This input data will only take effect if you have already defined:calliope.exceptions.ModelWarning"
     )
     def test_downtime(self, build_and_compare):
         overrides = {
@@ -1050,6 +1050,9 @@ class TestPeakMonthCost(CustomMathExamples):
         },
     }
 
+    @pytest.mark.filterwarnings(
+        "ignore:(?s).*This input data will only take effect if you have already defined:calliope.exceptions.ModelWarning"
+    )
     def test_net_import_share_max(self, build_and_compare):
         build_and_compare(
             "monthly_peak_flow_charge",

--- a/tests/preprocess/model_data_test.py
+++ b/tests/preprocess/model_data_test.py
@@ -73,7 +73,7 @@ def timeseries_da():
         ("2005-01-01 01:00", "bar"): [False, 20],
     }
     da = pd.Series(data).rename_axis(index=["timesteps", "foobaz"]).to_xarray()
-    da.coords["timesteps"] = da.coords["timesteps"].astype("M")
+    da.coords["timesteps"] = da.coords["timesteps"].astype("datetime64[ns]")
     return da
 
 
@@ -1421,6 +1421,9 @@ class TestUpdateAndResample:
         assert model_data_cleaner_with_def_matrix.runtime.resample.root == resample
         assert model_data_cleaner_with_def_matrix.dataset.timesteps.size == 2
 
+    @pytest.mark.filterwarnings(
+        "ignore:(?s).*Only one timestep defined. Inferring timestep resolution to be 1 hour:calliope.exceptions.ModelWarning"
+    )
     def test_resample_update_runtime_from_something(
         self, model_data_cleaner_with_def_matrix: ModelDataCleaner
     ):

--- a/tests/preprocess/time_test.py
+++ b/tests/preprocess/time_test.py
@@ -474,7 +474,7 @@ class TestAddInferredTimeParams:
         be inferred to be 1 hour
         """
         dataset = xr.Dataset().assign_coords(
-            timesteps=pd.date_range("2005-01-01", periods=1, freq="H")
+            timesteps=pd.date_range("2005-01-01", periods=1, freq="h")
         )
         # check in output error that it points to: 07/01/2005 10:00:00
         with pytest.warns(

--- a/tests/schemas/general_test.py
+++ b/tests/schemas/general_test.py
@@ -426,6 +426,7 @@ class TestCalliopeBaseModel:
         assert new_model.extra_nested.nested.foobar == 2
         assert model.model_dump() == model_dict
 
+    @pytest.mark.filterwarnings("ignore:Pydantic serializer warnings:UserWarning")
     @pytest.mark.parametrize(
         "to_update",
         [


### PR DESCRIPTION
Minor compliment to #864

## Summary of changes in this pull request

* Cleans up the tests a bit to diminish warning spam that has built up.
* Safer warning message handling (no longer relies on internal variable and guarantees clean exits on failures).
* Minor readability improvement (https://github.com/calliope-project/calliope/pull/864#discussion_r3239885246)

After this only one type of warning should remain.
I did not fix as it necessitates changes in the testing methods due to our use of `test_controller`, which mixes `cost_flow_in` and `cost_source_use`.

<img width="1111" height="165" alt="image" src="https://github.com/user-attachments/assets/deba5e4e-72df-4e6f-a3d0-7abfa833023f" />


## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved
