### PR TITLE
Add operate mode to the docs ref page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ For example, `model.inputs.flow_cap_max.attrs["default"]` is now only available 
 
 |changed| Community and help links now point to Zulip (https://calliope-modelblocks.zulipchat.com/) instead of GitHub Discussions.
 
+|fixed| Pre-defined operate mode math is now documented alongside the other built-in math.
+
+|fixed| Built-in math documentation now shows components that an override deactivates (`REMOVED`) and those it moves to a different component group, e.g. from decision variable to parameter (`REDEFINED`).
+
+|changed| Math documentation includes math components that have no math expression to show, documenting them by their description alone.
+
 ### Internal changes
 
 |fixed| example user-defined math tests that were missing global expressions in the resulting LP files.

--- a/docs/hooks/changelog_highlight.py
+++ b/docs/hooks/changelog_highlight.py
@@ -11,6 +11,7 @@ REPLACEMENTS = {
     "|REMOVED|": "<span class='bubble red'>REMOVED</span>",
     "|UPDATED|": "<span class='bubble yellow'>UPDATED</span>",
     "|NEW|": "<span class='bubble green'>NEW</span>",
+    "|REDEFINED|": "<span class='bubble blue'>REDEFINED</span>",
 }
 
 

--- a/docs/hooks/dummy_model/model.yaml
+++ b/docs/hooks/dummy_model/model.yaml
@@ -22,6 +22,18 @@ overrides:
       solve.spores.number: 2
     data_definitions:
       spores_slack: 0.1
+  operate:
+    config:
+      init.name: operate mode
+      init.mode: operate
+      build.operate:
+        window: 12h
+        horizon: 24h
+    techs:
+      # Cyclic storage must be switched off in operate mode.
+      conversion_tech.cyclic_storage: false
+      supply_tech.cyclic_storage: false
+      storage_tech.cyclic_storage: false
 
 config.init.name: base
 config.build.ensure_feasibility: true

--- a/docs/hooks/generate_math_docs.py
+++ b/docs/hooks/generate_math_docs.py
@@ -213,39 +213,90 @@ def generate_custom_math_documentation(
     """
     model = calliope.read_yaml(file=MODEL_PATH, scenario=override)
 
+    redefined = _find_redefined(base_documentation, model)
+
     full_del = []
-    expr_del = []
+    removed = {}
     for component_group, component_group_dict in model.math.build.model_dump().items():
-        if component_group in ["checks", "dimensions", "parameters", "lookups"]:
+        if component_group in ["checks", "dimensions"]:
             continue
+        # Parameters and lookups are always shown in full, so are not diffed against the base math.
+        diffed = component_group not in ["parameters", "lookups"]
+        redefined_here = redefined.keys() & component_group_dict.keys()
         for name, component_dict in component_group_dict.items():
-            if name in base_documentation.math[component_group]._active:
+            if name in redefined:
+                if redefined[name][1] == component_group:
+                    _add_to_description(
+                        component_dict,
+                        "|REDEFINED| ({} -> {})".format(*redefined[name]),
+                    )
+            elif not diffed:
+                continue
+            elif name in base_documentation.math[component_group]._active:
                 if not component_dict.get("active", True):
-                    expr_del.append((component_group, name))
-                    component_dict["description"] = "|REMOVED|"
+                    removed[name] = component_group
+                    _add_to_description(component_dict, "|REMOVED|")
                     component_dict["active"] = True
                 elif base_documentation.math.find(name).model_dump() != component_dict:
                     _add_to_description(component_dict, "|UPDATED|")
                 else:
-                    full_del.append((component_group, name))
+                    full_del.append(name)
             else:
                 _add_to_description(component_dict, "|NEW|")
-        model.math = model.math.update(
-            {f"build.{component_group}": component_group_dict}
-        )
+        if diffed or redefined_here:
+            model.math = model.math.update(
+                {f"build.{component_group}": component_group_dict}
+            )
     math_documentation = MathDocumentation(model)
+    dataset = math_documentation.backend._dataset
 
-    for grp, key in expr_del:
-        math_documentation.backend.math_strings[grp][key] = ""
-    for grp, key in full_del:
-        del math_documentation.backend._dataset[key]
-    for var in math_documentation.backend._dataset.values():
-        var.attrs["references"] = var.attrs["references"].intersection(
-            math_documentation.backend._dataset.keys()
-        )
-        var.attrs["references"] = var.attrs["references"].difference(expr_del)
+    for name, group in removed.items():
+        math_documentation.backend.math_strings[group][name] = ""
+    for name in full_del:
+        del dataset[name]
+    for name, var in dataset.items():
+        if name in removed:
+            var.attrs["references"] = set()
+        else:
+            var.attrs["references"] = (
+                var.attrs["references"].intersection(dataset.keys()) - removed.keys()
+            )
+        # Self-reference to keep redefined parameters/lookups in the documentation,
+        # which would otherwise only be shown if referenced by another component.
+        if name in redefined and not var.attrs["references"]:
+            var.attrs["references"] = {name}
 
     return math_documentation
+
+
+def _find_redefined(
+    base_documentation: MathDocumentation, model: calliope.Model
+) -> dict[str, tuple[str, str]]:
+    """Find math components that the override math moves to a different component group.
+
+    E.g., in operate mode, `flow_cap` switches from being a decision variable to being a parameter.
+
+    Args:
+        base_documentation (MathDocumentation): model documentation with only the base math applied.
+        model (calliope.Model): model with the override math applied.
+
+    Returns:
+        dict[str, tuple[str, str]]: Mapping of component name to its (base, override) component group.
+    """
+
+    def _groups(math) -> dict[str, str]:
+        return {
+            name: group
+            for group in type(math).model_fields
+            for name in math[group]._active
+        }
+
+    base_groups = _groups(base_documentation.math)
+    return {
+        name: (base_groups[name], group)
+        for name, group in _groups(model.math.build).items()
+        if base_groups.get(name, group) != group
+    }
 
 
 def _add_to_description(component_dict: dict, update_string: str) -> None:

--- a/src/calliope/backend/latex_backend_model.py
+++ b/src/calliope/backend/latex_backend_model.py
@@ -576,21 +576,9 @@ class LatexBackendModel(backend_model.BackendModelGenerator):
         }
         components = {
             objtype: [
-                {
-                    "expression": math_string,
-                    "name": name,
-                    "used_in": sorted(
-                        list(da.attrs.get("references", set()) - set([name]))
-                    ),
-                    "uses": sorted(list(uses[name] - set([name]))),
-                    "yaml_snippet": to_yaml(
-                        self.math[objtype][name].model_dump(exclude_unset=True)
-                    ),
-                    **self.math[objtype][name].model_dump(),
-                }
+                self._component_doc(objtype, name, da, uses[name])
                 for name, da in sorted(getattr(self, objtype).data_vars.items())
-                if (math_string := self.math_strings[objtype][name]) != ""
-                or (objtype in ["parameters", "lookups"] and da.attrs["references"])
+                if objtype not in ["parameters", "lookups"] or da.attrs["references"]
             ]
             for objtype in [
                 "objectives",
@@ -616,6 +604,30 @@ class LatexBackendModel(backend_model.BackendModelGenerator):
         return self._render(
             doc_template, mkdocs_features=mkdocs_features, components=components
         )
+
+    def _component_doc(
+        self, objtype: str, name: str, da: xr.DataArray, uses: set[str]
+    ) -> dict:
+        """Get the attributes of a math component to feed into the documentation template.
+
+        Components without any math to show - e.g., those deactivated by mode math -
+        are documented by their description alone.
+        Parameters and lookups never have math of their own, so keep all their attributes.
+        """
+        math_string = self.math_strings[objtype][name]
+        component = self.math[objtype][name]
+        doc = {
+            "expression": math_string,
+            "name": name,
+            "used_in": sorted(da.attrs.get("references", set()) - set([name])),
+            "uses": sorted(uses - set([name])),
+        }
+        if not math_string and objtype not in ["parameters", "lookups"]:
+            return doc | {"description": component.description}
+        return doc | {
+            "yaml_snippet": to_yaml(component.model_dump(exclude_unset=True)),
+            **component.model_dump(),
+        }
 
     def _eval_top_level_where(
         self,

--- a/src/calliope/math/operate.yaml
+++ b/src/calliope/math/operate.yaml
@@ -75,14 +75,6 @@ global_expressions:
     equations:
       - expression: sum(cost_operation_variable, over=timesteps)
 
-objectives:
-  min_cost_optimisation:
-    description: >-
-      Minimise the total cost of operating all technologies in the system.
-      If multiple cost classes are present (e.g., monetary and co2 emissions),
-      the weighted sum of total costs is minimised.
-      Cost class weights can be defined in the indexed parameter `objective_cost_weights`.
-
 checks:
   operate_mode_cyclic_storage:
     where: cyclic_storage==True AND (base_tech==storage OR include_storage==True)

--- a/src/calliope/math/operate.yaml
+++ b/src/calliope/math/operate.yaml
@@ -75,6 +75,14 @@ global_expressions:
     equations:
       - expression: sum(cost_operation_variable, over=timesteps)
 
+objectives:
+  min_cost_optimisation:
+    description: >-
+      Minimise the total cost of operating all technologies in the system.
+      If multiple cost classes are present (e.g., monetary and co2 emissions),
+      the weighted sum of total costs is minimised.
+      Cost class weights can be defined in the indexed parameter `objective_cost_weights`.
+
 checks:
   operate_mode_cyclic_storage:
     where: cyclic_storage==True AND (base_tech==storage OR include_storage==True)


### PR DESCRIPTION
Fixes missing operate mode in ref docs

## Summary of changes in this pull request

* Slight change to latex math to handle cases where an item has been removed but we want to keep its description around with a "removed" flag.

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Coverage maintained or improved
