### PR TITLE
docs: load models with calliope.read_yaml in Running in Python guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### User-facing changes
 
+|fixed| "Running in Python" docs to load models with `calliope.read_yaml` instead of the removed `calliope.Model(path)` instantiation form (#870).
+
 |fixed| Default values on masked array entries entering into math expression summation.
 In particular, fixes `sum(flow_cap, over=carriers)` on the constraint `source_availability_supply` erroneously returning `inf` (#862).
 

--- a/docs/basic/running-python.md
+++ b/docs/basic/running-python.md
@@ -1,21 +1,17 @@
 # Running a model in Python
 
-The most basic way to run a model programmatically from within a Python interpreter is to create a [calliope.Model][] instance with a given `model.yaml` configuration file, and then call its [calliope.Model.build][] followed by [calliope.Model.solve][] methods:
+The most basic way to run a model programmatically from within a Python interpreter is to load a model from a given `model.yaml` configuration file with `#!python calliope.read_yaml(...)`, and then call the resulting model's [calliope.Model.build][] followed by [calliope.Model.solve][] methods:
 
 ```python
 import calliope
-model = calliope.Model('path/to/model.yaml')
+model = calliope.read_yaml('path/to/model.yaml')
 model.build()
 model.solve()
 ```
 
-!!! note
-    If the model definition is not specified (i.e. `model = Model()`), an error is raised.
-    See the example models introduced in the [examples and tutorials](../examples/overview.md) section for information on instantiating a simple model without specifying a custom model configuration.
-
 Other ways to load a model in Python are:
 
-* Passing an [calliope.AttrDict][] or standard Python dictionary to the [calliope.Model][] constructor, with the same nested format as the YAML model configuration (top-level keys: `config`, `data_definitions`, `data_tables`, `nodes`, `techs`, etc.).
+* Passing an [calliope.AttrDict][] or standard Python dictionary to `#!python calliope.read_dict(...)`, with the same nested format as the YAML model configuration (top-level keys: `config`, `data_definitions`, `data_tables`, `nodes`, `techs`, etc.).
 * Loading a previously saved model from a NetCDF file with `#!python model = calliope.read_netcdf('path/to/saved_model.nc')`.
 This can either be a pre-processed model saved before its `build` method was called - which will include input data only - or a completely solved model, which will include input and result data.
 
@@ -36,13 +32,13 @@ There are two ways to override a base model when running in Python which are ana
 1. By setting the `scenario` argument, e.g.:
 
     ```python
-    model = calliope.Model('model.yaml', scenario='milp')
+    model = calliope.read_yaml('model.yaml', scenario='milp')
     ```
 
 2. By passing the `override_dict` argument, which is a Python dictionary, a [calliope.AttrDict][], or a YAML string of overrides:
 
     ```python
-    model = calliope.Model(
+    model = calliope.read_yaml(
         'model.yaml',
         override_dict={'config.solve.solver': 'gurobi'}
     )


### PR DESCRIPTION
Fixes #870

## Summary of changes in this pull request

* `Model.__init__` now takes `inputs`/`attrs` rather than a config path, so the "Running in Python" examples calling `calliope.Model('path/to/model.yaml')` no longer run. Switched them to `calliope.read_yaml(...)`, which is the public loader exported alongside `read_netcdf` in `calliope/__init__.py`.
* Updated the `scenario` and `override_dict` snippets to `read_yaml` (it forwards both arguments) and pointed the dictionary bullet at `read_dict`.
* Dropped the note about `model = Model()` raising an error, since direct construction is no longer the documented entry point.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [x] Documentation updated
- [x] Changelog updated
- [ ] Coverage maintained or improved
