### PR TITLE
Feat/uv pixi pr warnings

### DIFF
--- a/src/calliope/backend/backend_model.py
+++ b/src/calliope/backend/backend_model.py
@@ -792,9 +792,12 @@ class BackendModelGenerator(ABC, metaclass=SelectiveWrappingMeta):
         if kwargs:
             func = partial(func, **kwargs)
         vectorised_func = np.frompyfunc(func, len(args), n_out)
-        da = vectorised_func(
-            *(arg.broadcast_like(where) for arg in args), where=where.values
+
+        broadcast_where, *broadcast_args = xr.broadcast(where, *args)
+        outputs = tuple(
+            np.empty(broadcast_where.shape, dtype=object) for _ in range(n_out)
         )
+        da = vectorised_func(*broadcast_args, where=broadcast_where.values, out=outputs)
         if isinstance(da, xr.DataArray):
             da = da.fillna(np.nan)
         else:

--- a/src/calliope/backend/expression_parser.py
+++ b/src/calliope/backend/expression_parser.py
@@ -402,7 +402,16 @@ class EvalComparisonOp(EvalArrayOrMath):
                 op = np.less_equal
             case ">=":
                 op = np.greater_equal
-        constraint = op(lhs_where, rhs_where, where=where.values, dtype=np.object_)
+        broadcast_where, lhs_where, rhs_where = xr.broadcast(
+            where, lhs_where, rhs_where
+        )
+        constraint = op(
+            lhs_where,
+            rhs_where,
+            where=broadcast_where.values,
+            out=(np.empty(broadcast_where.shape, dtype=object),),
+            dtype=np.object_,
+        )
         return xr.DataArray(constraint)
 
 

--- a/src/calliope/backend/expression_parser.py
+++ b/src/calliope/backend/expression_parser.py
@@ -392,9 +392,6 @@ class EvalComparisonOp(EvalArrayOrMath):
                 raise self.error_msg(
                     f"The {side}-hand side of the equation is indexed over dimensions not present in `foreach`: {extra_dims}"
                 )
-        lhs_where = self._apply_where_array(lhs)
-        rhs_where = self._apply_where_array(rhs)
-
         match self.op:
             case "==":
                 op = np.equal
@@ -402,9 +399,7 @@ class EvalComparisonOp(EvalArrayOrMath):
                 op = np.less_equal
             case ">=":
                 op = np.greater_equal
-        broadcast_where, lhs_where, rhs_where = xr.broadcast(
-            where, lhs_where, rhs_where
-        )
+        broadcast_where, lhs_where, rhs_where = xr.broadcast(where, lhs, rhs)
         constraint = op(
             lhs_where,
             rhs_where,

--- a/src/calliope/model.py
+++ b/src/calliope/model.py
@@ -552,7 +552,9 @@ class Model(ModelStructure):
             iteration_results.coords["timesteps"] = new_ts
 
         results_list.append(iteration_results.sel(timesteps=slice(windowstep, None)))
-        results = xr.concat(results_list, dim="timesteps", combine_attrs="drop")
+        results = xr.concat(
+            results_list, dim="timesteps", data_vars="all", combine_attrs="drop"
+        )
         results.attrs["termination_condition"] = ",".join(
             set(
                 result.attrs["termination_condition"]

--- a/src/calliope/preprocess/model_data.py
+++ b/src/calliope/preprocess/model_data.py
@@ -363,7 +363,7 @@ class ModelDataBuilder(ModelDTypeUpdater):
                 )
                 input_data_das.append(self._input_data_to_array(name, validated_data))
             input_data_ds = xr.merge(
-                [input_data_ds, xr.combine_by_coords(input_data_das)],
+                [input_data_ds, xr.combine_by_coords(input_data_das, join="outer")],
                 join="outer",
                 compat="no_conflicts",
             )

--- a/tests/backend/backend_model_test.py
+++ b/tests/backend/backend_model_test.py
@@ -202,27 +202,33 @@ class TestOptimality:
 
 class TestGetters:
     @pytest.fixture(scope="class")
-    def variable(self, solved_model_cls):
+    @classmethod
+    def variable(cls, solved_model_cls):
         return solved_model_cls.backend.get_variable("flow_cap")
 
     @pytest.fixture(scope="class")
-    def parameter_undefined(self, solved_model_cls):
+    @classmethod
+    def parameter_undefined(cls, solved_model_cls):
         return solved_model_cls.backend.get_parameter("flow_in_eff")
 
     @pytest.fixture(scope="class")
-    def parameter_defined(self, solved_model_cls):
+    @classmethod
+    def parameter_defined(cls, solved_model_cls):
         return solved_model_cls.backend.get_parameter("flow_cap_max")
 
     @pytest.fixture(scope="class")
-    def constraint(self, solved_model_cls):
+    @classmethod
+    def constraint(cls, solved_model_cls):
         return solved_model_cls.backend.get_constraint("system_balance")
 
     @pytest.fixture(scope="class")
-    def global_expression(self, solved_model_cls):
+    @classmethod
+    def global_expression(cls, solved_model_cls):
         return solved_model_cls.backend.get_global_expression("cost_investment")
 
     @pytest.fixture(scope="class")
-    def lookup(self, solved_model_cls):
+    @classmethod
+    def lookup(cls, solved_model_cls):
         return solved_model_cls.backend.get_lookup("base_tech")
 
     @pytest.mark.parametrize(
@@ -1002,7 +1008,8 @@ class TestMILP:
 
 
 class TestPiecewiseConstraints:
-    def gen_params(self, data, index=[0, 1, 2], dim="breakpoints"):
+    @staticmethod
+    def gen_params(data, index=[0, 1, 2], dim="breakpoints"):
         return {
             "data_definitions": {
                 "piecewise_x": {"data": data, "index": index, "dims": dim},
@@ -1015,7 +1022,8 @@ class TestPiecewiseConstraints:
         }
 
     @pytest.fixture(scope="class")
-    def working_math(self):
+    @classmethod
+    def working_math(cls):
         return {
             "foreach": ["nodes", "techs", "carriers"],
             "where": "[test_supply_elec] in techs AND piecewise_x AND piecewise_y",
@@ -1027,23 +1035,28 @@ class TestPiecewiseConstraints:
         }
 
     @pytest.fixture(scope="class")
-    def working_params(self):
-        return self.gen_params([0, 5, 10])
+    @classmethod
+    def working_params(cls):
+        return cls.gen_params([0, 5, 10])
 
     @pytest.fixture(scope="class")
-    def length_mismatch_params(self):
-        return self.gen_params([0, 10], [0, 1])
+    @classmethod
+    def length_mismatch_params(cls):
+        return cls.gen_params([0, 10], [0, 1])
 
     @pytest.fixture(scope="class")
-    def not_reaching_var_bound_with_breakpoint_params(self):
-        return self.gen_params([0, 5, 8])
+    @classmethod
+    def not_reaching_var_bound_with_breakpoint_params(cls):
+        return cls.gen_params([0, 5, 8])
 
     @pytest.fixture(scope="class")
-    def missing_breakpoint_dims(self):
-        return self.gen_params([0, 5, 10], dim="foobar")
+    @classmethod
+    def missing_breakpoint_dims(cls):
+        return cls.gen_params([0, 5, 10], dim="foobar")
 
     @pytest.fixture(scope="class")
-    def add_math(self):
+    @classmethod
+    def add_math(cls):
         return {
             "parameters": {"piecewise_x": {}, "piecewise_y": {}},
             "dimensions": {
@@ -1052,7 +1065,8 @@ class TestPiecewiseConstraints:
         }
 
     @pytest.fixture(scope="class")
-    def working_model(self, backend, working_params, working_math, add_math):
+    @classmethod
+    def working_model(cls, backend, working_params, working_math, add_math):
         m = build_model(
             working_params,
             "simple_supply,two_hours,investment_costs",
@@ -1063,7 +1077,8 @@ class TestPiecewiseConstraints:
         return m
 
     @pytest.fixture(scope="class")
-    def piecewise_constraint(self, working_model):
+    @classmethod
+    def piecewise_constraint(cls, working_model):
         return working_model.backend.get_piecewise_constraint("foo")
 
     def test_piecewise_attrs(self, piecewise_constraint):

--- a/tests/backend/expression_parser_test.py
+++ b/tests/backend/expression_parser_test.py
@@ -1268,7 +1268,6 @@ class TestApplyWhereArray:
 
     _apply_where_array is called in:
     - EvalOperatorOperand.as_array() — once per operand in binary arithmetic
-    - EvalComparisonOp.as_array() — once for each of LHS and RHS
 
     It is NOT called when directly evaluating unsliced/sliced components.
     """
@@ -1313,27 +1312,6 @@ class TestApplyWhereArray:
             "all_ones + all_ones + no_dims", parse_all=True
         )
         self.assert_method_called(3, parsed_[0], **eval_kwargs)
-
-    def test_apply_where_array_called_in_comparison(
-        self, equation_comparison, eval_kwargs
-    ):
-        """_apply_where_array is called once each for the LHS and RHS of a comparison operation."""
-        parsed_ = equation_comparison.parse_string("1 == 1", parse_all=True)
-        self.assert_method_called(2, parsed_[0], **eval_kwargs)
-
-    def test_broadcast_in_apply_where_array_called_in_comparison(
-        self, equation_comparison, eval_kwargs
-    ):
-        """_apply_where_array broadcasts both LHS and RHS to the where_array shape in a comparison."""
-        where = eval_kwargs["eval_attrs"].input_data["all_true"]
-        parsed_ = equation_comparison.parse_string("all_ones == 1", parse_all=True)
-        evaluated_ = self.assert_method_called(
-            2,
-            parsed_[0],
-            eval_kwargs["return_type"],
-            replace(eval_kwargs["eval_attrs"], where_array=where),
-        )
-        assert evaluated_.dims == ("nodes", "techs")
 
     def test_apply_where_array_default_true_does_not_mask(
         self, arithmetic, eval_kwargs

--- a/tests/backend/gurobi_backend_model_test.py
+++ b/tests/backend/gurobi_backend_model_test.py
@@ -14,14 +14,16 @@ class TestNewBackend:
     pytest.importorskip("gurobipy")
 
     @pytest.fixture(scope="class")
-    def simple_supply_longnames(self):
+    @classmethod
+    def simple_supply_longnames(cls):
         m = build_model({}, "simple_supply,two_hours,investment_costs")
         m.build(backend="gurobi")
         m.backend.verbose_strings()
         return m
 
     @pytest.fixture(scope="class")
-    def simple_supply_gurobi(self):
+    @classmethod
+    def simple_supply_gurobi(cls):
         m = build_model({}, "simple_supply,two_hours,investment_costs")
         m.build(backend="gurobi")
         m.solve()
@@ -369,7 +371,8 @@ class TestShadowPrices:
 
 
 class TestPiecewiseConstraints:
-    def gen_params(self, data, index=[0, 1, 2], dim="breakpoints"):
+    @staticmethod
+    def gen_params(data, index=[0, 1, 2], dim="breakpoints"):
         return {
             "data_definitions": {
                 "piecewise_x": {"data": data, "index": index, "dims": dim},
@@ -382,7 +385,8 @@ class TestPiecewiseConstraints:
         }
 
     @pytest.fixture(scope="class")
-    def working_math(self):
+    @classmethod
+    def working_math(cls):
         return {
             "foreach": ["nodes", "techs", "carriers"],
             "where": "[test_supply_elec] in techs AND piecewise_x AND piecewise_y",
@@ -395,7 +399,8 @@ class TestPiecewiseConstraints:
         }
 
     @pytest.fixture(scope="class")
-    def add_math(self):
+    @classmethod
+    def add_math(cls):
         return {
             "parameters": {"piecewise_x": {}, "piecewise_y": {}},
             "dimensions": {
@@ -404,19 +409,23 @@ class TestPiecewiseConstraints:
         }
 
     @pytest.fixture(scope="class")
-    def failing_math(self, working_math):
+    @classmethod
+    def failing_math(cls, working_math):
         return {**working_math, **{"y_expression": "sum(flow_in, over=timesteps)"}}
 
     @pytest.fixture(scope="class")
-    def working_params(self):
-        return self.gen_params([0, 5, 10])
+    @classmethod
+    def working_params(cls):
+        return cls.gen_params([0, 5, 10])
 
     @pytest.fixture(scope="class")
-    def length_mismatch_params(self):
-        return self.gen_params([0, 10], [0, 1])
+    @classmethod
+    def length_mismatch_params(cls):
+        return cls.gen_params([0, 10], [0, 1])
 
     @pytest.fixture(scope="class")
-    def working_model(self, working_params, working_math, add_math):
+    @classmethod
+    def working_model(cls, working_params, working_math, add_math):
         m = build_model(
             working_params,
             "simple_supply,two_hours,investment_costs",

--- a/tests/backend/helper_functions_test.py
+++ b/tests/backend/helper_functions_test.py
@@ -100,7 +100,8 @@ def where_map_dim(where, parsing_kwargs):
 
 class TestAsArray:
     @pytest.fixture(scope="class")
-    def parsing_kwargs(self, dummy_model_data, dummy_model_math):
+    @classmethod
+    def parsing_kwargs(cls, dummy_model_data, dummy_model_math):
         attrs = eval_attrs.EvalAttrs(
             input_data=dummy_model_data, equation_name="foo", math=dummy_model_math
         )
@@ -529,7 +530,8 @@ class TestAsArray:
 
 class TestAsMathString:
     @pytest.fixture(scope="class")
-    def parsing_kwargs(self, dummy_model_data, dummy_model_math):
+    @classmethod
+    def parsing_kwargs(cls, dummy_model_data, dummy_model_math):
         attrs = eval_attrs.EvalAttrs(
             input_data=dummy_model_data, equation_name="foo", math=dummy_model_math
         )

--- a/tests/backend/pyomo_backend_model_test.py
+++ b/tests/backend/pyomo_backend_model_test.py
@@ -69,8 +69,9 @@ class TestNewBackend:
     LOGGER = logging.getLogger("calliope.backend.backend_model")
 
     @pytest.fixture(scope="class")
+    @classmethod
     def simple_supply_updated_cost_flow_cap(
-        self, simple_supply: calliope.Model, dummy_int: int
+        cls, simple_supply: calliope.Model, dummy_int: int
     ) -> calliope.Model:
         simple_supply.backend.verbose_strings()
         simple_supply.backend.update_input("cost_flow_cap", dummy_int)
@@ -429,7 +430,8 @@ class TestNewBackend:
 
 class TestVerboseStrings:
     @pytest.fixture(scope="class")
-    def simple_supply_longnames(self):
+    @classmethod
+    def simple_supply_longnames(cls):
         m = build_model({}, "simple_supply,two_hours,investment_costs")
         m.build()
         m.backend.verbose_strings()
@@ -540,7 +542,8 @@ class TestVerboseStrings:
 
 
 class TestPiecewiseConstraints:
-    def gen_params(self, data, index=[0, 1, 2], dim="breakpoints"):
+    @staticmethod
+    def gen_params(data, index=[0, 1, 2], dim="breakpoints"):
         return {
             "data_definitions": {
                 "piecewise_x": {"data": data, "index": index, "dims": dim},
@@ -553,7 +556,8 @@ class TestPiecewiseConstraints:
         }
 
     @pytest.fixture(scope="class")
-    def working_math(self):
+    @classmethod
+    def working_math(cls):
         return {
             "foreach": ["nodes", "techs", "carriers"],
             "where": "[test_supply_elec] in techs AND piecewise_x AND piecewise_y",
@@ -565,7 +569,8 @@ class TestPiecewiseConstraints:
         }
 
     @pytest.fixture(scope="class")
-    def add_math(self):
+    @classmethod
+    def add_math(cls):
         return {
             "parameters": {"piecewise_x": {}, "piecewise_y": {}},
             "dimensions": {
@@ -574,19 +579,23 @@ class TestPiecewiseConstraints:
         }
 
     @pytest.fixture(scope="class")
-    def working_params(self):
-        return self.gen_params([0, 5, 10])
+    @classmethod
+    def working_params(cls):
+        return cls.gen_params([0, 5, 10])
 
     @pytest.fixture(scope="class")
-    def length_mismatch_params(self):
-        return self.gen_params([0, 10], [0, 1])
+    @classmethod
+    def length_mismatch_params(cls):
+        return cls.gen_params([0, 10], [0, 1])
 
     @pytest.fixture(scope="class")
-    def not_reaching_var_bound_with_breakpoint_params(self):
-        return self.gen_params([0, 5, 8])
+    @classmethod
+    def not_reaching_var_bound_with_breakpoint_params(cls):
+        return cls.gen_params([0, 5, 8])
 
     @pytest.fixture(scope="class")
-    def working_model(self, working_params, working_math, add_math):
+    @classmethod
+    def working_model(cls, working_params, working_math, add_math):
         m = build_model(
             working_params,
             "simple_supply,two_hours,investment_costs",

--- a/tests/common/test_model/scenarios.yaml
+++ b/tests/common/test_model/scenarios.yaml
@@ -60,6 +60,10 @@ overrides:
         name: Less efficient supply tech
         carrier_out: electricity
         base_tech: supply
+        cost_source_use:
+          data: 0.1
+          index: monetary
+          dims: costs
         flow_cap_max: 10
         source_use_max: .inf
         flow_out_eff: 0.8
@@ -450,16 +454,33 @@ overrides:
           dims: costs
 
   var_costs:
-    templates:
-      test_controller:
-        cost_flow_in:
+    techs:
+      test_supply_gas:
+        cost_source_use: &variable_cost_source_use
           data: 0.1
           index: monetary
           dims: costs
-        cost_source_use:
+      test_supply_elec:
+        cost_source_use: *variable_cost_source_use
+      test_supply_coal:
+        cost_source_use: *variable_cost_source_use
+      test_supply_plus:
+        cost_source_use: *variable_cost_source_use
+      test_storage:
+        cost_flow_in: &variable_cost_flow_in
           data: 0.1
           index: monetary
           dims: costs
+      test_conversion:
+        cost_flow_in: *variable_cost_flow_in
+      test_conversion_plus:
+        cost_flow_in: *variable_cost_flow_in
+      test_chp:
+        cost_flow_in: *variable_cost_flow_in
+      test_link_a_b_elec:
+        cost_flow_in: *variable_cost_flow_in
+      test_link_a_b_heat:
+        cost_flow_in: *variable_cost_flow_in
 
   demand_elec_max:
     data_tables:

--- a/tests/example_models/example_models_test.py
+++ b/tests/example_models/example_models_test.py
@@ -97,7 +97,8 @@ class TestModelMathDocs:
 
 class TestNationalScaleExampleModelSenseChecks:
     @pytest.fixture(scope="class")
-    def nat_model_from_data_tables(self):
+    @classmethod
+    def nat_model_from_data_tables(cls):
         df = pd.read_csv(
             calliope.examples._EXAMPLE_MODEL_DIR
             / "national_scale"
@@ -115,7 +116,8 @@ class TestNationalScaleExampleModelSenseChecks:
         return model
 
     @pytest.fixture(scope="class")
-    def nat_model(self):
+    @classmethod
+    def nat_model(cls):
         model = calliope.examples.national_scale(
             subset={"timesteps": ["2005-01-01", "2005-01-01"]}
         )

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -45,21 +45,25 @@ class TestIO:
         return model
 
     @pytest.fixture(scope="class")
-    def model_file(self, tmpdir_factory, model):
+    @classmethod
+    def model_file(cls, tmpdir_factory, model):
         out_path = tmpdir_factory.mktemp("data").join("model.nc")
         model.to_netcdf(out_path)
         return out_path
 
     @pytest.fixture(scope="class")
-    def model_from_file(self, model_file):
+    @classmethod
+    def model_from_file(cls, model_file):
         return calliope.read_netcdf(model_file)
 
     @pytest.fixture(scope="class")
-    def model_from_file_no_processing(self, model_file):
+    @classmethod
+    def model_from_file_no_processing(cls, model_file):
         return xr.open_dataset(model_file, group="inputs")
 
     @pytest.fixture(scope="class")
-    def model_csv_dir(self, tmpdir_factory, model):
+    @classmethod
+    def model_csv_dir(cls, tmpdir_factory, model):
         parent_path = tmpdir_factory.mktemp("data")
         out_path = parent_path / "csvs"
         model.to_csv(out_path)

--- a/tests/math/checks_test.py
+++ b/tests/math/checks_test.py
@@ -70,8 +70,9 @@ class Checks(ABC):
     """Test class for base.yaml math checks using parametrized test data."""
 
     @pytest.fixture(scope="class", params=[])
+    @classmethod
     @abstractmethod
-    def check(self, request):
+    def check(cls, request):
         return request.param
 
     def test_check_raises_error_or_warning(self, check):
@@ -100,7 +101,8 @@ class TestBaseMathChecks(Checks):
     """Test class for base.yaml math checks using parametrized test data."""
 
     @pytest.fixture(scope="class", params=BASE_PARAMS)
-    def check(self, request):
+    @classmethod
+    def check(cls, request):
         return request.param
 
 
@@ -108,7 +110,8 @@ class TestMILPMathChecks(Checks):
     """Test class for milp.yaml math checks using parametrized test data."""
 
     @pytest.fixture(scope="class", params=MILP_PARAMS)
-    def check(self, request):
+    @classmethod
+    def check(cls, request):
         return request.param
 
 
@@ -116,5 +119,6 @@ class TestOperateMathChecks(Checks):
     """Test class for operate.yaml math checks using parametrized test data."""
 
     @pytest.fixture(scope="class", params=OPERATE_PARAMS)
-    def check(self, request):
+    @classmethod
+    def check(cls, request):
         return request.param

--- a/tests/math/math_test.py
+++ b/tests/math/math_test.py
@@ -103,22 +103,26 @@ class InternalMathFiles(ABC):
     EXTRA_MATH: list
 
     @pytest.fixture(scope="class")
-    def lp_temp_path(self, tmp_path_factory):
+    @classmethod
+    def lp_temp_path(cls, tmp_path_factory):
         """Use a single temp. location to make manual checks easier."""
-        return tmp_path_factory.mktemp(f"lp_files_{self.FILENAME}")
+        return tmp_path_factory.mktemp(f"lp_files_{cls.FILENAME}")
 
     @pytest.fixture(scope="class")
-    def full_math(self):
-        return create_full_math(["base"] + self.EXTRA_MATH)
+    @classmethod
+    def full_math(cls):
+        return create_full_math(["base"] + cls.EXTRA_MATH)
 
     @pytest.fixture(scope="class")
-    def barebones_math_file(self, full_math, tmp_path_factory) -> str:
+    @classmethod
+    def barebones_math_file(cls, full_math, tmp_path_factory) -> str:
         filepath = tmp_path_factory.mktemp("barebones") / "barebones.yaml"
         create_pruned_math_file(full_math, filepath)
         return str(filepath)
 
     @pytest.fixture(scope="class")
-    def barebones_config(self, barebones_math_file):
+    @classmethod
+    def barebones_config(cls, barebones_math_file):
         return {
             "math_paths": {"base": barebones_math_file},
             "pre_validate_math_strings": False,
@@ -143,9 +147,10 @@ class InternalMathFiles(ABC):
                 all_math.del_key(key)
         assert not any(all_math.values())
 
-    @abstractmethod
     @pytest.fixture(scope="class", params=[])
-    def config(self, request):
+    @classmethod
+    @abstractmethod
+    def config(cls, request):
         pass
 
     def test_math(self, full_math, lp_temp_path, barebones_config, config):
@@ -199,8 +204,9 @@ class TestBaseMath(InternalMathFiles):
     EXTRA_MATH = []
 
     @pytest.fixture(scope="class", params=TEST_CONFIGS[FILENAME].keys())
-    def config(self, request):
-        return TEST_CONFIGS[self.FILENAME][request.param]
+    @classmethod
+    def config(cls, request):
+        return TEST_CONFIGS[cls.FILENAME][request.param]
 
     def test_min_cost_optimisation_feasible(
         self, full_math, lp_temp_path, barebones_config
@@ -251,8 +257,9 @@ class TestMILPMath(InternalMathFiles):
     EXTRA_MATH = [FILENAME]
 
     @pytest.fixture(scope="class", params=TEST_CONFIGS[FILENAME].keys())
-    def config(self, request):
-        return TEST_CONFIGS[self.FILENAME][request.param]
+    @classmethod
+    def config(cls, request):
+        return TEST_CONFIGS[cls.FILENAME][request.param]
 
 
 class TestInterClusterStorageMath(InternalMathFiles):
@@ -261,8 +268,9 @@ class TestInterClusterStorageMath(InternalMathFiles):
     EXTRA_MATH = [FILENAME]
 
     @pytest.fixture(scope="class", params=TEST_CONFIGS[FILENAME].keys())
-    def config(self, request):
-        return TEST_CONFIGS[self.FILENAME][request.param]
+    @classmethod
+    def config(cls, request):
+        return TEST_CONFIGS[cls.FILENAME][request.param]
 
 
 class CustomMathExamples(ABC):
@@ -280,32 +288,38 @@ class CustomMathExamples(ABC):
         """Source of the specific test class custom math"""
 
     @pytest.fixture(scope="class")
-    def abs_filepath(self):
-        return (self.CUSTOM_MATH_DIR / self.YAML_FILEPATH).absolute().as_posix()
+    @classmethod
+    def abs_filepath(cls):
+        return (cls.CUSTOM_MATH_DIR / cls.YAML_FILEPATH).absolute().as_posix()
 
     @pytest.fixture(scope="class")
-    def custom_math(self):
-        return io.read_rich_yaml(self.CUSTOM_MATH_DIR / self.YAML_FILEPATH)
+    @classmethod
+    def custom_math(cls):
+        return io.read_rich_yaml(cls.CUSTOM_MATH_DIR / cls.YAML_FILEPATH)
 
     @pytest.fixture(scope="class")
-    def full_math(self, custom_math):
-        return create_full_math(["base"] + self.EXTRA_MATH, custom_math)
+    @classmethod
+    def full_math(cls, custom_math):
+        return create_full_math(["base"] + cls.EXTRA_MATH, custom_math)
 
     @pytest.fixture(scope="class")
-    def barebones_math_file(self, tmp_path_factory, full_math) -> str:
+    @classmethod
+    def barebones_math_file(cls, tmp_path_factory, full_math) -> str:
         filepath = tmp_path_factory.mktemp("barebones") / "barebones.yaml"
         create_pruned_math_file(full_math, filepath)
         return str(filepath)
 
     @pytest.fixture(scope="class")
-    def lp_temp_path(self, tmp_path_factory):
+    @classmethod
+    def lp_temp_path(cls, tmp_path_factory):
         """Use a single temp. location to make manual checks easier."""
         return tmp_path_factory.mktemp(
-            f"lp_files_{self.YAML_FILEPATH.removesuffix('.yaml')}"
+            f"lp_files_{cls.YAML_FILEPATH.removesuffix('.yaml')}"
         )
 
     @pytest.fixture(scope="class")
-    def all_custom_components(self, custom_math) -> dict[str, list[str]]:
+    @classmethod
+    def all_custom_components(cls, custom_math) -> dict[str, list[str]]:
         """Per-component lists in a custom math file."""
         custom_math_lists = {
             component: list(custom_math[component]) for component in custom_math

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -202,8 +202,9 @@ class TestChecks:
 
 
 class TestOperateMode:
+    @staticmethod
     @contextmanager
-    def caplog_session(self, request):
+    def caplog_session(request):
         """caplog for class/session-scoped fixtures.
 
         See https://github.com/pytest-dev/pytest/discussions/11177
@@ -214,7 +215,8 @@ class TestOperateMode:
             yield pytest.LogCaptureFixture(request.node, _ispytest=True)
 
     @pytest.fixture(scope="class")
-    def base_model(self):
+    @classmethod
+    def base_model(cls):
         """Solve in base mode for the same overrides, to check against operate mode model."""
         model = build_model(
             {}, "simple_supply,operate,var_costs,investment_costs", mode="base"
@@ -226,7 +228,8 @@ class TestOperateMode:
     @pytest.fixture(
         scope="class", params=[("6h", "12h"), ("12h", "12h"), ("16h", "20h")]
     )
-    def operate_model_and_log(self, base_model, request):
+    @classmethod
+    def operate_model_and_log(cls, base_model, request):
         """Solve in base mode, then use results to set operate mode inputs, then solve in operate mode.
 
         Three different operate/horizon windows chosen:
@@ -242,7 +245,7 @@ class TestOperateMode:
         )
         model.build(operate={"window": request.param[0], "horizon": request.param[1]})
 
-        with self.caplog_session(request) as caplog:
+        with cls.caplog_session(request) as caplog:
             with caplog.at_level(logging.INFO):
                 model.solve(force=True)
             log = caplog.text
@@ -316,8 +319,9 @@ class TestSporesMode:
         "spores,var_costs,two_hours,simple_supply_spores_ready,investment_costs"
     )
 
+    @staticmethod
     @contextmanager
-    def caplog_session(self, request):
+    def caplog_session(request):
         """caplog for class/session-scoped fixtures.
 
         See https://github.com/pytest-dev/pytest/discussions/11177
@@ -328,11 +332,12 @@ class TestSporesMode:
             yield pytest.LogCaptureFixture(request.node, _ispytest=True)
 
     @pytest.fixture(scope="class")
-    def spores_model_and_log(self, request):
+    @classmethod
+    def spores_model_and_log(cls, request):
         """Iterate 2 times in SPORES mode."""
-        model = build_model({}, self.SPORES_OVERRIDES)
+        model = build_model({}, cls.SPORES_OVERRIDES)
         model.build()
-        with self.caplog_session(request) as caplog:
+        with cls.caplog_session(request) as caplog:
             with caplog.at_level(logging.INFO):
                 model.solve()
             log = caplog.text
@@ -343,12 +348,13 @@ class TestSporesMode:
         scope="class",
         params=["integer", "relative_deployment", "random", "evolving_average"],
     )
-    def spores_model_and_log_algorithms(self, request):
+    @classmethod
+    def spores_model_and_log_algorithms(cls, request):
         """Iterate 2 times in SPORES mode using different scoring algorithms."""
-        model = build_model({}, self.SPORES_OVERRIDES)
+        model = build_model({}, cls.SPORES_OVERRIDES)
         model.build()
 
-        with self.caplog_session(request) as caplog:
+        with cls.caplog_session(request) as caplog:
             with caplog.at_level(logging.INFO):
                 model.solve(spores={"scoring_algorithm": request.param})
             log = caplog.text
@@ -356,9 +362,10 @@ class TestSporesMode:
         return model, log
 
     @pytest.fixture(scope="class")
-    def spores_model_continue_from_plan_and_log(self, request):
+    @classmethod
+    def spores_model_continue_from_plan_and_log(cls, request):
         """Iterate 2 times in SPORES mode having pre-computed the baseline results."""
-        model = build_model({}, self.SPORES_OVERRIDES, mode="base")
+        model = build_model({}, cls.SPORES_OVERRIDES, mode="base")
         model.build()
         model.solve()
 
@@ -369,7 +376,7 @@ class TestSporesMode:
             mode="spores",
         )
         model2.build()
-        with self.caplog_session(request) as caplog:
+        with cls.caplog_session(request) as caplog:
             with caplog.at_level(logging.INFO):
                 model2.solve(force=True, spores={"use_latest_results": True})
             log = caplog.text
@@ -377,13 +384,14 @@ class TestSporesMode:
         return model2, log
 
     @pytest.fixture(scope="class")
-    def spores_model_continue_from_spores_and_log(self, request):
+    @classmethod
+    def spores_model_continue_from_spores_and_log(cls, request):
         """Iterate 2 times in SPORES mode having pre-computed the baseline results."""
 
-        model = build_model({}, self.SPORES_OVERRIDES)
+        model = build_model({}, cls.SPORES_OVERRIDES)
         model.build()
         model.solve()
-        with self.caplog_session(request) as caplog:
+        with cls.caplog_session(request) as caplog:
             with caplog.at_level(logging.INFO):
                 model.solve(
                     force=True, spores={"use_latest_results": True, "number": 4}
@@ -393,17 +401,19 @@ class TestSporesMode:
         return model, log
 
     @pytest.fixture(scope="class")
-    def spores_save_per_spore_path(self, tmp_path_factory):
+    @classmethod
+    def spores_save_per_spore_path(cls, tmp_path_factory):
         return tmp_path_factory.mktemp("outputs")
 
     @pytest.fixture(scope="class")
-    def spores_model_save_per_spore_and_log(self, spores_save_per_spore_path, request):
+    @classmethod
+    def spores_model_save_per_spore_and_log(cls, spores_save_per_spore_path, request):
         """Iterate 2 times in SPORES mode and save to file each time."""
 
-        model = build_model({}, self.SPORES_OVERRIDES)
+        model = build_model({}, cls.SPORES_OVERRIDES)
         model.build()
 
-        with self.caplog_session(request) as caplog:
+        with cls.caplog_session(request) as caplog:
             with caplog.at_level(logging.INFO):
                 model.solve(spores={"save_per_spore_path": spores_save_per_spore_path})
             log = caplog.text
@@ -414,18 +424,20 @@ class TestSporesMode:
         scope="class",
         params=["integer", "relative_deployment", "random", "evolving_average"],
     )
-    def spores_model_with_tracker(self, request):
+    @classmethod
+    def spores_model_with_tracker(cls, request):
         """Iterate 2 times in SPORES mode with a SPORES score tracking parameter."""
-        model = build_model({}, f"{self.SPORES_OVERRIDES},spores_tech_tracking")
+        model = build_model({}, f"{cls.SPORES_OVERRIDES},spores_tech_tracking")
         model.build()
         model.solve(spores={"scoring_algorithm": request.param})
 
         return model
 
     @pytest.fixture(scope="class")
-    def rerun_spores_log(self, request, spores_model_and_log):
+    @classmethod
+    def rerun_spores_log(cls, request, spores_model_and_log):
         """Solve in spores mode a second time, to trigger new log messages."""
-        with self.caplog_session(request) as caplog:
+        with cls.caplog_session(request) as caplog:
             with caplog.at_level(logging.INFO):
                 spores_model_and_log[0].solve(force=True)
             return caplog.text

--- a/tests/postprocess/math_documentation_test.py
+++ b/tests/postprocess/math_documentation_test.py
@@ -9,19 +9,22 @@ from ..common.util import build_test_model, check_error_or_warning
 
 class TestMathDocumentation:
     @pytest.fixture(scope="class")
-    def no_build(self):
+    @classmethod
+    def no_build(cls):
         model = build_test_model({}, "simple_supply,two_hours,investment_costs")
         model.build()
         return model
 
     @pytest.fixture(scope="class")
-    def build_all(self):
+    @classmethod
+    def build_all(cls):
         model = build_test_model({}, "simple_supply,two_hours,investment_costs")
         model.build()
         return MathDocumentation(model, include="all")
 
     @pytest.fixture(scope="class")
-    def build_valid(self):
+    @classmethod
+    def build_valid(cls):
         model = build_test_model({}, "simple_supply,two_hours,investment_costs")
         model.build()
         return MathDocumentation(model, include="valid")

--- a/tests/preprocess/data_sources_test.py
+++ b/tests/preprocess/data_sources_test.py
@@ -38,7 +38,8 @@ def generate_data_table_dict(data_dir):
 
 class TestDataTableUtils:
     @pytest.fixture(scope="class")
-    def table_obj(self, generate_data_table_dict):
+    @classmethod
+    def table_obj(cls, generate_data_table_dict):
         df = pd.Series({"bar": 0, "baz": 1})
         table_dict = generate_data_table_dict(
             "foo.csv", df, rows="test_row", columns=None
@@ -98,28 +99,32 @@ class TestDataTableUtils:
 
 class TestDataTableInitOneLevel:
     @pytest.fixture(scope="class")
-    def multi_row_no_col_data(self, generate_data_table_dict):
+    @classmethod
+    def multi_row_no_col_data(cls, generate_data_table_dict):
         df = pd.Series({"bar": 0, "baz": 1})
         return df, generate_data_table_dict(
             "multi_row_no_col_file.csv", df, rows="test_row", columns=None
         )
 
     @pytest.fixture(scope="class")
-    def multi_row_one_col_data(self, generate_data_table_dict):
+    @classmethod
+    def multi_row_one_col_data(cls, generate_data_table_dict):
         df = pd.DataFrame({"foo": {"bar": 0, "baz": 1}})
         return df, generate_data_table_dict(
             "multi_row_one_col_file.csv", df, rows="test_row", columns="test_col"
         )
 
     @pytest.fixture(scope="class")
-    def one_row_multi_col_data(self, generate_data_table_dict):
+    @classmethod
+    def one_row_multi_col_data(cls, generate_data_table_dict):
         df = pd.DataFrame({"foo": {"bar": 0}, "foobar": {"bar": 1}})
         return df, generate_data_table_dict(
             "one_row_multi_col_file.csv", df, rows="test_row", columns="test_col"
         )
 
     @pytest.fixture(scope="class")
-    def multi_row_multi_col_data(self, generate_data_table_dict):
+    @classmethod
+    def multi_row_multi_col_data(cls, generate_data_table_dict):
         df = pd.DataFrame(
             {"foo": {"bar": 0, "baz": 10}, "foobar": {"bar": 0, "baz": 20}}
         )
@@ -185,7 +190,8 @@ class TestDataTableInitOneLevel:
 
 class TestDataTableInitMultiLevel:
     @pytest.fixture(scope="class")
-    def multi_row_no_col_data(self, generate_data_table_dict):
+    @classmethod
+    def multi_row_no_col_data(cls, generate_data_table_dict):
         df = pd.Series({("bar1", "bar2"): 0, ("baz1", "baz2"): 1})
         return df, generate_data_table_dict(
             "multi_row_no_col_file.csv",
@@ -195,7 +201,8 @@ class TestDataTableInitMultiLevel:
         )
 
     @pytest.fixture(scope="class")
-    def multi_row_one_col_data(self, generate_data_table_dict):
+    @classmethod
+    def multi_row_one_col_data(cls, generate_data_table_dict):
         df = pd.DataFrame({"foo": {("bar1", "bar2"): 0, ("baz1", "baz2"): 1}})
         return df, generate_data_table_dict(
             "multi_row_one_col_file.csv",
@@ -205,7 +212,8 @@ class TestDataTableInitMultiLevel:
         )
 
     @pytest.fixture(scope="class")
-    def one_row_multi_col_data(self, generate_data_table_dict):
+    @classmethod
+    def one_row_multi_col_data(cls, generate_data_table_dict):
         df = pd.DataFrame(
             {("foo1", "foo2"): {"bar": 0}, ("foobar1", "foobar2"): {"bar": 1}}
         )
@@ -217,7 +225,8 @@ class TestDataTableInitMultiLevel:
         )
 
     @pytest.fixture(scope="class")
-    def multi_row_multi_col_data(self, generate_data_table_dict):
+    @classmethod
+    def multi_row_multi_col_data(cls, generate_data_table_dict):
         df = pd.DataFrame(
             {
                 ("foo1", "foo2"): {("bar1", "bar2"): 0, ("baz1", "baz2"): 10},
@@ -267,7 +276,8 @@ class TestDataTableInitMultiLevel:
 
 class TestDataTableSelectDropAdd:
     @pytest.fixture(scope="class")
-    def table_obj(self):
+    @classmethod
+    def table_obj(cls):
         def _table_obj(**table_dict_kwargs):
             df = pd.DataFrame(
                 {
@@ -351,7 +361,8 @@ class TestDataTableSelectDropAdd:
 
 class TestDataTableRenameDims:
     @pytest.fixture(scope="class")
-    def multi_row_one_col_data(self, data_dir, dummy_int):
+    @classmethod
+    def multi_row_one_col_data(cls, data_dir, dummy_int):
         """Fixture to create the xarray dataset from the data table, including dimension name mapping."""
 
         def _multi_row_one_col_data(
@@ -412,7 +423,8 @@ class TestDataTableRenameDims:
 
 class TestDataTableMalformed:
     @pytest.fixture(scope="class")
-    def table_obj(self):
+    @classmethod
+    def table_obj(cls):
         def _table_obj(**table_dict_kwargs):
             df = pd.DataFrame(
                 {
@@ -471,7 +483,8 @@ class TestDataTableMalformed:
 
 class TestDataTableLookupDictFromParam:
     @pytest.fixture(scope="class")
-    def table_obj(self):
+    @classmethod
+    def table_obj(cls):
         df = pd.DataFrame(
             {
                 "FOO": {("foo1", "bar1"): 1, ("foo1", "bar2"): 1},
@@ -508,7 +521,8 @@ class TestDataTableLookupDictFromParam:
 
 class TestDataTableTechDict:
     @pytest.fixture(scope="class")
-    def table_obj(self):
+    @classmethod
+    def table_obj(cls):
         def _table_obj(df_dict, rows="techs"):
             df = pd.DataFrame(df_dict)
             table_dict = (
@@ -575,7 +589,8 @@ class TestDataTableTechDict:
 
 class TestDataTableNodeDict:
     @pytest.fixture(scope="class")
-    def table_obj(self):
+    @classmethod
+    def table_obj(cls):
         def _table_obj(df_dict, rows=["nodes", "techs"]):
             df = pd.DataFrame(df_dict)
             table_dict = data_table_schema.CalliopeDataTable.model_validate(
@@ -626,7 +641,7 @@ class TestDataTableNodeDict:
         tech_dict = CalliopeTechs(bar1={}, bar2={})
         node_tech_ds = table_obj(node_tech_df_dict)
         node_ds = table_obj(node_df_dict, rows="nodes")
-        node_tech_ds.dataset = node_tech_ds.dataset.merge(node_ds.dataset)
+        node_tech_ds.dataset = node_tech_ds.dataset.merge(node_ds.dataset, join="outer")
 
         node_dict = node_tech_ds.node_def(tech_dict)
         assert node_dict == CalliopeNodes(

--- a/tests/preprocess/model_data_test.py
+++ b/tests/preprocess/model_data_test.py
@@ -1194,7 +1194,8 @@ class TestDataTableBuilding:
             ],
         ],
     )
-    def diff_dim_tables(self, request, minimal_test_model_path, config, math):
+    @classmethod
+    def diff_dim_tables(cls, request, minimal_test_model_path, config, math):
         """
         Create a ModelDataBuilder with data tables that have parameters defined over different dimensions,
         to test that loading works correctly regardless of the order in which they are defined.

--- a/tests/preprocess/model_math_test.py
+++ b/tests/preprocess/model_math_test.py
@@ -43,14 +43,16 @@ def user_math_path(def_path, user_math):
 
 class TestInitMath:
     @pytest.fixture(scope="class", params=["default", "w_extra"])
-    def extra_math(self, request, user_math_path):
+    @classmethod
+    def extra_math(cls, request, user_math_path):
         extra = {}
         if request.param == "w_extra":
             extra["user_math"] = user_math_path
         return extra
 
     @pytest.fixture(scope="class")
-    def math_data(self, extra_math, def_path):
+    @classmethod
+    def math_data(cls, extra_math, def_path):
         return model_math.initialise_math(extra_math, def_path)
 
     def test_loaded_internal(self, math_data, extra_math):
@@ -78,7 +80,8 @@ class TestInitMath:
 
 class TestBuildMath:
     @pytest.fixture(scope="class")
-    def test_model(self):
+    @classmethod
+    def test_model(cls):
         """Simulate users adding extra math using the urban example model."""
         calliope_dir = Path(calliope.__file__).parent
         additional = calliope_dir / "example_models/urban_scale/additional_math.yaml"
@@ -100,11 +103,13 @@ class TestBuildMath:
         )
 
     @pytest.fixture(scope="class")
-    def config(self, test_model):
+    @classmethod
+    def config(cls, test_model):
         return test_model.config
 
     @pytest.fixture(scope="class")
-    def math_options(self, test_model: calliope.Model):
+    @classmethod
+    def math_options(cls, test_model: calliope.Model):
         return test_model.math.init.model_dump()
 
     @pytest.mark.parametrize(
@@ -143,12 +148,14 @@ class TestBuildMath:
 
 class TestValidateMathDict:
     @pytest.fixture(scope="class")
-    def init_math(self) -> dict:
+    @classmethod
+    def init_math(cls) -> dict:
         model = build_model({}, "simple_supply,investment_costs")
         return model.math.init.model_dump()
 
     @pytest.fixture(scope="class")
-    def math_priority(self) -> list[str]:
+    @classmethod
+    def math_priority(cls) -> list[str]:
         return ["base"]
 
     def test_base_math(self, caplog, init_math, math_priority):

--- a/tests/preprocess/time_test.py
+++ b/tests/preprocess/time_test.py
@@ -62,7 +62,8 @@ class TestTimeFormat:
 
 class TestSubsetTime:
     @pytest.fixture(scope="class")
-    def ts_index(self):
+    @classmethod
+    def ts_index(cls):
         return pd.date_range("2005-01-01", "2005-01-05", freq="h")
 
     @pytest.mark.parametrize(
@@ -108,12 +109,14 @@ class TestSubsetTime:
 
 class TestClustering:
     @pytest.fixture(scope="class", params=["datetime", "string"])
-    def cluster_dtype(self, request):
+    @classmethod
+    def cluster_dtype(cls, request):
         """The method should be able to handle datetime and string lookup data"""
         return request.param
 
     @pytest.fixture(scope="class")
-    def dummy_model_to_cluster(self, dummy_int, cluster_dtype):
+    @classmethod
+    def dummy_model_to_cluster(cls, dummy_int, cluster_dtype):
         """Create a dummy model with a parameter to cluster 3 years of data into 5 representative days."""
         ts = pd.date_range(
             "2025-01-01", "2028-01-01", freq="h", inclusive="left", name="timesteps"
@@ -139,7 +142,8 @@ class TestClustering:
         return ds
 
     @pytest.fixture(scope="class")
-    def dummy_clustered_model(self, dummy_model_to_cluster):
+    @classmethod
+    def dummy_clustered_model(cls, dummy_model_to_cluster):
         return time.cluster(
             dummy_model_to_cluster,
             clustering_param="clustering_param",
@@ -201,7 +205,8 @@ class TestClustering:
     @pytest.fixture(
         scope="class", params=["cluster_days", "cluster_days_diff_dateformat"]
     )
-    def clustered_model(self, request):
+    @classmethod
+    def clustered_model(cls, request):
         cluster_init = {
             "subset": {"timesteps": ["2005-01-01", "2005-01-04"]},
             "time_cluster": request.param,

--- a/tests/preprocess/time_test.py
+++ b/tests/preprocess/time_test.py
@@ -120,7 +120,7 @@ class TestClustering:
         )
         da = pd.Series(dummy_int, index=ts).to_xarray()
         cluster_ts = pd.date_range(
-            "2025-01-01", "2028-01-01", freq="1d", inclusive="left", name="datesteps"
+            "2025-01-01", "2028-01-01", freq="1D", inclusive="left", name="datesteps"
         )
         if cluster_dtype == "string":
             cluster_ts = cluster_ts.strftime("%Y-%m-%d")

--- a/tests/schemas/general_test.py
+++ b/tests/schemas/general_test.py
@@ -11,7 +11,8 @@ LOGGER = "calliope.schemas.general"
 
 class TestUniqueList:
     @pytest.fixture(scope="class")
-    def pydantic_model(self):
+    @classmethod
+    def pydantic_model(cls):
         return pydantic.create_model("TestModel", unique_list=(general.UniqueList, ...))
 
     @pytest.mark.parametrize(
@@ -56,7 +57,8 @@ class TestUniqueList:
 
 class TestNonEmptyList:
     @pytest.fixture(scope="class")
-    def pydantic_model(self):
+    @classmethod
+    def pydantic_model(cls):
         return pydantic.create_model(
             "TestModel", non_empty_list=(general.NonEmptyList, ...)
         )
@@ -69,7 +71,8 @@ class TestNonEmptyList:
 
 class TestNonEmptyUniqueList:
     @pytest.fixture(scope="class")
-    def pydantic_model(self):
+    @classmethod
+    def pydantic_model(cls):
         return pydantic.create_model(
             "TestModel", non_empty_unique_list=(general.NonEmptyUniqueList, ...)
         )
@@ -84,7 +87,8 @@ class TestNonEmptyUniqueList:
 
 class TestAttrStr:
     @pytest.fixture(scope="class")
-    def pydantic_model(self):
+    @classmethod
+    def pydantic_model(cls):
         return pydantic.create_model("TestModel", attrstr=(general.AttrStr, ...))
 
     @pytest.mark.parametrize(
@@ -97,7 +101,8 @@ class TestAttrStr:
 
 class TestNumveriVal:
     @pytest.fixture(scope="class")
-    def pydantic_model(self):
+    @classmethod
+    def pydantic_model(cls):
         return pydantic.create_model("TestModel", numeric_val=(general.NumericVal, ...))
 
     @pytest.mark.parametrize("invalid_input", [[1, 2], "foobar", None])
@@ -108,14 +113,16 @@ class TestNumveriVal:
 
 class TestCalliopeDictModel:
     @pytest.fixture(scope="class")
-    def dict_str_model(self):
+    @classmethod
+    def dict_str_model(cls):
         dict_model = pydantic.create_model(
             "TestModel", __base__=general.CalliopeDictModel, root=(dict[str, str], {})
         )
         return dict_model({"key1": "value1", "key2": "value2"})
 
     @pytest.fixture(scope="class")
-    def base_model(self):
+    @classmethod
+    def base_model(cls):
         return pydantic.create_model(
             "TestBaseModel",
             __base__=general.CalliopeBaseModel,
@@ -124,7 +131,8 @@ class TestCalliopeDictModel:
         )
 
     @pytest.fixture(scope="class")
-    def dict_base_model(self, base_model):
+    @classmethod
+    def dict_base_model(cls, base_model):
         dict_model = pydantic.create_model(
             "TestModel",
             __base__=general.CalliopeDictModel,
@@ -133,7 +141,8 @@ class TestCalliopeDictModel:
         return dict_model({"key1": {"bar": 2}, "key2": {"foo": "value2", "bar": 3}})
 
     @pytest.fixture(scope="class")
-    def dict_list_model(self, base_model):
+    @classmethod
+    def dict_list_model(cls, base_model):
         list_model = pydantic.create_model(
             "TestListModel",
             __base__=general.CalliopeListModel,
@@ -275,14 +284,16 @@ class TestCalliopeDictModel:
 
 class TestCalliopeListModel:
     @pytest.fixture(scope="class")
-    def list_str_model(self):
+    @classmethod
+    def list_str_model(cls):
         list_model = pydantic.create_model(
             "TestModel", __base__=general.CalliopeListModel, root=(list[str], [])
         )
         return list_model(["value1", "value2"])
 
     @pytest.fixture(scope="class")
-    def list_base_model(self):
+    @classmethod
+    def list_base_model(cls):
         base_model = pydantic.create_model(
             "TestBaseModel",
             __base__=general.CalliopeBaseModel,
@@ -372,7 +383,8 @@ class TestCalliopeBaseModel:
         )
 
     @pytest.fixture(scope="class")
-    def config_model_nested_with_dict_and_list_models(self, config_model_flat):
+    @classmethod
+    def config_model_nested_with_dict_and_list_models(cls, config_model_flat):
         """Fixture for a nested model with CalliopeDictModel and CalliopeListModel."""
         list_model = pydantic.create_model(
             "TestListModel",


### PR DESCRIPTION
Fixes a _lot_ of soon to be depreciated code. We had _25 thousand_ warnings!

I am submitting this PR separately from #883 to keep ourselves sane @brynpickering 
Changes in `src/` need deeper attention. I've added comments to those as an aid.

## Summary of changes in this pull request

* Made `xarray` broadcasting more explicit while retaining our behaviour, as the tool will remove / alter some defaults
* Changed tests that used `scope="class"` to be class methods, as suggested in: https://docs.pytest.org/en/stable/deprecations.html#class-scoped-fixture-as-instance-method

## Results

Warnings go from this:

<img width="1393" height="192" alt="image" src="https://github.com/user-attachments/assets/90470dc4-fd58-4994-8c03-633abbb5830c" />

To this. The last remaining warning is not our fault, and has already been fixed on `xarray`'s main branch. We'll have to live with it until that is released, then it should go away without any changes on our side.

<img width="1384" height="239" alt="image" src="https://github.com/user-attachments/assets/105b1855-5c49-4929-8770-5ef03d144f12" />


## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved
