### PR TITLE
All contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,228 @@
+{
+  "projectName": "calliope",
+  "projectOwner": "calliope-project",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "commitConvention": "none",
+  "contributors": [
+    {
+      "login": "sjpfenninger",
+      "name": "Stefan Pfenninger-Lee",
+      "avatar_url": "https://avatars.githubusercontent.com/u/141709?v=4",
+      "profile": "https://github.com/sjpfenninger",
+      "contributions": [
+        "code",
+        "doc",
+        "bug",
+        "fundingFinding",
+        "projectManagement",
+        "promotion",
+        "maintenance"
+      ],
+      "firstContribution": "2013-11-12"
+    },
+    {
+      "login": "brynpickering",
+      "name": "Bryn Pickering",
+      "avatar_url": "https://avatars.githubusercontent.com/u/17178478?v=4",
+      "profile": "https://github.com/brynpickering",
+      "contributions": [
+        "code",
+        "doc",
+        "bug",
+        "fundingFinding",
+        "projectManagement",
+        "promotion",
+        "maintenance"
+      ],
+      "firstContribution": "2016-06-10"
+    },
+    {
+      "login": "irm-codebase",
+      "name": "Ivan Ruiz Manuel",
+      "avatar_url": "https://avatars.githubusercontent.com/u/72193617?v=4",
+      "profile": "https://orcid.org/0000-0003-2288-6423",
+      "contributions": [
+        "code",
+        "doc",
+        "bug",
+        "promotion",
+        "maintenance"
+      ],
+      "firstContribution": "2024-06-26"
+    },
+    {
+      "login": "timtroendle",
+      "name": "Tim Tröndle",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3090386?v=4",
+      "profile": "https://cp.ethz.ch/people/person-detail.tim-troendle.html",
+      "contributions": [
+        "code",
+        "doc",
+        "bug",
+        "promotion"
+      ],
+      "firstContribution": "2018-10-26"
+    },
+    {
+      "login": "FLomb",
+      "name": "Francesco Lombardi",
+      "avatar_url": "https://avatars.githubusercontent.com/u/26432077?v=4",
+      "profile": "https://github.com/FLomb",
+      "contributions": [
+        "code",
+        "doc",
+        "bug",
+        "promotion"
+      ],
+      "firstContribution": "2020-01-06"
+    },
+    {
+      "login": "jnnr",
+      "name": "Jann Launer",
+      "avatar_url": "https://avatars.githubusercontent.com/u/32454596?v=4",
+      "profile": "https://github.com/jnnr",
+      "contributions": [
+        "code",
+        "bug",
+        "doc"
+      ],
+      "firstContribution": "2023-03-16"
+    },
+    {
+      "login": "FraSanvit",
+      "name": "Francesco Sanvito",
+      "avatar_url": "https://avatars.githubusercontent.com/u/68587472?v=4",
+      "profile": "https://github.com/FraSanvit",
+      "contributions": [
+        "code",
+        "bug",
+        "promotion"
+      ],
+      "firstContribution": "2023-04-21"
+    },
+    {
+      "login": "GraemeHawker",
+      "name": "Graeme Hawker",
+      "avatar_url": "https://avatars.githubusercontent.com/u/26121052?v=4",
+      "profile": "http://www.strath.ac.uk/staff/hawkergraemedr/",
+      "contributions": [
+        "code",
+        "bug"
+      ],
+      "firstContribution": "2018-04-27"
+    },
+    {
+      "login": "mlgarchery",
+      "name": "Martial Garchery",
+      "avatar_url": "https://avatars.githubusercontent.com/u/16239564?v=4",
+      "profile": "https://mammouth.ai/",
+      "contributions": [
+        "code",
+        "bug"
+      ],
+      "firstContribution": "2018-08-16"
+    },
+    {
+      "login": "smorgenthaler",
+      "name": "smorgenthaler",
+      "avatar_url": "https://avatars.githubusercontent.com/u/41112077?v=4",
+      "profile": "https://github.com/smorgenthaler",
+      "contributions": [
+        "code",
+        "bug"
+      ],
+      "firstContribution": "2019-01-11"
+    },
+    {
+      "login": "ahilbers",
+      "name": "Adriaan Hilbers",
+      "avatar_url": "https://avatars.githubusercontent.com/u/31656517?v=4",
+      "profile": "https://ahilbers.github.io/",
+      "contributions": [
+        "code",
+        "bug"
+      ],
+      "firstContribution": "2020-08-03"
+    },
+    {
+      "login": "sstroemer",
+      "name": "Stefan Strömer",
+      "avatar_url": "https://avatars.githubusercontent.com/u/8915976?v=4",
+      "profile": "https://github.com/sstroemer",
+      "contributions": [
+        "code",
+        "bug"
+      ],
+      "firstContribution": "2024-08-16"
+    },
+    {
+      "login": "katrinleinweber",
+      "name": "Katrin Leinweber",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9948149?v=4",
+      "profile": "https://github.com/katrinleinweber",
+      "contributions": [
+        "doc"
+      ],
+      "firstContribution": "2018-05-08"
+    },
+    {
+      "login": "brmanuel",
+      "name": "brmanuel",
+      "avatar_url": "https://avatars.githubusercontent.com/u/22857883?v=4",
+      "profile": "https://github.com/brmanuel",
+      "contributions": [
+        "code"
+      ],
+      "firstContribution": "2020-02-25"
+    },
+    {
+      "login": "suvayu",
+      "name": "Suvayu Ali",
+      "avatar_url": "https://avatars.githubusercontent.com/u/229540?v=4",
+      "profile": "https://github.com/suvayu",
+      "contributions": [
+        "code"
+      ],
+      "firstContribution": "2020-03-25"
+    },
+    {
+      "login": "omahs",
+      "name": "omahs",
+      "avatar_url": "https://avatars.githubusercontent.com/u/73983677?v=4",
+      "profile": "https://github.com/omahs",
+      "contributions": [
+        "code"
+      ],
+      "firstContribution": "2025-05-19"
+    },
+    {
+      "login": "marijacveevska",
+      "name": "Marija Cveevska",
+      "avatar_url": "https://avatars.githubusercontent.com/u/94995858?v=4",
+      "profile": "https://github.com/marijacveevska",
+      "contributions": [
+        "doc"
+      ],
+      "firstContribution": "2026-06-19"
+    },
+    {
+      "login": "SAY-5",
+      "name": "Sai Asish Y",
+      "avatar_url": "https://avatars.githubusercontent.com/u/240962040?v=4",
+      "profile": "https://sayportfolio.vercel.app/",
+      "contributions": [
+        "doc"
+      ],
+      "firstContribution": "2026-06-19"
+    }
+  ],
+  "contributorsPerLine": 7,
+  "linkToUsage": false,
+  "contributorsSortAlphabetically": false
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners for the entire Calliope repository
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @sjpfenninger @brynpickering @irm-codebase

--- a/.github/scripts/git-contrib-sort.py
+++ b/.github/scripts/git-contrib-sort.py
@@ -91,8 +91,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.check:
         print(
-            f"error: {args.path.name} is not sorted; run "
-            "`python git-contrib-sort.py` to fix.",
+            f"error: {args.path.name} is not sorted; run this script without --check to fix.",
             file=sys.stderr,
         )
         return 1

--- a/.github/scripts/git-contrib-sort.py
+++ b/.github/scripts/git-contrib-sort.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Sort ``.all-contributorsrc`` by contribution count, then first-contribution date.
+
+Contributors are ordered by:
+
+1. number of contributions/emojis (``len(contributions)``), descending;
+2. ``firstContribution`` date (``YYYY-MM-DD``), ascending — earliest first;
+3. ``login`` (case-insensitive), as a deterministic final tiebreak.
+
+Every contributor entry must carry a ``firstContribution`` field. This is stored
+directly in ``.all-contributorsrc`` (the all-contributors tooling preserves the
+extra key), so no separate cache is needed. When the all-contributors bot adds a
+new contributor it lands without this field, so add it by hand (the date of their
+first commit/contribution) before re-running this script.
+
+This is the only script needed to maintain the ordering going forward; the
+``git-contrib-*.sh`` helpers were one-time tooling used to seed the dates.
+
+Usage (run from anywhere):
+    python .github/scripts/git-contrib-sort.py          # sort the file in place
+    python .github/scripts/git-contrib-sort.py --check  # verify only, non-zero if unsorted
+    python .github/scripts/git-contrib-sort.py --path X # operate on another config file
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# This script lives in .github/scripts/; the config is at the repository root.
+DEFAULT_PATH = Path(__file__).resolve().parents[2] / ".all-contributorsrc"
+DATE_FIELD = "firstContribution"
+
+
+def sort_key(contributor: dict) -> tuple[int, str, str]:
+    """Return the ordering key: most contributions first, then earliest date."""
+    return (
+        -len(contributor["contributions"]),
+        contributor[DATE_FIELD],
+        contributor["login"].lower(),
+    )
+
+
+def render(data: dict) -> str:
+    """Serialise the config exactly as the all-contributors tooling does."""
+    return json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Sort (or check) the contributors list. Returns a process exit code."""
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=DEFAULT_PATH,
+        help="path to .all-contributorsrc (default: alongside this script)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit non-zero if the file is not already sorted; do not write",
+    )
+    args = parser.parse_args(argv)
+
+    original = args.path.read_text(encoding="utf-8")
+    data = json.loads(original)
+    contributors = data["contributors"]
+
+    missing = [c["login"] for c in contributors if not c.get(DATE_FIELD)]
+    if missing:
+        print(
+            f"error: contributors missing a '{DATE_FIELD}' (YYYY-MM-DD) date "
+            f"in {args.path.name}:",
+            file=sys.stderr,
+        )
+        for login in missing:
+            print(
+                f"  - {login}: add a '{DATE_FIELD}' date to this entry", file=sys.stderr
+            )
+        return 1
+
+    data["contributors"] = sorted(contributors, key=sort_key)
+    updated = render(data)
+
+    if updated == original:
+        return 0
+
+    if args.check:
+        print(
+            f"error: {args.path.name} is not sorted; run "
+            "`python git-contrib-sort.py` to fix.",
+            file=sys.stderr,
+        )
+        return 1
+
+    args.path.write_text(updated, encoding="utf-8")
+    print(f"sorted {len(contributors)} contributors in {args.path.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/git-contrib-sort.py
+++ b/.github/scripts/git-contrib-sort.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Sort ``.all-contributorsrc`` by contribution count, then first-contribution date.
 
 Contributors are ordered by:
@@ -6,32 +5,27 @@ Contributors are ordered by:
 1. number of contributions/emojis (``len(contributions)``), descending;
 2. ``firstContribution`` date (``YYYY-MM-DD``), ascending — earliest first;
 3. ``login`` (case-insensitive), as a deterministic final tiebreak.
-
-Every contributor entry must carry a ``firstContribution`` field. This is stored
-directly in ``.all-contributorsrc`` (the all-contributors tooling preserves the
-extra key), so no separate cache is needed. When the all-contributors bot adds a
-new contributor it lands without this field, so add it by hand (the date of their
-first commit/contribution) before re-running this script.
-
-This is the only script needed to maintain the ordering going forward; the
-``git-contrib-*.sh`` helpers were one-time tooling used to seed the dates.
-
-Usage (run from anywhere):
-    python .github/scripts/git-contrib-sort.py          # sort the file in place
-    python .github/scripts/git-contrib-sort.py --check  # verify only, non-zero if unsorted
-    python .github/scripts/git-contrib-sort.py --path X # operate on another config file
 """
-
-from __future__ import annotations
 
 import argparse
 import json
 import sys
+from datetime import date
 from pathlib import Path
 
-# This script lives in .github/scripts/; the config is at the repository root.
 DEFAULT_PATH = Path(__file__).resolve().parents[2] / ".all-contributorsrc"
 DATE_FIELD = "firstContribution"
+
+
+def is_valid_date(value: object) -> bool:
+    """Check that a value is a valid date in YYYY-MM-DD format."""
+    valid = False
+    if isinstance(value, str):
+        try:
+            valid = date.fromisoformat(value).isoformat() == value
+        except ValueError:
+            pass
+    return valid
 
 
 def sort_key(contributor: dict) -> tuple[int, str, str]:
@@ -70,16 +64,17 @@ def main(argv: list[str] | None = None) -> int:
     data = json.loads(original)
     contributors = data["contributors"]
 
-    missing = [c["login"] for c in contributors if not c.get(DATE_FIELD)]
-    if missing:
+    invalid = [c["login"] for c in contributors if not is_valid_date(c.get(DATE_FIELD))]
+    if invalid:
         print(
-            f"error: contributors missing a '{DATE_FIELD}' (YYYY-MM-DD) date "
+            f"error: contributors missing a valid '{DATE_FIELD}' (YYYY-MM-DD) date "
             f"in {args.path.name}:",
             file=sys.stderr,
         )
-        for login in missing:
+        for login in invalid:
             print(
-                f"  - {login}: add a '{DATE_FIELD}' date to this entry", file=sys.stderr
+                f"  - {login}: set '{DATE_FIELD}' to a valid YYYY-MM-DD date",
+                file=sys.stderr,
             )
         return 1
 

--- a/.github/scripts/git-contrib-sort.py
+++ b/.github/scripts/git-contrib-sort.py
@@ -57,7 +57,7 @@ def main(argv: list[str] | None = None) -> int:
         "--path",
         type=Path,
         default=DEFAULT_PATH,
-        help="path to .all-contributorsrc (default: alongside this script)",
+        help="path to .all-contributorsrc (default: repo root .all-contributorsrc)",
     )
     parser.add_argument(
         "--check",

--- a/.github/workflows/all-contributors-sort.yml
+++ b/.github/workflows/all-contributors-sort.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/all-contributors-sort.yml
+++ b/.github/workflows/all-contributors-sort.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/all-contributors-sort.yml
+++ b/.github/workflows/all-contributors-sort.yml
@@ -25,8 +25,8 @@ jobs:
             const marker = '<!-- all-contributors-date-reminder -->';
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
-            const { data: comments } = await github.rest.issues.listComments({
-              owner, repo, issue_number,
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
             });
             if (comments.some((c) => c.body && c.body.includes(marker))) {
               return;

--- a/.github/workflows/all-contributors-sort.yml
+++ b/.github/workflows/all-contributors-sort.yml
@@ -1,0 +1,49 @@
+name: All-contributors sort check
+
+on:
+  pull_request:
+    paths:
+      - ".all-contributorsrc"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check contributor ordering and first-contribution dates
+        run: python3 .github/scripts/git-contrib-sort.py --check
+      - name: Remind to add a first-contribution date on the bot's PR
+        if: failure() && github.event.pull_request.user.login == 'allcontributors[bot]'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- all-contributors-date-reminder -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number,
+            });
+            if (comments.some((c) => c.body && c.body.includes(marker))) {
+              return;
+            }
+            const body = [
+              marker,
+              '👋 Thanks for adding a new contributor!',
+              '',
+              'Before merging, please add a `firstContribution` date to the new',
+              'entry in `.all-contributorsrc` — the `YYYY-MM-DD` date of their',
+              'first commit/contribution — then re-sort the list:',
+              '',
+              '```bash',
+              'python .github/scripts/git-contrib-sort.py',
+              '```',
+              '',
+              'and push the result to this branch. This keeps contributors ordered',
+              'by number of contributions, then by how long ago they first',
+              'contributed.',
+            ].join('\n');
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });

--- a/README.md
+++ b/README.md
@@ -80,3 +80,62 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+## Maintainers
+
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/sjpfenninger"><img src="https://avatars.githubusercontent.com/u/141709?v=4?s=100" width="100px;" alt="Stefan Pfenninger-Lee"/><br /><sub><b>Stefan Pfenninger-Lee</b></sub></a><br /></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/brynpickering"><img src="https://avatars.githubusercontent.com/u/17178478?v=4?s=100" width="100px;" alt="Bryn Pickering"/><br /><sub><b>Bryn Pickering</b></sub></a><br /></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://orcid.org/0000-0003-2288-6423"><img src="https://avatars.githubusercontent.com/u/72193617?v=4?s=100" width="100px;" alt="Ivan Ruiz Manuel"/><br /><sub><b>Ivan Ruiz Manuel</b></sub></a><br /></td>
+      <td valign="top" width="14.28%"></td>
+      <td valign="top" width="14.28%"></td>
+      <td valign="top" width="14.28%"></td>
+      <td valign="top" width="14.28%"></td>
+    </tr>
+  </tbody>
+</table>
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/en/reference/emoji-key/)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/sjpfenninger"><img src="https://avatars.githubusercontent.com/u/141709?v=4?s=100" width="100px;" alt="Stefan Pfenninger-Lee"/><br /><sub><b>Stefan Pfenninger-Lee</b></sub></a><br /><a href="https://github.com/calliope-project/calliope/commits?author=sjpfenninger" title="Code">💻</a> <a href="https://github.com/calliope-project/calliope/commits?author=sjpfenninger" title="Documentation">📖</a> <a href="https://github.com/calliope-project/calliope/issues?q=author%3Asjpfenninger" title="Bug reports">🐛</a> <a href="#fundingFinding-sjpfenninger" title="Funding Finding">🔍</a> <a href="#projectManagement-sjpfenninger" title="Project Management">📆</a> <a href="#promotion-sjpfenninger" title="Promotion">📣</a> <a href="#maintenance-sjpfenninger" title="Maintenance">🚧</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/brynpickering"><img src="https://avatars.githubusercontent.com/u/17178478?v=4?s=100" width="100px;" alt="Bryn Pickering"/><br /><sub><b>Bryn Pickering</b></sub></a><br /><a href="https://github.com/calliope-project/calliope/commits?author=brynpickering" title="Code">💻</a> <a href="https://github.com/calliope-project/calliope/commits?author=brynpickering" title="Documentation">📖</a> <a href="https://github.com/calliope-project/calliope/issues?q=author%3Abrynpickering" title="Bug reports">🐛</a> <a href="#fundingFinding-brynpickering" title="Funding Finding">🔍</a> <a href="#projectManagement-brynpickering" title="Project Management">📆</a> <a href="#promotion-brynpickering" title="Promotion">📣</a> <a href="#maintenance-brynpickering" title="Maintenance">🚧</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://orcid.org/0000-0003-2288-6423"><img src="https://avatars.githubusercontent.com/u/72193617?v=4?s=100" width="100px;" alt="Ivan Ruiz Manuel"/><br /><sub><b>Ivan Ruiz Manuel</b></sub></a><br /><a href="https://github.com/calliope-project/calliope/commits?author=irm-codebase" title="Code">💻</a> <a href="https://github.com/calliope-project/calliope/commits?author=irm-codebase" title="Documentation">📖</a> <a href="https://github.com/calliope-project/calliope/issues?q=author%3Airm-codebase" title="Bug reports">🐛</a> <a href="#promotion-irm-codebase" title="Promotion">📣</a> <a href="#maintenance-irm-codebase" title="Maintenance">🚧</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://cp.ethz.ch/people/person-detail.tim-troendle.html"><img src="https://avatars.githubusercontent.com/u/3090386?v=4?s=100" width="100px;" alt="Tim Tröndle"/><br /><sub><b>Tim Tröndle</b></sub></a><br /><a href="https://github.com/calliope-project/calliope/commits?author=timtroendle" title="Code">💻</a> <a href="https://github.com/calliope-project/calliope/commits?author=timtroendle" title="Documentation">📖</a> <a href="https://github.com/calliope-project/calliope/issues?q=author%3Atimtroendle" title="Bug reports">🐛</a> <a href="#promotion-timtroendle" title="Promotion">📣</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/FLomb"><img src="https://avatars.githubusercontent.com/u/26432077?v=4?s=100" width="100px;" alt="Francesco Lombardi"/><br /><sub><b>Francesco Lombardi</b></sub></a><br /><a href="https://github.com/calliope-project/calliope/commits?author=FLomb" title="Code">💻</a> <a href="https://github.com/calliope-project/calliope/commits?author=FLomb" title="Documentation">📖</a> <a href="https://github.com/calliope-project/calliope/issues?q=author%3AFLomb" title="Bug reports">🐛</a> <a href="#promotion-FLomb" title="Promotion">📣</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/jnnr"><img src="https://avatars.githubusercontent.com/u/32454596?v=4?s=100" width="100px;" alt="Jann Launer"/><br /><sub><b>Jann Launer</b></sub></a><br /><a href="https://github.com/calliope-project/calliope/commits?author=jnnr" title="Code">💻</a> <a href="https://github.com/calliope-project/calliope/issues?q=author%3Ajnnr" title="Bug reports">🐛</a> <a href="https://github.com/calliope-project/calliope/commits?author=jnnr" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/FraSanvit"><img src="https://avatars.githubusercontent.com/u/68587472?v=4?s=100" width="100px;" alt="Francesco Sanvito"/><br /><sub><b>Francesco Sanvito</b></sub></a><br /><a href="https://github.com/calliope-project/calliope/commits?author=FraSanvit" title="Code">💻</a> <a href="https://github.com/calliope-project/calliope/issues?q=author%3AFraSanvit" title="Bug reports">🐛</a> <a href="#promotion-FraSanvit" title="Promotion">📣</a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="http://www.strath.ac.uk/staff/hawkergraemedr/"><img src="https://avatars.githubusercontent.com/u/26121052?v=4?s=100" width="100px;" alt="Graeme Hawker"/><br /><sub><b>Graeme Hawker</b></sub></a><br /><a href="https://github.com/calliope-project/calliope/commits?author=GraemeHawker" title="Code">💻</a> <a href="https://github.com/calliope-project/calliope/issues?q=author%3AGraemeHawker" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://mammouth.ai/"><img src="https://avatars.githubusercontent.com/u/16239564?v=4?s=100" width="100px;" alt="Martial Garchery"/><br /><sub><b>Martial Garchery</b></sub></a><br /><a href="https://github.com/calliope-project/calliope/commits?author=mlgarchery" title="Code">💻</a> <a href="https://github.com/calliope-project/calliope/issues?q=author%3Amlgarchery" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/smorgenthaler"><img src="https://avatars.githubusercontent.com/u/41112077?v=4?s=100" width="100px;" alt="smorgenthaler"/><br /><sub><b>smorgenthaler</b></sub></a><br /><a href="https://github.com/calliope-project/calliope/commits?author=smorgenthaler" title="Code">💻</a> <a href="https://github.com/calliope-project/calliope/issues?q=author%3Asmorgenthaler" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://ahilbers.github.io/"><img src="https://avatars.githubusercontent.com/u/31656517?v=4?s=100" width="100px;" alt="Adriaan Hilbers"/><br /><sub><b>Adriaan Hilbers</b></sub></a><br /><a href="https://github.com/calliope-project/calliope/commits?author=ahilbers" title="Code">💻</a> <a href="https://github.com/calliope-project/calliope/issues?q=author%3Aahilbers" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/sstroemer"><img src="https://avatars.githubusercontent.com/u/8915976?v=4?s=100" width="100px;" alt="Stefan Strömer"/><br /><sub><b>Stefan Strömer</b></sub></a><br /><a href="https://github.com/calliope-project/calliope/commits?author=sstroemer" title="Code">💻</a> <a href="https://github.com/calliope-project/calliope/issues?q=author%3Asstroemer" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/katrinleinweber"><img src="https://avatars.githubusercontent.com/u/9948149?v=4?s=100" width="100px;" alt="Katrin Leinweber"/><br /><sub><b>Katrin Leinweber</b></sub></a><br /><a href="https://github.com/calliope-project/calliope/commits?author=katrinleinweber" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/brmanuel"><img src="https://avatars.githubusercontent.com/u/22857883?v=4?s=100" width="100px;" alt="brmanuel"/><br /><sub><b>brmanuel</b></sub></a><br /><a href="https://github.com/calliope-project/calliope/commits?author=brmanuel" title="Code">💻</a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/suvayu"><img src="https://avatars.githubusercontent.com/u/229540?v=4?s=100" width="100px;" alt="Suvayu Ali"/><br /><sub><b>Suvayu Ali</b></sub></a><br /><a href="https://github.com/calliope-project/calliope/commits?author=suvayu" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/omahs"><img src="https://avatars.githubusercontent.com/u/73983677?v=4?s=100" width="100px;" alt="omahs"/><br /><sub><b>omahs</b></sub></a><br /><a href="https://github.com/calliope-project/calliope/commits?author=omahs" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/marijacveevska"><img src="https://avatars.githubusercontent.com/u/94995858?v=4?s=100" width="100px;" alt="Marija Cveevska"/><br /><sub><b>Marija Cveevska</b></sub></a><br /><a href="https://github.com/calliope-project/calliope/commits?author=marijacveevska" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://sayportfolio.vercel.app/"><img src="https://avatars.githubusercontent.com/u/240962040?v=4?s=100" width="100px;" alt="Sai Asish Y"/><br /><sub><b>Sai Asish Y</b></sub></a><br /><a href="https://github.com/calliope-project/calliope/commits?author=SAY-5" title="Documentation">📖</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/README.md
+++ b/README.md
@@ -81,22 +81,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-## Maintainers
-
-<table>
-  <tbody>
-    <tr>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/sjpfenninger"><img src="https://avatars.githubusercontent.com/u/141709?v=4?s=100" width="100px;" alt="Stefan Pfenninger-Lee"/><br /><sub><b>Stefan Pfenninger-Lee</b></sub></a><br /></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/brynpickering"><img src="https://avatars.githubusercontent.com/u/17178478?v=4?s=100" width="100px;" alt="Bryn Pickering"/><br /><sub><b>Bryn Pickering</b></sub></a><br /></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://orcid.org/0000-0003-2288-6423"><img src="https://avatars.githubusercontent.com/u/72193617?v=4?s=100" width="100px;" alt="Ivan Ruiz Manuel"/><br /><sub><b>Ivan Ruiz Manuel</b></sub></a><br /></td>
-      <td valign="top" width="14.28%"></td>
-      <td valign="top" width="14.28%"></td>
-      <td valign="top" width="14.28%"></td>
-      <td valign="top" width="14.28%"></td>
-    </tr>
-  </tbody>
-</table>
-
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/en/reference/emoji-key/)):


### PR DESCRIPTION
## Summary of changes in this pull request

* Adds all-contributors dataseeded from past contributions.
* Sort order is custom: by number of contribution types and within that, by date.
* The date is a custom field in `.all-contributorsrc`, e.g. `"firstContribution": "2026-07-24"`. A sorting script can be run whenever a new contributor is added. A check is run automatically when the all-contributors bot opens a PR to ensure sorting happens.
* List maintainers separately and add CODEOWNERS file with the maintainers in it.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved
