### PR TITLE
Minor documentation fixes (part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### User-facing changes
 
-|fixed| Documentation now clarifies more expicitly that Calliope is unit-agnostic and that capacity and its costs are relative to carrier flow (#775).
-
 |removed| `link_flow_cap` decision variable, for constraining the `flow_cap` either end of a transmission link to the same value.
 Instead, rather than via this auxiliary variable, the constraint is applied directly to each `flow_cap` entry.
 
@@ -35,6 +33,10 @@ For example, `model.inputs.flow_cap_max.attrs["default"]` is now only available 
 |fixed| Reloading a clustered model from file was attempting to re-cluster (#824).
 
 |fixed| Example notebook outputs no longer clutter search results in docs and search result example notebook pages are grouped under the top-level page header (#675).
+
+|fixed| Documentation now clarifies more expicitly that Calliope is unit-agnostic and that capacity and its costs are relative to carrier flow (#775).
+
+|fixed| Documentation explains better how dimensions and broadcasting work (#667).
 
 ### Internal changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### User-facing changes
 
+|fixed| Documentation now clarifies more expicitly that Calliope is unit-agnostic and that capacity and its costs are relative to carrier flow (#775).
+
 |removed| `link_flow_cap` decision variable, for constraining the `flow_cap` either end of a transmission link to the same value.
 Instead, rather than via this auxiliary variable, the constraint is applied directly to each `flow_cap` entry.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ For example, `model.inputs.flow_cap_max.attrs["default"]` is now only available 
 
 |fixed| Example notebook outputs no longer clutter search results in docs and search result example notebook pages are grouped under the top-level page header (#675).
 
-|fixed| Documentation now clarifies more expicitly that Calliope is unit-agnostic and that capacity and its costs are relative to carrier flow (#775).
+|fixed| Documentation now clarifies more explicitly that Calliope is unit-agnostic and that capacity and its costs are relative to carrier flow (#775).
 
 |fixed| Documentation explains better how dimensions and broadcasting work (#667).
 

--- a/docs/basic/techs.md
+++ b/docs/basic/techs.md
@@ -32,7 +32,7 @@ ccgt:
     index: monetary
     dims: costs
   cost_flow_cap:
-    data: 750  # USD per kW
+    data: 750  # USD per kW of output capacity
     index: monetary
     dims: costs
   cost_flow_in:

--- a/docs/getting_started/analysing.md
+++ b/docs/getting_started/analysing.md
@@ -41,6 +41,43 @@ In Python you can quickly "densify" your data to look at only filled data points
 !!! note
     On [saving to CSV][calliope.Model.to_csv], each data variable is saved to its own file with all empty data points removed.
 
+### Dimensions and broadcasting
+
+Each parameter is only stored over the dimensions it was actually defined over, so that Calliope keeps its model data as small as possible.
+For example, if you set `flow_cap_max` to the same value for every technology, defining it only at the technology level, then `#!python model.inputs.flow_cap_max` will be indexed over `techs` alone. This means that it will _not_ have a `nodes` dimension.
+
+As soon as you override the value for one technology at one node, a `nodes` dimension appears.
+Calliope only broadcasts a parameter up to the full set of dimensions it needs when it builds the optimisation problem, so the inputs and results you save reflect as minimal a form as possible.
+
+This means the dimensions of a saved array can change depending on how you defined your data.
+If your post-processing relies on a parameter always having, say, a `nodes` dimension, you should broadcast the data to the dimensions you expect on your end when you read it in.
+
+The cleanest target to broadcast over is `#!python model.inputs.definition_matrix`, a boolean array over `[nodes, techs, carriers]` that is `True` exactly for the valid technology/carrier combinations at each node.
+Broadcasting against it therefore only adds dimensions where a technology is actually defined:
+
+```python
+# Give flow_cap_max a nodes dimension
+model.inputs.flow_cap_max.broadcast_like(model.inputs.definition_matrix).where(
+    model.inputs.definition_matrix
+)
+```
+
+!!! tip
+    Broadcasting is easiest to do in [xarray][], so we recommend saving to NetCDF ([calliope.Model.to_netcdf][]) if your post-processing script will be doing broadcasting after reading the data back in.
+
+!!! info "See also"
+    If you would rather have Calliope produce an output over a fixed set of dimensions for you, you can define a [post-processed result](../basic/postprocessing.md) in your math with an explicit `foreach`, and reference the parameter in its expression.
+    For example, to get `flow_cap_max` indexed over a known set of dimensions:
+
+    ```yaml
+    postprocessed:
+      flow_cap_max_known_dims:
+        foreach: [nodes, techs, carriers] # `results_flow_cap_max_known_dims.csv` will be indexed over these dimensions
+        where: flow_cap_max
+        equations:
+          - expression: flow_cap_max
+    ```
+
 ## Reading solutions
 
 Calliope provides functionality to read a previously-saved model from a single NetCDF file:

--- a/docs/getting_started/analysing.md
+++ b/docs/getting_started/analysing.md
@@ -56,7 +56,7 @@ The cleanest target to broadcast over is `#!python model.inputs.definition_matri
 Broadcasting against it therefore only adds dimensions where a technology is actually defined:
 
 ```python
-# Give flow_cap_max a nodes dimension
+# Give flow_cap_max a nodes and carriers dimension
 model.inputs.flow_cap_max.broadcast_like(model.inputs.definition_matrix).where(
     model.inputs.definition_matrix
 )
@@ -72,7 +72,7 @@ model.inputs.flow_cap_max.broadcast_like(model.inputs.definition_matrix).where(
     ```yaml
     postprocessed:
       flow_cap_max_known_dims:
-        foreach: [nodes, techs, carriers] # `results_flow_cap_max_known_dims.csv` will be indexed over these dimensions
+        foreach: [nodes, techs, carriers]
         where: flow_cap_max
         equations:
           - expression: flow_cap_max

--- a/docs/getting_started/concepts.md
+++ b/docs/getting_started/concepts.md
@@ -122,10 +122,14 @@ Note that you can define your data directly in the YAML text files that make up 
 More on this will follow in the next "getting started" section, [Creating a model](creating.md).
 
 !!! note "Note on units"
-    Calliope does not ensure consistency of units across a model.
+    Calliope is unit-agnostic and does not ensure consistency of units across a model.
     It is the responsibility of the modeller to ensure that units are consistent.
     Our math definitions do specify a `unit` for variables and parameters, but we keep these at a generic level, for example `energy` for `flow_out` and `power` for `flow_cap`.
     These unit definitions are listed in the [math documentation][base-math] and there for you to double-check the consistency of your data.
+
+!!! warning "Capacity and its costs are measured on the carrier flow"
+    A technology's capacity (`flow_cap`, i.e. its nominal/nameplate capacity) and any cost defined per unit of capacity (e.g. `cost_flow_cap`, `cost_om_annual`) are measured relative to a technology's carrier flow.
+    For a generation technology (`supply`), the capacity limits the output flow, so an investment cost per capacity is effectively a cost per unit of output (e.g. EUR/kW of electricity produced).
 
 ### Model configuration
 

--- a/docs/getting_started/concepts.md
+++ b/docs/getting_started/concepts.md
@@ -129,7 +129,7 @@ More on this will follow in the next "getting started" section, [Creating a mode
 
 !!! warning "Capacity and its costs are measured on the carrier flow"
     A technology's capacity (`flow_cap`, i.e. its nominal/nameplate capacity) and any cost defined per unit of capacity (e.g. `cost_flow_cap`, `cost_om_annual`) are measured relative to a technology's carrier flow.
-    For a generation technology (`supply`), the capacity limits the output flow, so an investment cost per capacity is effectively a cost per unit of output (e.g. EUR/kW of electricity produced).
+    For a generation technology (`supply`), the capacity limits the output flow, so an investment cost per capacity is effectively a cost per unit of output (e.g. EUR/kW of electrical output capacity).
 
 ### Model configuration
 
@@ -152,7 +152,7 @@ Again, more on this will follow in the next "getting started" section, [Creating
 
 Once you start looking at Calliope model data from a successful model run, you will see `inputs` and `results`.
 
-The `inputs` correspond your input data and can either be **parameters** or **lookups**.
+The `inputs` correspond to your input data and can either be **parameters** or **lookups**.
 Lookups are simply non-numeric parameters, for example, a boolean (true/false) switch used to choose between two possible constraint formulations.
 Each parameter is only stored over the dimensions it was defined over, so the dimensions of a given array can vary with how you defined your data.
 See [dimensions and broadcasting](analysing.md#dimensions-and-broadcasting) for more explanation.

--- a/docs/getting_started/concepts.md
+++ b/docs/getting_started/concepts.md
@@ -154,6 +154,8 @@ Once you start looking at Calliope model data from a successful model run, you w
 
 The `inputs` correspond your input data and can either be **parameters** or **lookups**.
 Lookups are simply non-numeric parameters, for example, a boolean (true/false) switch used to choose between two possible constraint formulations.
+Each parameter is only stored over the dimensions it was defined over, so the dimensions of a given array can vary with how you defined your data.
+See [dimensions and broadcasting](analysing.md#dimensions-and-broadcasting) for more explanation.
 
 The `results` correspond to variables, global expressions, or post-processed results.
 They can be one of three things:

--- a/docs/getting_started/creating.md
+++ b/docs/getting_started/creating.md
@@ -103,7 +103,7 @@ ccgt:
     index: monetary
     dims: costs
   cost_flow_cap:
-    data: 750  # USD per kW
+    data: 750  # USD per kW of output capacity
     index: monetary
     dims: costs
   cost_flow_in:


### PR DESCRIPTION
Fixes #667, fixes #775

## Summary of changes in this pull request

* Documentation explains better how dimensions and broadcasting work (#667)
* Documentation now clarifies more expicitly that Calliope is unit-agnostic and that capacity and its costs are relative to carrier flow (#775)

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved
